### PR TITLE
Add Buck-Boost converter page

### DIFF
--- a/lib/db/derivedtables/buck_boost_converter.ts
+++ b/lib/db/derivedtables/buck_boost_converter.ts
@@ -1,0 +1,137 @@
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import { BaseComponent } from "./component-base"
+import type { DerivedTableSpec } from "./types"
+
+export interface BuckBoostConverter extends BaseComponent {
+  package: string
+  input_voltage_min: number | null
+  input_voltage_max: number | null
+  output_voltage_min: number | null
+  output_voltage_max: number | null
+  output_current_max: number | null
+  switching_frequency: number | null
+  is_synchronous: boolean | null
+  topology: string | null
+  number_of_outputs: number | null
+}
+
+export const buckBoostConverterTableSpec: DerivedTableSpec<BuckBoostConverter> =
+  {
+    tableName: "buck_boost_converter",
+    extraColumns: [
+      { name: "package", type: "text" },
+      { name: "input_voltage_min", type: "real" },
+      { name: "input_voltage_max", type: "real" },
+      { name: "output_voltage_min", type: "real" },
+      { name: "output_voltage_max", type: "real" },
+      { name: "output_current_max", type: "real" },
+      { name: "switching_frequency", type: "real" },
+      { name: "is_synchronous", type: "boolean" },
+      { name: "topology", type: "text" },
+      { name: "number_of_outputs", type: "integer" },
+    ],
+    listCandidateComponents: (db) =>
+      db
+        .selectFrom("components")
+        .innerJoin("categories", "components.category_id", "categories.id")
+        .selectAll()
+        .where("categories.subcategory", "=", "DC-DC Converters")
+        .where((eb) =>
+          eb.or([
+            eb("description", "like", "%Buck-Boost%"),
+            eb("description", "like", "%buck-boost%"),
+            eb("description", "like", "%Buck Boost%"),
+            eb("description", "like", "%Step-down-Boost%"),
+          ]),
+        ),
+    mapToTable: (components) => {
+      const parseVoltageRange = (
+        text: string | undefined,
+      ): [number | null, number | null] => {
+        if (!text) return [null, null]
+        const range = text.match(/([\d.]+)V~([\d.]+)V/)
+        if (range) return [parseFloat(range[1]), parseFloat(range[2])]
+        const single = text.match(/([\d.]+)V/)
+        if (single) {
+          const v = parseFloat(single[1])
+          return [v, v]
+        }
+        return [null, null]
+      }
+
+      return components.map((c) => {
+        try {
+          const extra = c.extra ? JSON.parse(c.extra) : {}
+          const attrs = extra.attributes || {}
+          const desc = c.description
+
+          let [inputMin, inputMax] = parseVoltageRange(attrs["Input Voltage"]) // default from attrs
+          if (!inputMin && !inputMax) {
+            const match = desc.match(/([\d.]+V)~([\d.]+V)/)
+            if (match) {
+              inputMin = parseFloat(match[1])
+              inputMax = parseFloat(match[2])
+            }
+          }
+
+          const [outputMin, outputMax] = parseVoltageRange(
+            attrs["Output Voltage"],
+          ) // may be null
+
+          let outputCurrent: number | null = null
+          const rawCurrent = attrs["Output Current"]
+          if (rawCurrent) {
+            const parsed = parseAndConvertSiUnit(rawCurrent).value
+            if (parsed) outputCurrent = parsed as number
+          } else {
+            const m = desc.match(/(\d+(?:\.\d+)?)(?:A|mA)/i)
+            if (m) {
+              const val = parseFloat(m[1])
+              outputCurrent = desc.toLowerCase().includes("ma")
+                ? val / 1000
+                : val
+            }
+          }
+
+          let switchingFreq: number | null = null
+          const rawFreq = attrs["Switching Frequency"]
+          if (rawFreq) {
+            const parsed = parseAndConvertSiUnit(rawFreq).value
+            if (parsed) switchingFreq = parsed as number
+          }
+
+          const isSync = attrs["Synchronous Rectification"]
+            ? attrs["Synchronous Rectification"].toLowerCase() === "yes"
+            : null
+
+          const topology = attrs["Topology"] || null
+          const numOutputs = attrs["Number of Outputs"]
+            ? parseInt(attrs["Number of Outputs"]) || null
+            : null
+
+          return {
+            lcsc: c.lcsc,
+            mfr: c.mfr,
+            description: c.description,
+            stock: c.stock,
+            price1: extractMinQPrice(c.price),
+            in_stock: c.stock > 0,
+            package: c.package || "",
+            input_voltage_min: inputMin,
+            input_voltage_max: inputMax,
+            output_voltage_min: outputMin,
+            output_voltage_max: outputMax,
+            output_current_max: outputCurrent,
+            switching_frequency: switchingFreq,
+            is_synchronous: isSync,
+            topology,
+            number_of_outputs: numOutputs,
+            attributes: attrs,
+          }
+        } catch (e) {
+          return null
+        }
+      })
+    },
+  }

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -113,6 +113,26 @@ export interface BoostConverter {
   topology: string | null;
 }
 
+export interface BuckBoostConverter {
+  attributes: string | null;
+  description: string | null;
+  in_stock: number | null;
+  input_voltage_max: number | null;
+  input_voltage_min: number | null;
+  is_synchronous: number | null;
+  lcsc: number | null;
+  mfr: string | null;
+  number_of_outputs: number | null;
+  output_current_max: number | null;
+  output_voltage_max: number | null;
+  output_voltage_min: number | null;
+  package: string | null;
+  price1: number | null;
+  stock: number | null;
+  switching_frequency: number | null;
+  topology: string | null;
+}
+
 export interface Capacitor {
   attributes: string | null;
   capacitance_farads: number | null;
@@ -659,6 +679,7 @@ export interface DB {
   analog_multiplexer: AnalogMultiplexer;
   bjt_transistor: BjtTransistor;
   boost_converter: BoostConverter;
+  buck_boost_converter: BuckBoostConverter;
   capacitor: Capacitor;
   categories: Category;
   components: Component;

--- a/routes/buck_boost_converters/list.json.tsx
+++ b/routes/buck_boost_converters/list.json.tsx
@@ -1,0 +1,2 @@
+import list from "./list"
+export default list

--- a/routes/buck_boost_converters/list.tsx
+++ b/routes/buck_boost_converters/list.tsx
@@ -1,0 +1,165 @@
+import { Table } from "lib/ui/Table"
+import { withWinterSpec } from "lib/with-winter-spec"
+import { z } from "zod"
+import { formatPrice } from "lib/util/format-price"
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET"],
+  commonParams: z.object({
+    json: z.boolean().optional(),
+    package: z.string().optional(),
+    input_voltage: z.coerce.number().optional(),
+    output_voltage: z.coerce.number().optional(),
+    output_current: z.coerce.number().optional(),
+  }),
+  jsonResponse: z.object({
+    buck_boost_converters: z.array(
+      z.object({
+        lcsc: z.number(),
+        mfr: z.string(),
+        description: z.string(),
+        stock: z.number(),
+        price1: z.number().nullable(),
+        in_stock: z.boolean(),
+        package: z.string().nullable(),
+        input_voltage_min: z.number().nullable(),
+        input_voltage_max: z.number().nullable(),
+        output_voltage_min: z.number().nullable(),
+        output_voltage_max: z.number().nullable(),
+        output_current_max: z.number().nullable(),
+      }),
+    ),
+  }),
+} as const)(async (req, ctx) => {
+  const params = req.commonParams
+  let query = ctx.db
+    .selectFrom("buck_boost_converter")
+    .selectAll()
+    .orderBy("stock", "desc")
+    .limit(100)
+
+  if (params.package) {
+    query = query.where("package", "=", params.package)
+  }
+  if (params.input_voltage !== undefined) {
+    query = query
+      .where("input_voltage_min", "<=", params.input_voltage)
+      .where("input_voltage_max", ">=", params.input_voltage)
+  }
+  if (params.output_voltage !== undefined) {
+    query = query.where((eb) =>
+      eb.or([
+        eb("output_voltage_min", "<=", params.output_voltage!),
+        eb("output_voltage_max", ">=", params.output_voltage!),
+      ]),
+    )
+  }
+  if (params.output_current !== undefined) {
+    query = query.where("output_current_max", ">=", params.output_current)
+  }
+
+  const converters = await query.execute()
+
+  if (ctx.isApiRequest) {
+    return ctx.json({
+      buck_boost_converters: converters.map((c) => ({
+        lcsc: Number(c.lcsc),
+        mfr: String(c.mfr || ""),
+        description: String(c.description || ""),
+        stock: Number(c.stock || 0),
+        price1: c.price1 === null ? null : Number(c.price1),
+        in_stock: Boolean(c.in_stock),
+        package: c.package,
+        input_voltage_min: c.input_voltage_min,
+        input_voltage_max: c.input_voltage_max,
+        output_voltage_min: c.output_voltage_min,
+        output_voltage_max: c.output_voltage_max,
+        output_current_max: c.output_current_max,
+      })),
+    })
+  }
+
+  const packages = await ctx.db
+    .selectFrom("buck_boost_converter")
+    .select("package")
+    .distinct()
+    .orderBy("package")
+    .execute()
+
+  return ctx.react(
+    <div>
+      <h2>Buck-Boost DC-DC Converters</h2>
+
+      <form method="GET" className="flex flex-row gap-4">
+        <div>
+          <label>Package:</label>
+          <select name="package">
+            <option value="">All</option>
+            {packages.map((p) => (
+              <option
+                key={p.package}
+                value={p.package ?? ""}
+                selected={p.package === params.package}
+              >
+                {p.package}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label>Input Voltage:</label>
+          <input
+            type="number"
+            step="0.1"
+            name="input_voltage"
+            defaultValue={params.input_voltage}
+          />
+        </div>
+
+        <div>
+          <label>Output Voltage:</label>
+          <input
+            type="number"
+            step="0.1"
+            name="output_voltage"
+            defaultValue={params.output_voltage}
+          />
+        </div>
+
+        <div>
+          <label>Output Current &ge;:</label>
+          <input
+            type="number"
+            step="0.1"
+            name="output_current"
+            defaultValue={params.output_current}
+          />
+        </div>
+
+        <button type="submit">Filter</button>
+      </form>
+
+      <Table
+        rows={converters.map((c) => ({
+          lcsc: c.lcsc,
+          mfr: c.mfr,
+          package: c.package,
+          input:
+            c.input_voltage_min && c.input_voltage_max
+              ? `${c.input_voltage_min}V - ${c.input_voltage_max}V`
+              : "",
+          output:
+            c.output_voltage_min && c.output_voltage_max
+              ? `${c.output_voltage_min}V - ${c.output_voltage_max}V`
+              : "",
+          current: c.output_current_max ? `${c.output_current_max}A` : "",
+          stock: c.stock,
+          price: <span className="tabular-nums">{formatPrice(c.price1)}</span>,
+        }))}
+      />
+    </div>,
+    "JLCPCB Buck-Boost Converter Search",
+  )
+})

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -32,6 +32,7 @@ export default withWinterSpec({
         <a href="/microcontrollers/list">Microcontrollers</a>
         <a href="/voltage_regulators/list">Voltage Regulators</a>
         <a href="/boost_converters/list">Boost DC-DC Converters</a>
+        <a href="/buck_boost_converters/list">Buck-Boost DC-DC Converters</a>
         <a href="/led_drivers/list">LED Drivers</a>
         <a href="/mosfets/list">Mosfets</a>
         <a href="/led_with_ic/list">LED with ICs</a>

--- a/scripts/setup-derived-tables.ts
+++ b/scripts/setup-derived-tables.ts
@@ -29,6 +29,7 @@ import { gyroscopeTableSpec } from "lib/db/derivedtables/gyroscope"
 import { accelerometerTableSpec } from "lib/db/derivedtables/accelerometer"
 import { gasSensorTableSpec } from "lib/db/derivedtables/gas_sensor"
 import { boostConverterTableSpec } from "lib/db/derivedtables/boost_converter"
+import { buckBoostConverterTableSpec } from "lib/db/derivedtables/buck_boost_converter"
 
 const resetArg = process.argv.indexOf("--reset")
 const resetTable = resetArg !== -1 ? process.argv[resetArg + 1] : null
@@ -49,6 +50,7 @@ const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   voltageRegulatorTableSpec,
   ledDriverTableSpec,
   boostConverterTableSpec,
+  buckBoostConverterTableSpec,
   mosfetTableSpec,
   gyroscopeTableSpec,
   accelerometerTableSpec,

--- a/tests/routes/buck_boost_converters/list.test.ts
+++ b/tests/routes/buck_boost_converters/list.test.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "bun:test"
+import { getTestServer } from "../../fixtures/get-test-server"
+
+test("GET /buck_boost_converters/list with json param returns converter data", async () => {
+  const { axios } = await getTestServer()
+
+  const res = await axios.get("/buck_boost_converters/list?json=true")
+
+  expect(res.data).toHaveProperty("buck_boost_converters")
+  expect(Array.isArray(res.data.buck_boost_converters)).toBe(true)
+
+  if (res.data.buck_boost_converters.length > 0) {
+    const conv = res.data.buck_boost_converters[0]
+    expect(conv).toHaveProperty("lcsc")
+    expect(conv).toHaveProperty("mfr")
+    expect(conv).toHaveProperty("package")
+    expect(typeof conv.lcsc).toBe("number")
+  }
+})
+
+test("GET /buck_boost_converters/list with package filter returns filtered data", async () => {
+  const { axios } = await getTestServer()
+
+  const res = await axios.get(
+    "/buck_boost_converters/list?json=true&package=SOT-23-6",
+  )
+  expect(res.data).toHaveProperty("buck_boost_converters")
+  for (const conv of res.data.buck_boost_converters) {
+    expect(conv.package).toBe("SOT-23-6")
+  }
+})


### PR DESCRIPTION
## Summary
- add `buck_boost_converter` derived table
- add page and API route for buck‑boost converters
- expose link on homepage
- generate updated DB types
- test the new route

## Testing
- `bun run scripts/setup-derived-tables.ts --reset buck_boost_converter`
- `bun x kysely-codegen --out-file ./lib/db/generated/kysely.ts --singular --dialect bun-sqlite --url ./db.sqlite3`
- `bun test tests/routes/buck_boost_converters/list.test.ts`
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_b_685f12fa3ea4832eade15c92879c2240