### PR TITLE
Add gyroscope listing page

### DIFF
--- a/lib/db/derivedtables/gyroscope.ts
+++ b/lib/db/derivedtables/gyroscope.ts
@@ -1,0 +1,119 @@
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import type { DerivedTableSpec } from "./types"
+import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import { BaseComponent } from "./component-base"
+
+export interface Gyroscope extends BaseComponent {
+  package: string
+  supply_voltage_min: number | null
+  supply_voltage_max: number | null
+  operating_temp_min: number | null
+  operating_temp_max: number | null
+  axes: string | null
+  has_i2c: boolean
+  has_spi: boolean
+  has_uart: boolean
+}
+
+export const gyroscopeTableSpec: DerivedTableSpec<Gyroscope> = {
+  tableName: "gyroscope",
+  extraColumns: [
+    { name: "package", type: "text" },
+    { name: "supply_voltage_min", type: "real" },
+    { name: "supply_voltage_max", type: "real" },
+    { name: "operating_temp_min", type: "real" },
+    { name: "operating_temp_max", type: "real" },
+    { name: "axes", type: "text" },
+    { name: "has_i2c", type: "boolean" },
+    { name: "has_spi", type: "boolean" },
+    { name: "has_uart", type: "boolean" },
+  ],
+  listCandidateComponents: (db) =>
+    db
+      .selectFrom("components")
+      .innerJoin("categories", "components.category_id", "categories.id")
+      .selectAll()
+      .where((eb) =>
+        eb.or([
+          eb("categories.subcategory", "=", "Attitude Sensors"),
+          eb("categories.subcategory", "=", "Attitude Sensor/Gyroscope"),
+          eb("categories.subcategory", "=", "Angular Velocity Sensors"),
+        ]),
+      ),
+  mapToTable: (components) => {
+    return components.map((c): Gyroscope | null => {
+      if (!c.extra) return null
+      const extra = JSON.parse(c.extra ?? "{}")
+      if (!extra.attributes) return null
+
+      const attrs = extra.attributes
+      const desc = c.description.toLowerCase()
+
+      // Parse voltage range
+      let voltageMin: number | null = null
+      let voltageMax: number | null = null
+      const rawVoltage = attrs["Supply Voltage"]
+      if (rawVoltage) {
+        const match = rawVoltage.match(/([\d.]+)V~([\d.]+)V/)
+        if (match) {
+          voltageMin = parseFloat(match[1])
+          voltageMax = parseFloat(match[2])
+        } else {
+          const single = rawVoltage.match(/([\d.]+)V/)
+          if (single) {
+            voltageMin = voltageMax = parseFloat(single[1])
+          }
+        }
+      }
+
+      // Parse temperature range
+      let tempMin: number | null = null
+      let tempMax: number | null = null
+      const rawTemp = attrs["Operating Temperature"]
+      if (rawTemp) {
+        const match = rawTemp.match(/([-\d]+)℃~\+([-\d]+)℃/)
+        if (match) {
+          tempMin = parseInt(match[1])
+          tempMax = parseInt(match[2])
+        }
+      }
+
+      // Parse axes information
+      const axes = attrs["Axial Direction"] || null
+
+      const interfaceStr = (
+        attrs["Interface Type"] ||
+        attrs["Interface"] ||
+        ""
+      ).toLowerCase()
+
+      const hasI2c =
+        interfaceStr.includes("i2c") ||
+        interfaceStr.includes("i²c") ||
+        interfaceStr.includes("iic") ||
+        desc.includes("i2c")
+
+      const hasSpi = interfaceStr.includes("spi") || desc.includes("spi")
+      const hasUart = interfaceStr.includes("uart") || desc.includes("uart")
+
+      return {
+        lcsc: c.lcsc,
+        mfr: c.mfr,
+        description: c.description,
+        stock: c.stock,
+        price1: extractMinQPrice(c.price),
+        in_stock: c.stock > 0,
+        package: c.package || "",
+        supply_voltage_min: voltageMin,
+        supply_voltage_max: voltageMax,
+        operating_temp_min: tempMin,
+        operating_temp_max: tempMax,
+        axes,
+        has_i2c: hasI2c,
+        has_spi: hasSpi,
+        has_uart: hasUart,
+        attributes: attrs,
+      }
+    })
+  },
+}

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -3,607 +3,627 @@
  * Please do not edit it manually.
  */
 
-import type { ColumnType } from "kysely"
+import type { ColumnType } from "kysely";
 
 export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
   ? ColumnType<S, I | undefined, U>
-  : ColumnType<T, T | undefined, T>
+  : ColumnType<T, T | undefined, T>;
 
 export interface Adc {
-  attributes: string | null
-  description: string | null
-  has_i2c: number | null
-  has_parallel_interface: number | null
-  has_serial_interface: number | null
-  has_spi: number | null
-  has_uart: number | null
-  in_stock: number | null
-  is_differential: number | null
-  lcsc: number | null
-  mfr: string | null
-  num_channels: number | null
-  operating_temp_max: number | null
-  operating_temp_min: number | null
-  package: string | null
-  price1: number | null
-  resolution_bits: number | null
-  sampling_rate_hz: number | null
-  stock: number | null
-  supply_voltage_max: number | null
-  supply_voltage_min: number | null
+  attributes: string | null;
+  description: string | null;
+  has_i2c: number | null;
+  has_parallel_interface: number | null;
+  has_serial_interface: number | null;
+  has_spi: number | null;
+  has_uart: number | null;
+  in_stock: number | null;
+  is_differential: number | null;
+  lcsc: number | null;
+  mfr: string | null;
+  num_channels: number | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  package: string | null;
+  price1: number | null;
+  resolution_bits: number | null;
+  sampling_rate_hz: number | null;
+  stock: number | null;
+  supply_voltage_max: number | null;
+  supply_voltage_min: number | null;
 }
 
 export interface AnalogMultiplexer {
-  attributes: string | null
-  channel_type: string | null
-  description: string | null
-  has_enable: number | null
-  has_i2c: number | null
-  has_parallel_interface: number | null
-  has_spi: number | null
-  in_stock: number | null
-  lcsc: number | null
-  leakage_current_na: number | null
-  mfr: string | null
-  num_bits: number | null
-  num_channels: number | null
-  on_resistance_ohms: number | null
-  operating_temp_max: number | null
-  operating_temp_min: number | null
-  package: string | null
-  price1: number | null
-  stock: number | null
-  supply_voltage_max: number | null
-  supply_voltage_min: number | null
+  attributes: string | null;
+  channel_type: string | null;
+  description: string | null;
+  has_enable: number | null;
+  has_i2c: number | null;
+  has_parallel_interface: number | null;
+  has_spi: number | null;
+  in_stock: number | null;
+  lcsc: number | null;
+  leakage_current_na: number | null;
+  mfr: string | null;
+  num_bits: number | null;
+  num_channels: number | null;
+  on_resistance_ohms: number | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  package: string | null;
+  price1: number | null;
+  stock: number | null;
+  supply_voltage_max: number | null;
+  supply_voltage_min: number | null;
 }
 
 export interface BjtTransistor {
-  attributes: string | null
-  collector_current: number | null
-  collector_emitter_voltage: number | null
-  current_gain: number | null
-  description: string | null
-  in_stock: number | null
-  lcsc: number | null
-  mfr: string | null
-  package: string | null
-  power_dissipation: number | null
-  price1: number | null
-  stock: number | null
-  temperature_range: string | null
-  transition_frequency: number | null
+  attributes: string | null;
+  collector_current: number | null;
+  collector_emitter_voltage: number | null;
+  current_gain: number | null;
+  description: string | null;
+  in_stock: number | null;
+  lcsc: number | null;
+  mfr: string | null;
+  package: string | null;
+  power_dissipation: number | null;
+  price1: number | null;
+  stock: number | null;
+  temperature_range: string | null;
+  transition_frequency: number | null;
 }
 
 export interface Capacitor {
-  attributes: string | null
-  capacitance_farads: number | null
-  capacitor_type: string | null
-  description: string | null
-  esr_ohms: number | null
-  in_stock: number | null
-  is_polarized: number | null
-  is_surface_mount: number | null
-  lcsc: number | null
-  lifetime_hours: number | null
-  mfr: string | null
-  package: string | null
-  price1: number | null
-  ripple_current_amps: number | null
-  stock: number | null
-  temperature_coefficient: string | null
-  tolerance_fraction: number | null
-  voltage_rating: number | null
+  attributes: string | null;
+  capacitance_farads: number | null;
+  capacitor_type: string | null;
+  description: string | null;
+  esr_ohms: number | null;
+  in_stock: number | null;
+  is_polarized: number | null;
+  is_surface_mount: number | null;
+  lcsc: number | null;
+  lifetime_hours: number | null;
+  mfr: string | null;
+  package: string | null;
+  price1: number | null;
+  ripple_current_amps: number | null;
+  stock: number | null;
+  temperature_coefficient: string | null;
+  tolerance_fraction: number | null;
+  voltage_rating: number | null;
 }
 
 export interface Category {
-  category: string
-  id: number
-  subcategory: string
+  category: string;
+  id: number;
+  subcategory: string;
 }
 
 export interface Component {
-  basic: number
-  category_id: number
-  datasheet: string
-  description: string
-  extra: string | null
-  flag: Generated<number>
-  joints: number
-  last_on_stock: Generated<number>
-  last_update: number
-  lcsc: number
-  manufacturer_id: number
-  mfr: string
-  package: string
-  preferred: Generated<number>
-  price: string
-  stock: number
+  basic: number;
+  category_id: number;
+  datasheet: string;
+  description: string;
+  extra: string | null;
+  flag: Generated<number>;
+  joints: number;
+  last_on_stock: Generated<number>;
+  last_update: number;
+  lcsc: number;
+  manufacturer_id: number;
+  mfr: string;
+  package: string;
+  preferred: Generated<number>;
+  price: string;
+  stock: number;
 }
 
 export interface ComponentsFt {
-  description: string | null
-  lcsc: string | null
-  mfr: string | null
-  mfr_chars: string | null
+  description: string | null;
+  lcsc: string | null;
+  mfr: string | null;
+  mfr_chars: string | null;
 }
 
 export interface ComponentsFtsConfig {
-  k: string
-  v: string | null
+  k: string;
+  v: string | null;
 }
 
 export interface ComponentsFtsContent {
-  c0: string | null
-  c1: string | null
-  c2: string | null
-  c3: string | null
-  id: number | null
+  c0: string | null;
+  c1: string | null;
+  c2: string | null;
+  c3: string | null;
+  id: number | null;
 }
 
 export interface ComponentsFtsDatum {
-  block: Buffer | null
-  id: number | null
+  block: Buffer | null;
+  id: number | null;
 }
 
 export interface ComponentsFtsDocsize {
-  id: number | null
-  sz: Buffer | null
+  id: number | null;
+  sz: Buffer | null;
 }
 
 export interface ComponentsFtsIdx {
-  pgno: string | null
-  segid: string
-  term: string
+  pgno: string | null;
+  segid: string;
+  term: string;
 }
 
 export interface Dac {
-  attributes: string | null
-  description: string | null
-  has_i2c: number | null
-  has_parallel_interface: number | null
-  has_spi: number | null
-  in_stock: number | null
-  lcsc: number | null
-  mfr: string | null
-  nonlinearity_lsb: number | null
-  num_channels: number | null
-  operating_temp_max: number | null
-  operating_temp_min: number | null
-  output_type: string | null
-  package: string | null
-  price1: number | null
-  resolution_bits: number | null
-  settling_time_us: number | null
-  stock: number | null
-  supply_voltage_max: number | null
-  supply_voltage_min: number | null
+  attributes: string | null;
+  description: string | null;
+  has_i2c: number | null;
+  has_parallel_interface: number | null;
+  has_spi: number | null;
+  in_stock: number | null;
+  lcsc: number | null;
+  mfr: string | null;
+  nonlinearity_lsb: number | null;
+  num_channels: number | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  output_type: string | null;
+  package: string | null;
+  price1: number | null;
+  resolution_bits: number | null;
+  settling_time_us: number | null;
+  stock: number | null;
+  supply_voltage_max: number | null;
+  supply_voltage_min: number | null;
 }
 
 export interface Diode {
-  attributes: string | null
-  configuration: string | null
-  description: string | null
-  diode_type: string | null
-  forward_current: number | null
-  forward_voltage: number | null
-  in_stock: number | null
-  is_schottky: number | null
-  is_tvs: number | null
-  is_zener: number | null
-  lcsc: number | null
-  mfr: string | null
-  operating_temp_max: number | null
-  operating_temp_min: number | null
-  package: string | null
-  power_dissipation_watts: number | null
-  price1: number | null
-  recovery_time_ns: number | null
-  reverse_leakage_current: number | null
-  reverse_voltage: number | null
-  stock: number | null
+  attributes: string | null;
+  configuration: string | null;
+  description: string | null;
+  diode_type: string | null;
+  forward_current: number | null;
+  forward_voltage: number | null;
+  in_stock: number | null;
+  is_schottky: number | null;
+  is_tvs: number | null;
+  is_zener: number | null;
+  lcsc: number | null;
+  mfr: string | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  package: string | null;
+  power_dissipation_watts: number | null;
+  price1: number | null;
+  recovery_time_ns: number | null;
+  reverse_leakage_current: number | null;
+  reverse_voltage: number | null;
+  stock: number | null;
 }
 
 export interface Fuse {
-  attributes: string | null
-  current_rating: number | null
-  description: string | null
-  in_stock: number | null
-  is_glass_encased: number | null
-  is_resettable: number | null
-  is_surface_mount: number | null
-  lcsc: number | null
-  mfr: string | null
-  package: string | null
-  price1: number | null
-  response_time: string | null
-  stock: number | null
-  voltage_rating: number | null
+  attributes: string | null;
+  current_rating: number | null;
+  description: string | null;
+  in_stock: number | null;
+  is_glass_encased: number | null;
+  is_resettable: number | null;
+  is_surface_mount: number | null;
+  lcsc: number | null;
+  mfr: string | null;
+  package: string | null;
+  price1: number | null;
+  response_time: string | null;
+  stock: number | null;
+  voltage_rating: number | null;
+}
+
+export interface Gyroscope {
+  attributes: string | null;
+  axes: string | null;
+  description: string | null;
+  has_i2c: number | null;
+  has_spi: number | null;
+  has_uart: number | null;
+  in_stock: number | null;
+  lcsc: number | null;
+  mfr: string | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  package: string | null;
+  price1: number | null;
+  stock: number | null;
+  supply_voltage_max: number | null;
+  supply_voltage_min: number | null;
 }
 
 export interface Header {
-  attributes: string | null
-  contact_material: string | null
-  contact_plating: string | null
-  current_rating_amp: number | null
-  description: string | null
-  gender: string | null
-  in_stock: number | null
-  insulation_height_mm: number | null
-  is_right_angle: number | null
-  is_shrouded: number | null
-  lcsc: number | null
-  mfr: string | null
-  mounting_style: string | null
-  num_pins: number | null
-  num_pins_per_row: number | null
-  num_rows: number | null
-  operating_temperature_max: number | null
-  operating_temperature_min: number | null
-  package: string | null
-  pin_length_mm: number | null
-  pitch_mm: number | null
-  price1: number | null
-  row_spacing_mm: number | null
-  stock: number | null
-  voltage_rating_volt: number | null
+  attributes: string | null;
+  contact_material: string | null;
+  contact_plating: string | null;
+  current_rating_amp: number | null;
+  description: string | null;
+  gender: string | null;
+  in_stock: number | null;
+  insulation_height_mm: number | null;
+  is_right_angle: number | null;
+  is_shrouded: number | null;
+  lcsc: number | null;
+  mfr: string | null;
+  mounting_style: string | null;
+  num_pins: number | null;
+  num_pins_per_row: number | null;
+  num_rows: number | null;
+  operating_temperature_max: number | null;
+  operating_temperature_min: number | null;
+  package: string | null;
+  pin_length_mm: number | null;
+  pitch_mm: number | null;
+  price1: number | null;
+  row_spacing_mm: number | null;
+  stock: number | null;
+  voltage_rating_volt: number | null;
 }
 
 export interface IoExpander {
-  attributes: string | null
-  clock_frequency_hz: number | null
-  description: string | null
-  has_i2c: number | null
-  has_interrupt: number | null
-  has_smbus: number | null
-  has_spi: number | null
-  in_stock: number | null
-  lcsc: number | null
-  mfr: string | null
-  num_gpios: number | null
-  operating_temp_max: number | null
-  operating_temp_min: number | null
-  output_type: string | null
-  package: string | null
-  price1: number | null
-  sink_current_ma: number | null
-  source_current_ma: number | null
-  stock: number | null
-  supply_voltage_max: number | null
-  supply_voltage_min: number | null
+  attributes: string | null;
+  clock_frequency_hz: number | null;
+  description: string | null;
+  has_i2c: number | null;
+  has_interrupt: number | null;
+  has_smbus: number | null;
+  has_spi: number | null;
+  in_stock: number | null;
+  lcsc: number | null;
+  mfr: string | null;
+  num_gpios: number | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  output_type: string | null;
+  package: string | null;
+  price1: number | null;
+  sink_current_ma: number | null;
+  source_current_ma: number | null;
+  stock: number | null;
+  supply_voltage_max: number | null;
+  supply_voltage_min: number | null;
 }
 
 export interface LcdDisplay {
-  attributes: string | null
-  description: string | null
-  display_size: string | null
-  display_type: string | null
-  in_stock: number | null
-  lcsc: number | null
-  mfr: string | null
-  package: string | null
-  price1: number | null
-  resolution: string | null
-  stock: number | null
+  attributes: string | null;
+  description: string | null;
+  display_size: string | null;
+  display_type: string | null;
+  in_stock: number | null;
+  lcsc: number | null;
+  mfr: string | null;
+  package: string | null;
+  price1: number | null;
+  resolution: string | null;
+  stock: number | null;
 }
 
 export interface Led {
-  attributes: string | null
-  color: string | null
-  description: string | null
-  forward_current: number | null
-  forward_voltage: number | null
-  in_stock: number | null
-  is_rgb: number | null
-  lcsc: number | null
-  lens_color: string | null
-  luminous_intensity_mcd: number | null
-  mfr: string | null
-  mounting_style: string | null
-  operating_temp_max: number | null
-  operating_temp_min: number | null
-  package: string | null
-  power_dissipation_mw: number | null
-  price1: number | null
-  stock: number | null
-  viewing_angle_deg: number | null
-  wavelength_nm: number | null
+  attributes: string | null;
+  color: string | null;
+  description: string | null;
+  forward_current: number | null;
+  forward_voltage: number | null;
+  in_stock: number | null;
+  is_rgb: number | null;
+  lcsc: number | null;
+  lens_color: string | null;
+  luminous_intensity_mcd: number | null;
+  mfr: string | null;
+  mounting_style: string | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  package: string | null;
+  power_dissipation_mw: number | null;
+  price1: number | null;
+  stock: number | null;
+  viewing_angle_deg: number | null;
+  wavelength_nm: number | null;
 }
 
 export interface LedDotMatrixDisplay {
-  attributes: string | null
-  color: string | null
-  description: string | null
-  in_stock: number | null
-  lcsc: number | null
-  matrix_size: string | null
-  mfr: string | null
-  package: string | null
-  price1: number | null
-  stock: number | null
+  attributes: string | null;
+  color: string | null;
+  description: string | null;
+  in_stock: number | null;
+  lcsc: number | null;
+  matrix_size: string | null;
+  mfr: string | null;
+  package: string | null;
+  price1: number | null;
+  stock: number | null;
 }
 
 export interface LedDriver {
-  attributes: string | null
-  channel_count: number | null
-  description: string | null
-  dimming_method: string | null
-  efficiency_percent: number | null
-  in_stock: number | null
-  lcsc: number | null
-  mfr: string | null
-  mounting_style: string | null
-  operating_temp_max: number | null
-  operating_temp_min: number | null
-  output_current_max: number | null
-  package: string | null
-  price1: number | null
-  protection_features: string | null
-  stock: number | null
-  supply_voltage_max: number | null
-  supply_voltage_min: number | null
+  attributes: string | null;
+  channel_count: number | null;
+  description: string | null;
+  dimming_method: string | null;
+  efficiency_percent: number | null;
+  in_stock: number | null;
+  lcsc: number | null;
+  mfr: string | null;
+  mounting_style: string | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  output_current_max: number | null;
+  package: string | null;
+  price1: number | null;
+  protection_features: string | null;
+  stock: number | null;
+  supply_voltage_max: number | null;
+  supply_voltage_min: number | null;
 }
 
 export interface LedSegmentDisplay {
-  attributes: string | null
-  color: string | null
-  description: string | null
-  in_stock: number | null
-  lcsc: number | null
-  mfr: string | null
-  package: string | null
-  positions: string | null
-  price1: number | null
-  size: string | null
-  stock: number | null
-  type: string | null
+  attributes: string | null;
+  color: string | null;
+  description: string | null;
+  in_stock: number | null;
+  lcsc: number | null;
+  mfr: string | null;
+  package: string | null;
+  positions: string | null;
+  price1: number | null;
+  size: string | null;
+  stock: number | null;
+  type: string | null;
 }
 
 export interface LedWithIc {
-  attributes: string | null
-  color: string | null
-  description: string | null
-  forward_current: number | null
-  forward_voltage: number | null
-  in_stock: number | null
-  lcsc: number | null
-  mfr: string | null
-  mounting_style: string | null
-  package: string | null
-  price1: number | null
-  protocol: string | null
-  stock: number | null
+  attributes: string | null;
+  color: string | null;
+  description: string | null;
+  forward_current: number | null;
+  forward_voltage: number | null;
+  in_stock: number | null;
+  lcsc: number | null;
+  mfr: string | null;
+  mounting_style: string | null;
+  package: string | null;
+  price1: number | null;
+  protocol: string | null;
+  stock: number | null;
 }
 
 export interface Manufacturer {
-  id: number
-  name: string
+  id: number;
+  name: string;
 }
 
 export interface Microcontroller {
-  adc_resolution_bits: number | null
-  attributes: string | null
-  cpu_core: string | null
-  cpu_speed_hz: number | null
-  dac_resolution_bits: number | null
-  description: string | null
-  eeprom_size_bytes: number | null
-  flash_size_bytes: number | null
-  gpio_count: number | null
-  has_adc: number | null
-  has_can: number | null
-  has_comparator: number | null
-  has_dac: number | null
-  has_dma: number | null
-  has_i2c: number | null
-  has_pwm: number | null
-  has_rtc: number | null
-  has_spi: number | null
-  has_uart: number | null
-  has_usb: number | null
-  has_watchdog: number | null
-  in_stock: number | null
-  lcsc: number | null
-  mfr: string | null
-  operating_temp_max: number | null
-  operating_temp_min: number | null
-  package: string | null
-  price1: number | null
-  ram_size_bytes: number | null
-  stock: number | null
-  supply_voltage_max: number | null
-  supply_voltage_min: number | null
+  adc_resolution_bits: number | null;
+  attributes: string | null;
+  cpu_core: string | null;
+  cpu_speed_hz: number | null;
+  dac_resolution_bits: number | null;
+  description: string | null;
+  eeprom_size_bytes: number | null;
+  flash_size_bytes: number | null;
+  gpio_count: number | null;
+  has_adc: number | null;
+  has_can: number | null;
+  has_comparator: number | null;
+  has_dac: number | null;
+  has_dma: number | null;
+  has_i2c: number | null;
+  has_pwm: number | null;
+  has_rtc: number | null;
+  has_spi: number | null;
+  has_uart: number | null;
+  has_usb: number | null;
+  has_watchdog: number | null;
+  in_stock: number | null;
+  lcsc: number | null;
+  mfr: string | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  package: string | null;
+  price1: number | null;
+  ram_size_bytes: number | null;
+  stock: number | null;
+  supply_voltage_max: number | null;
+  supply_voltage_min: number | null;
 }
 
 export interface Mosfet {
-  attributes: string | null
-  continuous_drain_current: number | null
-  description: string | null
-  drain_source_voltage: number | null
-  gate_threshold_voltage: number | null
-  in_stock: number | null
-  lcsc: number | null
-  mfr: string | null
-  mounting_style: string | null
-  operating_temp_max: number | null
-  operating_temp_min: number | null
-  package: string | null
-  power_dissipation: number | null
-  price1: number | null
-  stock: number | null
+  attributes: string | null;
+  continuous_drain_current: number | null;
+  description: string | null;
+  drain_source_voltage: number | null;
+  gate_threshold_voltage: number | null;
+  in_stock: number | null;
+  lcsc: number | null;
+  mfr: string | null;
+  mounting_style: string | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  package: string | null;
+  power_dissipation: number | null;
+  price1: number | null;
+  stock: number | null;
 }
 
 export interface OledDisplay {
-  attributes: string | null
-  description: string | null
-  display_width: string | null
-  in_stock: number | null
-  lcsc: number | null
-  mfr: string | null
-  package: string | null
-  pixel_resolution: string | null
-  price1: number | null
-  protocol: string | null
-  stock: number | null
+  attributes: string | null;
+  description: string | null;
+  display_width: string | null;
+  in_stock: number | null;
+  lcsc: number | null;
+  mfr: string | null;
+  package: string | null;
+  pixel_resolution: string | null;
+  price1: number | null;
+  protocol: string | null;
+  stock: number | null;
 }
 
 export interface Potentiometer {
-  attributes: string | null
-  description: string | null
-  in_stock: number | null
-  is_surface_mount: number | null
-  lcsc: number | null
-  max_resistance: number | null
-  mfr: string | null
-  package: string | null
-  pin_variant: string | null
-  price1: number | null
-  stock: number | null
+  attributes: string | null;
+  description: string | null;
+  in_stock: number | null;
+  is_surface_mount: number | null;
+  lcsc: number | null;
+  max_resistance: number | null;
+  mfr: string | null;
+  package: string | null;
+  pin_variant: string | null;
+  price1: number | null;
+  stock: number | null;
 }
 
 export interface Resistor {
-  attributes: string | null
-  description: string | null
-  in_stock: number | null
-  is_multi_resistor_chip: number | null
-  is_potentiometer: number | null
-  is_surface_mount: number | null
-  lcsc: number | null
-  max_overload_voltage: number | null
-  mfr: string | null
-  number_of_pins: number | null
-  number_of_resistors: number | null
-  package: string | null
-  power_watts: number | null
-  price1: number | null
-  resistance: number | null
-  stock: number | null
-  tolerance_fraction: number | null
+  attributes: string | null;
+  description: string | null;
+  in_stock: number | null;
+  is_multi_resistor_chip: number | null;
+  is_potentiometer: number | null;
+  is_surface_mount: number | null;
+  lcsc: number | null;
+  max_overload_voltage: number | null;
+  mfr: string | null;
+  number_of_pins: number | null;
+  number_of_resistors: number | null;
+  package: string | null;
+  power_watts: number | null;
+  price1: number | null;
+  resistance: number | null;
+  stock: number | null;
+  tolerance_fraction: number | null;
 }
 
 export interface Switch {
-  attributes: string | null
-  circuit: string | null
-  current_rating_a: number | null
-  description: string | null
-  in_stock: number | null
-  is_latching: number | null
-  lcsc: number | null
-  mfr: string | null
-  mounting_style: string | null
-  operating_temp_max: number | null
-  operating_temp_min: number | null
-  package: string | null
-  pin_count: number | null
-  price1: number | null
-  stock: number | null
-  switch_type: string | null
-  voltage_rating_v: number | null
+  attributes: string | null;
+  circuit: string | null;
+  current_rating_a: number | null;
+  description: string | null;
+  in_stock: number | null;
+  is_latching: number | null;
+  lcsc: number | null;
+  mfr: string | null;
+  mounting_style: string | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  package: string | null;
+  pin_count: number | null;
+  price1: number | null;
+  stock: number | null;
+  switch_type: string | null;
+  voltage_rating_v: number | null;
 }
 
 export interface VComponent {
-  basic: number | null
-  category: string | null
-  category_id: number | null
-  datasheet: string | null
-  description: string | null
-  extra: string | null
-  joints: number | null
-  last_on_stock: number | null
-  lcsc: number | null
-  manufacturer: string | null
-  mfr: string | null
-  package: string | null
-  preferred: number | null
-  price: string | null
-  stock: number | null
-  subcategory: string | null
+  basic: number | null;
+  category: string | null;
+  category_id: number | null;
+  datasheet: string | null;
+  description: string | null;
+  extra: string | null;
+  joints: number | null;
+  last_on_stock: number | null;
+  lcsc: number | null;
+  manufacturer: string | null;
+  mfr: string | null;
+  package: string | null;
+  preferred: number | null;
+  price: string | null;
+  stock: number | null;
+  subcategory: string | null;
 }
 
 export interface VoltageRegulator {
-  attributes: string | null
-  description: string | null
-  dropout_voltage: number | null
-  in_stock: number | null
-  input_voltage_max: number | null
-  input_voltage_min: number | null
-  is_low_dropout: number | null
-  is_positive: number | null
-  lcsc: number | null
-  mfr: string | null
-  operating_temp_max: number | null
-  operating_temp_min: number | null
-  output_current_max: number | null
-  output_noise_uvrms: number | null
-  output_type: string | null
-  output_voltage_max: number | null
-  output_voltage_min: number | null
-  package: string | null
-  power_supply_rejection_db: number | null
-  price1: number | null
-  quiescent_current: number | null
-  stock: number | null
-  topology: string | null
+  attributes: string | null;
+  description: string | null;
+  dropout_voltage: number | null;
+  in_stock: number | null;
+  input_voltage_max: number | null;
+  input_voltage_min: number | null;
+  is_low_dropout: number | null;
+  is_positive: number | null;
+  lcsc: number | null;
+  mfr: string | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  output_current_max: number | null;
+  output_noise_uvrms: number | null;
+  output_type: string | null;
+  output_voltage_max: number | null;
+  output_voltage_min: number | null;
+  package: string | null;
+  power_supply_rejection_db: number | null;
+  price1: number | null;
+  quiescent_current: number | null;
+  stock: number | null;
+  topology: string | null;
 }
 
 export interface WifiModule {
-  antenna_type: string | null
-  attributes: string | null
-  core_processor: string | null
-  description: string | null
-  frequency_ghz: number | null
-  has_adc: number | null
-  has_gpio: number | null
-  has_i2c: number | null
-  has_pwm: number | null
-  has_spi: number | null
-  has_uart: number | null
-  in_stock: number | null
-  lcsc: number | null
-  mfr: string | null
-  operating_temp_max: number | null
-  operating_temp_min: number | null
-  operating_voltage: number | null
-  output_power_dbm: number | null
-  package: string | null
-  price1: number | null
-  rx_current_ma: number | null
-  sensitivity_dbm: number | null
-  stock: number | null
-  tx_current_ma: number | null
+  antenna_type: string | null;
+  attributes: string | null;
+  core_processor: string | null;
+  description: string | null;
+  frequency_ghz: number | null;
+  has_adc: number | null;
+  has_gpio: number | null;
+  has_i2c: number | null;
+  has_pwm: number | null;
+  has_spi: number | null;
+  has_uart: number | null;
+  in_stock: number | null;
+  lcsc: number | null;
+  mfr: string | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  operating_voltage: number | null;
+  output_power_dbm: number | null;
+  package: string | null;
+  price1: number | null;
+  rx_current_ma: number | null;
+  sensitivity_dbm: number | null;
+  stock: number | null;
+  tx_current_ma: number | null;
 }
 
 export interface DB {
-  adc: Adc
-  analog_multiplexer: AnalogMultiplexer
-  bjt_transistor: BjtTransistor
-  capacitor: Capacitor
-  categories: Category
-  components: Component
-  components_fts: ComponentsFt
-  components_fts_config: ComponentsFtsConfig
-  components_fts_content: ComponentsFtsContent
-  components_fts_data: ComponentsFtsDatum
-  components_fts_docsize: ComponentsFtsDocsize
-  components_fts_idx: ComponentsFtsIdx
-  dac: Dac
-  diode: Diode
-  fuse: Fuse
-  header: Header
-  io_expander: IoExpander
-  lcd_display: LcdDisplay
-  led: Led
-  led_dot_matrix_display: LedDotMatrixDisplay
-  led_driver: LedDriver
-  led_segment_display: LedSegmentDisplay
-  led_with_ic: LedWithIc
-  manufacturers: Manufacturer
-  microcontroller: Microcontroller
-  mosfet: Mosfet
-  oled_display: OledDisplay
-  potentiometer: Potentiometer
-  resistor: Resistor
-  switch: Switch
-  v_components: VComponent
-  voltage_regulator: VoltageRegulator
-  wifi_module: WifiModule
+  adc: Adc;
+  analog_multiplexer: AnalogMultiplexer;
+  bjt_transistor: BjtTransistor;
+  capacitor: Capacitor;
+  categories: Category;
+  components: Component;
+  components_fts: ComponentsFt;
+  components_fts_config: ComponentsFtsConfig;
+  components_fts_content: ComponentsFtsContent;
+  components_fts_data: ComponentsFtsDatum;
+  components_fts_docsize: ComponentsFtsDocsize;
+  components_fts_idx: ComponentsFtsIdx;
+  dac: Dac;
+  diode: Diode;
+  fuse: Fuse;
+  gyroscope: Gyroscope;
+  header: Header;
+  io_expander: IoExpander;
+  lcd_display: LcdDisplay;
+  led: Led;
+  led_dot_matrix_display: LedDotMatrixDisplay;
+  led_driver: LedDriver;
+  led_segment_display: LedSegmentDisplay;
+  led_with_ic: LedWithIc;
+  manufacturers: Manufacturer;
+  microcontroller: Microcontroller;
+  mosfet: Mosfet;
+  oled_display: OledDisplay;
+  potentiometer: Potentiometer;
+  resistor: Resistor;
+  switch: Switch;
+  v_components: VComponent;
+  voltage_regulator: VoltageRegulator;
+  wifi_module: WifiModule;
 }

--- a/routes/gyroscopes/list.json.tsx
+++ b/routes/gyroscopes/list.json.tsx
@@ -1,0 +1,2 @@
+import list from "./list"
+export default list

--- a/routes/gyroscopes/list.tsx
+++ b/routes/gyroscopes/list.tsx
@@ -1,0 +1,136 @@
+import { Table } from "lib/ui/Table"
+import { withWinterSpec } from "lib/with-winter-spec"
+import { z } from "zod"
+import { formatPrice } from "lib/util/format-price"
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET"],
+  queryParams: z.object({
+    package: z.string().optional(),
+    interface: z.enum(["spi", "i2c", "uart", ""]).optional(),
+  }),
+  jsonResponse: z.any(),
+} as const)(async (req, ctx) => {
+  let query = ctx.db
+    .selectFrom("gyroscope")
+    .selectAll()
+    .limit(100)
+    .orderBy("stock", "desc")
+
+  if (req.query.package) {
+    query = query.where("package", "=", req.query.package)
+  }
+
+  if (req.query.interface) {
+    switch (req.query.interface) {
+      case "spi":
+        query = query.where("has_spi", "=", 1)
+        break
+      case "i2c":
+        query = query.where("has_i2c", "=", 1)
+        break
+      case "uart":
+        query = query.where("has_uart", "=", 1)
+        break
+    }
+  }
+
+  const packages = await ctx.db
+    .selectFrom("gyroscope")
+    .select("package")
+    .distinct()
+    .orderBy("package")
+    .execute()
+
+  const gyros = await query.execute()
+
+  if (ctx.isApiRequest) {
+    return ctx.json({
+      gyroscopes: gyros
+        .map((g) => ({
+          lcsc: g.lcsc ?? 0,
+          mfr: g.mfr ?? "",
+          package: g.package ?? "",
+          supply_voltage_min: g.supply_voltage_min ?? undefined,
+          supply_voltage_max: g.supply_voltage_max ?? undefined,
+          axes: g.axes ?? undefined,
+          has_i2c: g.has_i2c ?? undefined,
+          has_spi: g.has_spi ?? undefined,
+          has_uart: g.has_uart ?? undefined,
+          stock: g.stock ?? undefined,
+          price1: g.price1 ?? undefined,
+        }))
+        .filter((g) => g.lcsc !== 0 && g.package !== ""),
+    })
+  }
+
+  return ctx.react(
+    <div>
+      <h2>Gyroscopes</h2>
+
+      <form method="GET" className="flex flex-row gap-4">
+        <div>
+          <label>Package:</label>
+          <select name="package">
+            <option value="">All</option>
+            {packages.map((p) => (
+              <option
+                key={p.package}
+                value={p.package ?? ""}
+                selected={p.package === req.query.package}
+              >
+                {p.package}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label>Interface:</label>
+          <select name="interface">
+            <option value="">All</option>
+            <option value="spi" selected={req.query.interface === "spi"}>
+              SPI
+            </option>
+            <option value="i2c" selected={req.query.interface === "i2c"}>
+              I2C
+            </option>
+            <option value="uart" selected={req.query.interface === "uart"}>
+              UART
+            </option>
+          </select>
+        </div>
+
+        <button type="submit">Filter</button>
+      </form>
+
+      <Table
+        rows={gyros.map((g) => ({
+          lcsc: g.lcsc,
+          mfr: g.mfr,
+          package: g.package,
+          voltage:
+            g.supply_voltage_min && g.supply_voltage_max ? (
+              <span className="tabular-nums">
+                {g.supply_voltage_min}V - {g.supply_voltage_max}V
+              </span>
+            ) : (
+              ""
+            ),
+          axes: g.axes,
+          interface: [
+            g.has_spi && "SPI",
+            g.has_i2c && "I2C",
+            g.has_uart && "UART",
+          ]
+            .filter(Boolean)
+            .join(", "),
+          stock: <span className="tabular-nums">{g.stock}</span>,
+          price: <span className="tabular-nums">{formatPrice(g.price1)}</span>,
+        }))}
+      />
+    </div>,
+    "JLCPCB Gyroscope Search",
+  )
+})

--- a/scripts/setup-derived-tables.ts
+++ b/scripts/setup-derived-tables.ts
@@ -25,6 +25,7 @@ import { potentiometerTableSpec } from "lib/db/derivedtables/potentiometer"
 import { fuseTableSpec } from "lib/db/derivedtables/fuse"
 import { bjtTransistorTableSpec } from "lib/db/derivedtables/bjt_transistor"
 import { switchTableSpec } from "lib/db/derivedtables/switch"
+import { gyroscopeTableSpec } from "lib/db/derivedtables/gyroscope"
 
 const resetArg = process.argv.indexOf("--reset")
 const resetTable = resetArg !== -1 ? process.argv[resetArg + 1] : null
@@ -45,6 +46,7 @@ const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   voltageRegulatorTableSpec,
   ledDriverTableSpec,
   mosfetTableSpec,
+  gyroscopeTableSpec,
   ledWithICTableSpec,
   ledDotMatrixDisplayTableSpec,
   oledDisplayTableSpec,


### PR DESCRIPTION
## Summary
- create `gyroscope` derived table
- allow generating the gyroscope table in `setup-derived-tables.ts`
- add routes for browsing gyroscope chips in HTML and JSON
- regenerate Kysely DB types

## Testing
- `bun run scripts/setup-derived-tables.ts --reset gyroscope`
- `npx kysely-codegen --out-file ./lib/db/generated/kysely.ts --singular --dialect bun-sqlite --url ./db.sqlite3`


------
https://chatgpt.com/codex/tasks/task_b_68430a742b80832ea8b484d8d122782d