### PR TITLE
More aggressive caching behavior via `s-maxage` and `stale-while-revalidate`

### DIFF
--- a/lib/middlewares/with-cache-headers.ts
+++ b/lib/middlewares/with-cache-headers.ts
@@ -4,8 +4,11 @@ export const withCacheHeaders: Middleware<{}, {}> = async (req, ctx, next) => {
   const res = await next(req, ctx)
 
   if (req.url.includes("tscircuit.com")) {
-    // Save for 24 hours
-    res.headers.set("Cache-Control", "public, max-age=86400")
+    // Cache for 1 week (604800 seconds) with 1 hour stale-while-revalidate
+    res.headers.set(
+      "Cache-Control",
+      "public, max-age=604800, s-maxage=604800, stale-while-revalidate=3600"
+    )
     res.headers.set("Vary", "*")
   }
 

--- a/lib/middlewares/with-cache-headers.ts
+++ b/lib/middlewares/with-cache-headers.ts
@@ -7,7 +7,7 @@ export const withCacheHeaders: Middleware<{}, {}> = async (req, ctx, next) => {
     // Cache for 1 week (604800 seconds) with 1 hour stale-while-revalidate
     res.headers.set(
       "Cache-Control",
-      "public, max-age=604800, s-maxage=604800, stale-while-revalidate=3600"
+      "public, max-age=604800, s-maxage=604800, stale-while-revalidate=3600",
     )
     res.headers.set("Vary", "*")
   }


### PR DESCRIPTION
CC @imrishabh18 this may help with some of the timeouts