### PR TITLE
Add package and pin count filters for switches

### DIFF
--- a/tests/routes/switches/list.test.ts
+++ b/tests/routes/switches/list.test.ts
@@ -14,6 +14,7 @@ test("GET /switches/list with json param returns switch data", async () => {
     expect(sw).toHaveProperty("lcsc")
     expect(sw).toHaveProperty("mfr")
     expect(sw).toHaveProperty("package")
+    expect(sw).toHaveProperty("pin_count")
     expect(sw).toHaveProperty("switch_type")
     expect(typeof sw.lcsc).toBe("number")
   }
@@ -22,7 +23,9 @@ test("GET /switches/list with json param returns switch data", async () => {
 test("GET /switches/list with filters returns filtered data", async () => {
   const { axios } = await getTestServer()
 
-  const res = await axios.get("/switches/list?json=true&circuit=SPDT")
+  const res = await axios.get(
+    "/switches/list?json=true&circuit=SPDT&package=SMD&pin_count=2",
+  )
 
   expect(res.data).toHaveProperty("switches")
   expect(Array.isArray(res.data.switches)).toBe(true)
@@ -30,6 +33,12 @@ test("GET /switches/list with filters returns filtered data", async () => {
   for (const sw of res.data.switches) {
     if (sw.circuit) {
       expect(sw.circuit).toBe("SPDT")
+    }
+    if (sw.package) {
+      expect(sw.package).toBe("SMD")
+    }
+    if (sw.pin_count) {
+      expect(sw.pin_count).toBe(2)
     }
   }
 })


### PR DESCRIPTION
## Summary
- filter switches by package and pin count
- adjust switches tests for new filters

## Testing
- `bun run format`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68430a1b8988832ead6a30d9da8857c1