### PR TITLE
Add gas sensor measurement flags

### DIFF
--- a/lib/db/derivedtables/gas_sensor.ts
+++ b/lib/db/derivedtables/gas_sensor.ts
@@ -1,0 +1,98 @@
+import type { DerivedTableSpec } from "./types"
+import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import { BaseComponent } from "./component-base"
+
+export interface GasSensor extends BaseComponent {
+  package: string
+  sensor_type: string | null
+  measures_air_quality: boolean
+  measures_co2: boolean
+  measures_oxygen: boolean
+  measures_carbon_monoxide: boolean
+  measures_methane: boolean
+  measures_nitrogen_oxides: boolean
+  measures_sulfur_hexafluoride: boolean
+  measures_volatile_organic_compounds: boolean
+  measures_formaldehyde: boolean
+  measures_hydrogen: boolean
+  measures_explosive_gases: boolean
+}
+
+export const gasSensorTableSpec: DerivedTableSpec<GasSensor> = {
+  tableName: "gas_sensor",
+  extraColumns: [
+    { name: "package", type: "text" },
+    { name: "sensor_type", type: "text" },
+    { name: "measures_air_quality", type: "boolean" },
+    { name: "measures_co2", type: "boolean" },
+    { name: "measures_oxygen", type: "boolean" },
+    { name: "measures_carbon_monoxide", type: "boolean" },
+    { name: "measures_methane", type: "boolean" },
+    { name: "measures_nitrogen_oxides", type: "boolean" },
+    { name: "measures_sulfur_hexafluoride", type: "boolean" },
+    { name: "measures_volatile_organic_compounds", type: "boolean" },
+    { name: "measures_formaldehyde", type: "boolean" },
+    { name: "measures_hydrogen", type: "boolean" },
+    { name: "measures_explosive_gases", type: "boolean" },
+  ],
+  listCandidateComponents(db) {
+    return db
+      .selectFrom("components")
+      .innerJoin("categories", "components.category_id", "categories.id")
+      .selectAll()
+      .where("categories.subcategory", "=", "Gas Sensors")
+  },
+  mapToTable(components) {
+    return components.map((c) => {
+      const desc = (c.description || "").toLowerCase()
+      const name = (c.mfr || "").toLowerCase()
+
+      const measuresAirQuality =
+        desc.includes("air quality") ||
+        desc.includes("\u7a7a\u6c14\u8d28\u91cf")
+      const measuresCo2 = desc.includes("co2")
+      const measuresOxygen = desc.includes("oxygen")
+      const measuresCarbonMonoxide = desc.includes("carbon monoxide")
+      const measuresMethane = desc.includes("methane")
+      const measuresNitrogenOxides = desc.includes("nitrogen oxide")
+      const measuresSulfurHexafluoride =
+        desc.includes("sulfur hexafluoride") || name.includes("sf6")
+      const measuresVOC =
+        desc.includes("volatile") ||
+        desc.includes("voc") ||
+        desc.includes("\u6325\u53d1")
+      const measuresFormaldehyde =
+        name.includes("ch2o") ||
+        desc.includes("ch2o") ||
+        desc.includes("formaldehyde")
+      const measuresHydrogen = name.endsWith("-h2") || desc.includes("hydrogen")
+      const measuresExplosive = desc.includes("explosive")
+
+      const sensorType = measuresAirQuality
+        ? "Air Quality Sensor"
+        : "Gas Sensor"
+      return {
+        lcsc: c.lcsc,
+        mfr: c.mfr,
+        description: c.description,
+        stock: c.stock,
+        price1: extractMinQPrice(c.price),
+        in_stock: c.stock > 0,
+        package: c.package || "",
+        sensor_type: sensorType,
+        measures_air_quality: measuresAirQuality,
+        measures_co2: measuresCo2,
+        measures_oxygen: measuresOxygen,
+        measures_carbon_monoxide: measuresCarbonMonoxide,
+        measures_methane: measuresMethane,
+        measures_nitrogen_oxides: measuresNitrogenOxides,
+        measures_sulfur_hexafluoride: measuresSulfurHexafluoride,
+        measures_volatile_organic_compounds: measuresVOC,
+        measures_formaldehyde: measuresFormaldehyde,
+        measures_hydrogen: measuresHydrogen,
+        measures_explosive_gases: measuresExplosive,
+        attributes: {},
+      }
+    })
+  },
+}

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -259,6 +259,29 @@ export interface Fuse {
   voltage_rating: number | null;
 }
 
+export interface GasSensor {
+  attributes: string | null;
+  description: string | null;
+  in_stock: number | null;
+  lcsc: number | null;
+  measures_air_quality: number | null;
+  measures_carbon_monoxide: number | null;
+  measures_co2: number | null;
+  measures_explosive_gases: number | null;
+  measures_formaldehyde: number | null;
+  measures_hydrogen: number | null;
+  measures_methane: number | null;
+  measures_nitrogen_oxides: number | null;
+  measures_oxygen: number | null;
+  measures_sulfur_hexafluoride: number | null;
+  measures_volatile_organic_compounds: number | null;
+  mfr: string | null;
+  package: string | null;
+  price1: number | null;
+  sensor_type: string | null;
+  stock: number | null;
+}
+
 export interface Gyroscope {
   attributes: string | null;
   axes: string | null;
@@ -648,6 +671,7 @@ export interface DB {
   dac: Dac;
   diode: Diode;
   fuse: Fuse;
+  gas_sensor: GasSensor;
   gyroscope: Gyroscope;
   header: Header;
   io_expander: IoExpander;

--- a/routes/gas_sensors/list.json.tsx
+++ b/routes/gas_sensors/list.json.tsx
@@ -1,0 +1,2 @@
+import list from "./list"
+export default list

--- a/routes/gas_sensors/list.tsx
+++ b/routes/gas_sensors/list.tsx
@@ -1,0 +1,126 @@
+import { Table } from "lib/ui/Table"
+import { withWinterSpec } from "lib/with-winter-spec"
+import { z } from "zod"
+import { formatPrice } from "lib/util/format-price"
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET"],
+  queryParams: z.object({
+    package: z.string().optional(),
+    sensor_type: z.string().optional(),
+  }),
+  jsonResponse: z.any(),
+} as const)(async (req, ctx) => {
+  let query = ctx.db
+    .selectFrom("gas_sensor")
+    .selectAll()
+    .limit(100)
+    .orderBy("stock", "desc")
+
+  if (req.query.package) {
+    query = query.where("package", "=", req.query.package)
+  }
+
+  if (req.query.sensor_type) {
+    query = query.where("sensor_type", "=", req.query.sensor_type)
+  }
+
+  const packages = await ctx.db
+    .selectFrom("gas_sensor")
+    .select("package")
+    .distinct()
+    .orderBy("package")
+    .execute()
+
+  const types = await ctx.db
+    .selectFrom("gas_sensor")
+    .select("sensor_type")
+    .distinct()
+    .where("sensor_type", "is not", null)
+    .orderBy("sensor_type")
+    .execute()
+
+  const sensors = await query.execute()
+
+  if (ctx.isApiRequest) {
+    return ctx.json({
+      gas_sensors: sensors
+        .map((s) => ({
+          lcsc: s.lcsc ?? 0,
+          mfr: s.mfr ?? "",
+          package: s.package ?? "",
+          sensor_type: s.sensor_type ?? undefined,
+          measures_air_quality: s.measures_air_quality === 1,
+          measures_co2: s.measures_co2 === 1,
+          measures_oxygen: s.measures_oxygen === 1,
+          measures_carbon_monoxide: s.measures_carbon_monoxide === 1,
+          measures_methane: s.measures_methane === 1,
+          measures_nitrogen_oxides: s.measures_nitrogen_oxides === 1,
+          measures_sulfur_hexafluoride: s.measures_sulfur_hexafluoride === 1,
+          measures_volatile_organic_compounds:
+            s.measures_volatile_organic_compounds === 1,
+          measures_formaldehyde: s.measures_formaldehyde === 1,
+          measures_hydrogen: s.measures_hydrogen === 1,
+          measures_explosive_gases: s.measures_explosive_gases === 1,
+          stock: s.stock ?? undefined,
+          price1: s.price1 ?? undefined,
+        }))
+        .filter((s) => s.lcsc !== 0 && s.package !== ""),
+    })
+  }
+
+  return ctx.react(
+    <div>
+      <h2>Gas Sensors</h2>
+
+      <form method="GET" className="flex flex-row gap-4">
+        <div>
+          <label>Package:</label>
+          <select name="package">
+            <option value="">All</option>
+            {packages.map((p) => (
+              <option
+                key={p.package}
+                value={p.package ?? ""}
+                selected={p.package === req.query.package}
+              >
+                {p.package}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label>Type:</label>
+          <select name="sensor_type">
+            <option value="">All</option>
+            {types.map((t) => (
+              <option
+                key={t.sensor_type}
+                value={t.sensor_type ?? ""}
+                selected={t.sensor_type === req.query.sensor_type}
+              >
+                {t.sensor_type}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <button type="submit">Filter</button>
+      </form>
+
+      <Table
+        rows={sensors.map((s) => ({
+          lcsc: s.lcsc,
+          mfr: s.mfr,
+          package: s.package,
+          sensor_type: s.sensor_type,
+          stock: <span className="tabular-nums">{s.stock}</span>,
+          price: <span className="tabular-nums">{formatPrice(s.price1)}</span>,
+        }))}
+      />
+    </div>,
+    "JLCPCB Gas Sensor Search",
+  )
+})

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -25,6 +25,7 @@ export default withWinterSpec({
         <a href="/io_expanders/list">I/O Expanders</a>
         <a href="/gyroscopes/list">Gyroscopes</a>
         <a href="/accelerometers/list">Accelerometers</a>
+        <a href="/gas_sensors/list">Gas Sensors</a>
         <a href="/diodes/list">Diodes</a>
         <a href="/dacs/list">DACs</a>
         <a href="/wifi_modules/list">WiFi Modules</a>

--- a/scripts/setup-derived-tables.ts
+++ b/scripts/setup-derived-tables.ts
@@ -27,6 +27,7 @@ import { bjtTransistorTableSpec } from "lib/db/derivedtables/bjt_transistor"
 import { switchTableSpec } from "lib/db/derivedtables/switch"
 import { gyroscopeTableSpec } from "lib/db/derivedtables/gyroscope"
 import { accelerometerTableSpec } from "lib/db/derivedtables/accelerometer"
+import { gasSensorTableSpec } from "lib/db/derivedtables/gas_sensor"
 import { boostConverterTableSpec } from "lib/db/derivedtables/boost_converter"
 
 const resetArg = process.argv.indexOf("--reset")
@@ -51,6 +52,7 @@ const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   mosfetTableSpec,
   gyroscopeTableSpec,
   accelerometerTableSpec,
+  gasSensorTableSpec,
   ledWithICTableSpec,
   ledDotMatrixDisplayTableSpec,
   oledDisplayTableSpec,

--- a/tests/routes/gas_sensors/list.test.ts
+++ b/tests/routes/gas_sensors/list.test.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "bun:test"
+import { getTestServer } from "../../fixtures/get-test-server"
+
+test("GET /gas_sensors/list with json param returns gas sensor data", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/gas_sensors/list?json=true")
+  expect(res.data).toHaveProperty("gas_sensors")
+  expect(Array.isArray(res.data.gas_sensors)).toBe(true)
+  if (res.data.gas_sensors.length > 0) {
+    const sensor = res.data.gas_sensors[0]
+    expect(sensor).toHaveProperty("lcsc")
+    expect(sensor).toHaveProperty("mfr")
+    expect(sensor).toHaveProperty("package")
+    expect(sensor).toHaveProperty("measures_oxygen")
+    expect(typeof sensor.measures_oxygen).toBe("boolean")
+  }
+})


### PR DESCRIPTION
## Summary
- track what gases each gas sensor can detect
- expose measurement flags from `/gas_sensors/list`
- regenerate DB types
- test presence of new boolean field

## Testing
- `bun test tests/routes/gas_sensors/list.test.ts`
- `bun test tests/routes/analog_multiplexers/list.test.ts`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_685d6d04a658832ebcae604870de3562