### PR TITLE
Add measurement filtering for gas sensors

### DIFF
--- a/routes/gas_sensors/list.tsx
+++ b/routes/gas_sensors/list.tsx
@@ -9,6 +9,22 @@ export default withWinterSpec({
   queryParams: z.object({
     package: z.string().optional(),
     sensor_type: z.string().optional(),
+    measurement: z
+      .enum([
+        "",
+        "air_quality",
+        "co2",
+        "oxygen",
+        "carbon_monoxide",
+        "methane",
+        "nitrogen_oxides",
+        "sulfur_hexafluoride",
+        "volatile_organic_compounds",
+        "formaldehyde",
+        "hydrogen",
+        "explosive_gases",
+      ])
+      .optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -24,6 +40,44 @@ export default withWinterSpec({
 
   if (req.query.sensor_type) {
     query = query.where("sensor_type", "=", req.query.sensor_type)
+  }
+
+  if (req.query.measurement) {
+    switch (req.query.measurement) {
+      case "air_quality":
+        query = query.where("measures_air_quality", "=", 1)
+        break
+      case "co2":
+        query = query.where("measures_co2", "=", 1)
+        break
+      case "oxygen":
+        query = query.where("measures_oxygen", "=", 1)
+        break
+      case "carbon_monoxide":
+        query = query.where("measures_carbon_monoxide", "=", 1)
+        break
+      case "methane":
+        query = query.where("measures_methane", "=", 1)
+        break
+      case "nitrogen_oxides":
+        query = query.where("measures_nitrogen_oxides", "=", 1)
+        break
+      case "sulfur_hexafluoride":
+        query = query.where("measures_sulfur_hexafluoride", "=", 1)
+        break
+      case "volatile_organic_compounds":
+        query = query.where("measures_volatile_organic_compounds", "=", 1)
+        break
+      case "formaldehyde":
+        query = query.where("measures_formaldehyde", "=", 1)
+        break
+      case "hydrogen":
+        query = query.where("measures_hydrogen", "=", 1)
+        break
+      case "explosive_gases":
+        query = query.where("measures_explosive_gases", "=", 1)
+        break
+    }
   }
 
   const packages = await ctx.db
@@ -104,6 +158,76 @@ export default withWinterSpec({
                 {t.sensor_type}
               </option>
             ))}
+          </select>
+        </div>
+
+        <div>
+          <label>Measurement:</label>
+          <select name="measurement">
+            <option value="">All</option>
+            <option
+              value="air_quality"
+              selected={req.query.measurement === "air_quality"}
+            >
+              Air Quality
+            </option>
+            <option value="co2" selected={req.query.measurement === "co2"}>
+              CO₂
+            </option>
+            <option
+              value="oxygen"
+              selected={req.query.measurement === "oxygen"}
+            >
+              Oxygen
+            </option>
+            <option
+              value="carbon_monoxide"
+              selected={req.query.measurement === "carbon_monoxide"}
+            >
+              Carbon Monoxide
+            </option>
+            <option
+              value="methane"
+              selected={req.query.measurement === "methane"}
+            >
+              Methane
+            </option>
+            <option
+              value="nitrogen_oxides"
+              selected={req.query.measurement === "nitrogen_oxides"}
+            >
+              Nitrogen Oxides
+            </option>
+            <option
+              value="sulfur_hexafluoride"
+              selected={req.query.measurement === "sulfur_hexafluoride"}
+            >
+              Sulfur Hexafluoride
+            </option>
+            <option
+              value="volatile_organic_compounds"
+              selected={req.query.measurement === "volatile_organic_compounds"}
+            >
+              VOC
+            </option>
+            <option
+              value="formaldehyde"
+              selected={req.query.measurement === "formaldehyde"}
+            >
+              Formaldehyde
+            </option>
+            <option
+              value="hydrogen"
+              selected={req.query.measurement === "hydrogen"}
+            >
+              Hydrogen
+            </option>
+            <option
+              value="explosive_gases"
+              selected={req.query.measurement === "explosive_gases"}
+            >
+              Explosive Gases
+            </option>
           </select>
         </div>
 

--- a/tests/routes/gas_sensors/list.test.ts
+++ b/tests/routes/gas_sensors/list.test.ts
@@ -15,3 +15,20 @@ test("GET /gas_sensors/list with json param returns gas sensor data", async () =
     expect(typeof sensor.measures_oxygen).toBe("boolean")
   }
 })
+
+test("GET /gas_sensors/list with measurement filter returns filtered data", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/gas_sensors/list", {
+    params: {
+      json: true,
+      measurement: "oxygen",
+    },
+  })
+
+  expect(res.data).toHaveProperty("gas_sensors")
+  expect(Array.isArray(res.data.gas_sensors)).toBe(true)
+
+  for (const sensor of res.data.gas_sensors) {
+    expect(sensor.measures_oxygen).toBe(true)
+  }
+})


### PR DESCRIPTION
## Summary
- add `measurement` query param and filter logic
- show dropdown for measurement options on Gas Sensors page
- test measurement filter

## Testing
- `bun test tests/routes/gas_sensors/list.test.ts` *(fails: no such table: gas_sensor)*

------
https://chatgpt.com/codex/tasks/task_b_685db8800dc4832eaf915f7da8321193