### PR TITLE
Add switches derived table and routes

### DIFF
--- a/docs/generated/switches.md
+++ b/docs/generated/switches.md
@@ -1,8 +1,69 @@
-# Switches
+# switches
 
-This section showcases examples of mechanical switches such as tactile, slide
-and rotary types. The `circuit` attribute indicates configurations like SPST or
-DPDT.
+###  
+
+| Key | Ex1 | Ex2 |
+| --- | --- | --- |
+| lcsc | 5149201 | 962342 |
+| stock | 40262 | 4702 |
+| mfr | SK6812MINI-E | ES8311 |
+| package | SMD | WQFN-20-EP(3x3) |
+| joints | 4 | 21 |
+| description | SMD RGB LEDs(Built-in IC) ROHS | WQFN-20-EP(3x3) Signal Switches, Multiplexers, Decoders ROHS |
+| min_q_price | 0.084347826 | 0.510144928 |
+| extra_title | OPSCO Optoelectronics SK6812MINI-E | Everest-semi(Everest Semiconductor) ES8311 |
+| extra.number | C5149201 | C962342 |
+| extra.package | SMD | QFN-20-EP(3x3) |
+
+### 
+
+| Key | Ex1 | Ex2 |
+| --- | --- | --- |
+| lcsc | 5299908 | 5346354 |
+| stock | 5570 | 4793 |
+| mfr | CH32V003F4U6 | CH32V003J4M6 |
+| package | QFN-20(3X3) | SOP-8 |
+| joints | 21 | 8 |
+| description | 16KB 2KB 18 RISC-V 48MHz QFN-20(3X3)  Microcontrollers (MCU/MPU/SOC) ROHS | SOP-8  Microcontrollers (MCU/MPU/SOC) ROHS |
+| min_q_price | 0.229130435 | 0.185362319 |
+| extra_title | WCH(Jiangsu Qin Heng) CH32V003F4U6 | WCH(Jiangsu Qin Heng) CH32V003J4M6 |
+| extra.number | C5299908 | C5346354 |
+| extra.package | QFN-20(3X3) | SOP-8 |
+| extra.attributes["DAC (Bit)"] | - |  |
+| extra.attributes["Program Memory Type"] | - |  |
+| extra.attributes["Peripheral/Function"] | - |  |
+| extra.attributes["CPU Core"] | RISC-V |  |
+| extra.attributes["Operating Voltage Range"] | - |  |
+| extra.attributes["communication protocol"] | - |  |
+| extra.attributes["Infrared Data Association"] | - |  |
+| extra.attributes["SPI"] | 1 |  |
+| extra.attributes["UART/USART"] | 1 |  |
+| extra.attributes["32Bit Timer"] | - |  |
+| extra.attributes["Direct Memory Access"] | - |  |
+| extra.attributes["Universal Serial Bus"] | - |  |
+| extra.attributes["Low-Voltage Detect"] | - |  |
+| extra.attributes["Real-Time Clock"] | Yes |  |
+| extra.attributes["I2C"] | 1 |  |
+| extra.attributes["Application Area"] | - |  |
+| extra.attributes["PWM (Bit)"] | - |  |
+| extra.attributes["LCD Module"] | - |  |
+| extra.attributes["CCP Capture/Compare"] | - |  |
+| extra.attributes["LED Module"] | - |  |
+| extra.attributes["RAM Size"] | 2KB |  |
+| extra.attributes["Operating Temperature Range"] | - |  |
+| extra.attributes["Internal Comparator"] | - |  |
+| extra.attributes["I2S"] | - |  |
+| extra.attributes["Internal Oscillator"] | - |  |
+| extra.attributes["GPIO Ports Number"] | 18 |  |
+| extra.attributes["16Bit Timer"] | - |  |
+| extra.attributes["EEPROM"] | - |  |
+| extra.attributes["CPU Maximum Speed"] | 48MHz |  |
+| extra.attributes["CAN"] | - |  |
+| extra.attributes["Program Storage Size"] | 16KB |  |
+| extra.attributes["Watchdog"] | Yes |  |
+| extra.attributes["8Bit Timer"] | - |  |
+| extra.attributes["ADC (Bit)"] | - |  |
+| extra.attributes["Secure Digital Input and Output"] | - |  |
 
 ### Tactile Switches
 

--- a/docs/generated/switches.md
+++ b/docs/generated/switches.md
@@ -1,69 +1,8 @@
-# switches
+# Switches
 
-###  
-
-| Key | Ex1 | Ex2 |
-| --- | --- | --- |
-| lcsc | 5149201 | 962342 |
-| stock | 40262 | 4702 |
-| mfr | SK6812MINI-E | ES8311 |
-| package | SMD | WQFN-20-EP(3x3) |
-| joints | 4 | 21 |
-| description | SMD RGB LEDs(Built-in IC) ROHS | WQFN-20-EP(3x3) Signal Switches, Multiplexers, Decoders ROHS |
-| min_q_price | 0.084347826 | 0.510144928 |
-| extra_title | OPSCO Optoelectronics SK6812MINI-E | Everest-semi(Everest Semiconductor) ES8311 |
-| extra.number | C5149201 | C962342 |
-| extra.package | SMD | QFN-20-EP(3x3) |
-
-### 
-
-| Key | Ex1 | Ex2 |
-| --- | --- | --- |
-| lcsc | 5299908 | 5346354 |
-| stock | 5570 | 4793 |
-| mfr | CH32V003F4U6 | CH32V003J4M6 |
-| package | QFN-20(3X3) | SOP-8 |
-| joints | 21 | 8 |
-| description | 16KB 2KB 18 RISC-V 48MHz QFN-20(3X3)  Microcontrollers (MCU/MPU/SOC) ROHS | SOP-8  Microcontrollers (MCU/MPU/SOC) ROHS |
-| min_q_price | 0.229130435 | 0.185362319 |
-| extra_title | WCH(Jiangsu Qin Heng) CH32V003F4U6 | WCH(Jiangsu Qin Heng) CH32V003J4M6 |
-| extra.number | C5299908 | C5346354 |
-| extra.package | QFN-20(3X3) | SOP-8 |
-| extra.attributes["DAC (Bit)"] | - |  |
-| extra.attributes["Program Memory Type"] | - |  |
-| extra.attributes["Peripheral/Function"] | - |  |
-| extra.attributes["CPU Core"] | RISC-V |  |
-| extra.attributes["Operating Voltage Range"] | - |  |
-| extra.attributes["communication protocol"] | - |  |
-| extra.attributes["Infrared Data Association"] | - |  |
-| extra.attributes["SPI"] | 1 |  |
-| extra.attributes["UART/USART"] | 1 |  |
-| extra.attributes["32Bit Timer"] | - |  |
-| extra.attributes["Direct Memory Access"] | - |  |
-| extra.attributes["Universal Serial Bus"] | - |  |
-| extra.attributes["Low-Voltage Detect"] | - |  |
-| extra.attributes["Real-Time Clock"] | Yes |  |
-| extra.attributes["I2C"] | 1 |  |
-| extra.attributes["Application Area"] | - |  |
-| extra.attributes["PWM (Bit)"] | - |  |
-| extra.attributes["LCD Module"] | - |  |
-| extra.attributes["CCP Capture/Compare"] | - |  |
-| extra.attributes["LED Module"] | - |  |
-| extra.attributes["RAM Size"] | 2KB |  |
-| extra.attributes["Operating Temperature Range"] | - |  |
-| extra.attributes["Internal Comparator"] | - |  |
-| extra.attributes["I2S"] | - |  |
-| extra.attributes["Internal Oscillator"] | - |  |
-| extra.attributes["GPIO Ports Number"] | 18 |  |
-| extra.attributes["16Bit Timer"] | - |  |
-| extra.attributes["EEPROM"] | - |  |
-| extra.attributes["CPU Maximum Speed"] | 48MHz |  |
-| extra.attributes["CAN"] | - |  |
-| extra.attributes["Program Storage Size"] | 16KB |  |
-| extra.attributes["Watchdog"] | Yes |  |
-| extra.attributes["8Bit Timer"] | - |  |
-| extra.attributes["ADC (Bit)"] | - |  |
-| extra.attributes["Secure Digital Input and Output"] | - |  |
+This section showcases examples of mechanical switches such as tactile, slide
+and rotary types. The `circuit` attribute indicates configurations like SPST or
+DPDT.
 
 ### Tactile Switches
 

--- a/lib/db/derivedtables/switch.ts
+++ b/lib/db/derivedtables/switch.ts
@@ -1,0 +1,95 @@
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import type { DerivedTableSpec } from "./types"
+import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import { BaseComponent } from "./component-base"
+
+export interface Switch extends BaseComponent {
+  package: string
+  switch_type: string
+  circuit: string | null
+  current_rating_a: number | null
+  voltage_rating_v: number | null
+  mounting_style: string | null
+  is_latching: boolean | null
+  operating_temp_min: number | null
+  operating_temp_max: number | null
+}
+
+export const switchTableSpec: DerivedTableSpec<Switch> = {
+  tableName: "switch",
+  extraColumns: [
+    { name: "package", type: "text" },
+    { name: "switch_type", type: "text" },
+    { name: "circuit", type: "text" },
+    { name: "current_rating_a", type: "real" },
+    { name: "voltage_rating_v", type: "real" },
+    { name: "mounting_style", type: "text" },
+    { name: "is_latching", type: "boolean" },
+    { name: "operating_temp_min", type: "real" },
+    { name: "operating_temp_max", type: "real" },
+  ],
+  listCandidateComponents(db) {
+    return db
+      .selectFrom("components")
+      .innerJoin("categories", "components.category_id", "categories.id")
+      .selectAll()
+      .where((eb) =>
+        eb.and([
+          eb("categories.category", "like", "%Switch%"),
+          eb("categories.subcategory", "not like", "%Relay%"),
+          eb("categories.subcategory", "not like", "%Accessory%"),
+        ]),
+      )
+  },
+  mapToTable(components) {
+    return components.map((c) => {
+      if (!c.extra) return null
+      const extra = JSON.parse(c.extra ?? "{}")
+      const attrs = extra.attributes || {}
+
+      const parseNum = (val: string | undefined): number | null => {
+        if (!val) return null
+        return parseAndConvertSiUnit(val).value as number
+      }
+
+      let isLatching: boolean | null = null
+      const lockField =
+        attrs["Self Lock / No Lock"] || attrs["self lock / no lock"]
+      if (lockField) {
+        isLatching = lockField.toLowerCase().includes("latch") ? true : false
+      }
+
+      const tempRange = attrs["Operating Temperature"]
+      let tempMin: number | null = null
+      let tempMax: number | null = null
+      if (tempRange && tempRange.includes("~")) {
+        const [min, max] = tempRange.split("~")
+        tempMin = parseNum(min)
+        tempMax = parseNum(max)
+      }
+
+      return {
+        lcsc: c.lcsc,
+        mfr: c.mfr,
+        description: c.description,
+        stock: c.stock,
+        price1: extractMinQPrice(c.price)!,
+        in_stock: c.stock > 0,
+        package: c.package || "",
+        switch_type: (c as any).subcategory || "",
+        circuit: attrs["Circuit"] || null,
+        current_rating_a:
+          parseNum(attrs["Current Rating (DC)"] || attrs["Contact Current"]) ||
+          parseNum(attrs["Current Rating (AC)"]),
+        voltage_rating_v:
+          parseNum(attrs["Voltage Rating (DC)"]) ||
+          parseNum(attrs["Voltage Rating (AC)"]),
+        mounting_style: attrs["Mounting Style"] || attrs["Pin Style"] || null,
+        is_latching: isLatching,
+        operating_temp_min: tempMin,
+        operating_temp_max: tempMax,
+        attributes: attrs,
+      }
+    })
+  },
+}

--- a/lib/db/derivedtables/switch.ts
+++ b/lib/db/derivedtables/switch.ts
@@ -13,6 +13,7 @@ export interface Switch extends BaseComponent {
   is_latching: boolean | null
   operating_temp_min: number | null
   operating_temp_max: number | null
+  pin_count: number | null
 }
 
 export const switchTableSpec: DerivedTableSpec<Switch> = {
@@ -27,6 +28,7 @@ export const switchTableSpec: DerivedTableSpec<Switch> = {
     { name: "is_latching", type: "boolean" },
     { name: "operating_temp_min", type: "real" },
     { name: "operating_temp_max", type: "real" },
+    { name: "pin_count", type: "integer" },
   ],
   listCandidateComponents(db) {
     return db
@@ -88,6 +90,7 @@ export const switchTableSpec: DerivedTableSpec<Switch> = {
         is_latching: isLatching,
         operating_temp_min: tempMin,
         operating_temp_max: tempMax,
+        pin_count: c.joints ?? null,
         attributes: attrs,
       }
     })

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -480,6 +480,26 @@ export interface Resistor {
   tolerance_fraction: number | null
 }
 
+export interface Switch {
+  attributes: string | null
+  circuit: string | null
+  current_rating_a: number | null
+  description: string | null
+  in_stock: number | null
+  is_latching: number | null
+  lcsc: number | null
+  mfr: string | null
+  mounting_style: string | null
+  operating_temp_max: number | null
+  operating_temp_min: number | null
+  package: string | null
+  pin_count: number | null
+  price1: number | null
+  stock: number | null
+  switch_type: string | null
+  voltage_rating_v: number | null
+}
+
 export interface VComponent {
   basic: number | null
   category: string | null
@@ -582,6 +602,7 @@ export interface DB {
   oled_display: OledDisplay
   potentiometer: Potentiometer
   resistor: Resistor
+  switch: Switch
   v_components: VComponent
   voltage_regulator: VoltageRegulator
   wifi_module: WifiModule

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -37,6 +37,7 @@ export default withWinterSpec({
         <a href="/oled_display/list"> OLED Displays Modules</a>
         <a href="/led_segment_display/list">LED Segment Display Modules</a>
         <a href="/lcd_display/list">LCD Display Modules</a>
+        <a href="/switches/list">Switches</a>
         <a href="/fuses/list">Fuses</a>
         <a href="/bjt_transistors/list">BJT Transistors</a>
       </div>

--- a/routes/led_with_ic/list.tsx
+++ b/routes/led_with_ic/list.tsx
@@ -105,7 +105,7 @@ export default withWinterSpec({
           stock: c.stock ?? 0,
           price1: c.price1 ?? 0,
           color: c.color ?? undefined,
-          protocol: c.protocol ?? undefined,
+          protocol: c.protocol ?? "",
           forward_voltage: c.forward_voltage ?? undefined,
           forward_current: c.forward_current ?? undefined,
         }))

--- a/routes/oled_display/list.tsx
+++ b/routes/oled_display/list.tsx
@@ -105,7 +105,7 @@ export default withWinterSpec({
           description: c.description ?? "",
           stock: c.stock ?? 0,
           price1: c.price1 ?? 0,
-          protocol: c.protocol ?? undefined,
+          protocol: c.protocol ?? "",
           display_width: c.display_width ?? undefined,
           pixel_resolution: c.pixel_resolution ?? undefined,
         }))

--- a/routes/switches/list.json.tsx
+++ b/routes/switches/list.json.tsx
@@ -1,0 +1,2 @@
+import list from "./list"
+export default list

--- a/routes/switches/list.tsx
+++ b/routes/switches/list.tsx
@@ -1,0 +1,130 @@
+import { Table } from "lib/ui/Table"
+import { withWinterSpec } from "lib/with-winter-spec"
+import { z } from "zod"
+import { formatPrice } from "lib/util/format-price"
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET", "POST"],
+  commonParams: z.object({
+    json: z.boolean().optional(),
+    switch_type: z.string().optional(),
+    circuit: z.string().optional(),
+  }),
+  jsonResponse: z.string().or(
+    z.object({
+      switches: z.array(
+        z.object({
+          lcsc: z.number().int(),
+          mfr: z.string(),
+          package: z.string(),
+          switch_type: z.string(),
+          circuit: z.string().optional(),
+          stock: z.number().optional(),
+          price1: z.number().optional(),
+        }),
+      ),
+    }),
+  ),
+} as const)(async (req, ctx) => {
+  const params = req.commonParams
+
+  let query = ctx.db
+    .selectFrom("switch")
+    .selectAll()
+    .limit(100)
+    .orderBy("stock", "desc")
+
+  if (params.switch_type) {
+    query = query.where("switch_type", "=", params.switch_type)
+  }
+
+  if (params.circuit) {
+    query = query.where("circuit", "=", params.circuit)
+  }
+
+  const types = await ctx.db
+    .selectFrom("switch")
+    .select("switch_type")
+    .distinct()
+    .execute()
+
+  const circuits = await ctx.db
+    .selectFrom("switch")
+    .select("circuit")
+    .distinct()
+    .where("circuit", "is not", null)
+    .execute()
+
+  const switches = await query.execute()
+
+  if (ctx.isApiRequest) {
+    return ctx.json({
+      switches: switches
+        .map((s) => ({
+          lcsc: s.lcsc ?? 0,
+          mfr: s.mfr ?? "",
+          package: s.package ?? "",
+          switch_type: s.switch_type ?? "",
+          circuit: s.circuit ?? undefined,
+          stock: s.stock ?? undefined,
+          price1: s.price1 ?? undefined,
+        }))
+        .filter((s) => s.lcsc !== 0 && s.package !== ""),
+    })
+  }
+
+  return ctx.react(
+    <div>
+      <h2>Switches</h2>
+
+      <form method="GET" className="flex flex-row gap-4">
+        <div>
+          <label>Type:</label>
+          <select name="switch_type">
+            <option value="">All</option>
+            {types.map((t) => (
+              <option
+                key={t.switch_type}
+                value={t.switch_type ?? ""}
+                selected={t.switch_type === params.switch_type}
+              >
+                {t.switch_type}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label>Circuit:</label>
+          <select name="circuit">
+            <option value="">All</option>
+            {circuits.map((c) => (
+              <option
+                key={c.circuit}
+                value={c.circuit ?? ""}
+                selected={c.circuit === params.circuit}
+              >
+                {c.circuit}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <button type="submit">Filter</button>
+      </form>
+
+      <Table
+        rows={switches.map((s) => ({
+          lcsc: s.lcsc,
+          mfr: s.mfr,
+          package: s.package,
+          type: s.switch_type,
+          circuit: s.circuit ?? "",
+          stock: <span className="tabular-nums">{s.stock}</span>,
+          price: <span className="tabular-nums">{formatPrice(s.price1)}</span>,
+        }))}
+      />
+    </div>,
+  )
+})

--- a/scripts/setup-derived-tables.ts
+++ b/scripts/setup-derived-tables.ts
@@ -24,6 +24,7 @@ import { lcdDisplayTableSpec } from "lib/db/derivedtables/lcd_display"
 import { potentiometerTableSpec } from "lib/db/derivedtables/potentiometer"
 import { fuseTableSpec } from "lib/db/derivedtables/fuse"
 import { bjtTransistorTableSpec } from "lib/db/derivedtables/bjt_transistor"
+import { switchTableSpec } from "lib/db/derivedtables/switch"
 
 const resetArg = process.argv.indexOf("--reset")
 const resetTable = resetArg !== -1 ? process.argv[resetArg + 1] : null
@@ -52,6 +53,7 @@ const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   potentiometerTableSpec,
   fuseTableSpec,
   bjtTransistorTableSpec,
+  switchTableSpec,
 ]
 
 function jsonParseOrNull(strObject: string) {

--- a/tests/routes/switches/list.test.ts
+++ b/tests/routes/switches/list.test.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("GET /switches/list with json param returns switch data", async () => {
+  const { axios } = await getTestServer()
+
+  const res = await axios.get("/switches/list?json=true")
+
+  expect(res.data).toHaveProperty("switches")
+  expect(Array.isArray(res.data.switches)).toBe(true)
+
+  if (res.data.switches.length > 0) {
+    const sw = res.data.switches[0]
+    expect(sw).toHaveProperty("lcsc")
+    expect(sw).toHaveProperty("mfr")
+    expect(sw).toHaveProperty("package")
+    expect(sw).toHaveProperty("switch_type")
+    expect(typeof sw.lcsc).toBe("number")
+  }
+})
+
+test("GET /switches/list with filters returns filtered data", async () => {
+  const { axios } = await getTestServer()
+
+  const res = await axios.get("/switches/list?json=true&circuit=SPDT")
+
+  expect(res.data).toHaveProperty("switches")
+  expect(Array.isArray(res.data.switches)).toBe(true)
+
+  for (const sw of res.data.switches) {
+    if (sw.circuit) {
+      expect(sw.circuit).toBe("SPDT")
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- add a `switch` derived table
- wire up switches in setup script and index
- expose `/switches/list` page and API
- update docs with mechanical switch info
- ensure OLED display routes return protocol strings
- test the new switches route

## Testing
- `bun run format`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_684213557254832eb729125a94ee563e