### PR TITLE
Allow small tolerance in value filters (resistance and capacitance) to prevent "missing" resistors or capacitors when exact values round improperly (e.g. to 0.00099999)

### DIFF
--- a/routes/capacitors/list.tsx
+++ b/routes/capacitors/list.tsx
@@ -53,7 +53,7 @@ export default withWinterSpec({
   }
 
   // Apply capacitance filter with a small tolerance for rounding errors
-  if (params.capacitance !== undefined) {
+  if (params.capacitance != null) {
     const delta = params.capacitance * 0.0001
     query = query
       .where("capacitance_farads", ">=", params.capacitance - delta)

--- a/routes/capacitors/list.tsx
+++ b/routes/capacitors/list.tsx
@@ -52,9 +52,12 @@ export default withWinterSpec({
     query = query.where("package", "=", params.package)
   }
 
-  // Apply exact capacitance filter
+  // Apply capacitance filter with a small tolerance for rounding errors
   if (params.capacitance !== undefined) {
-    query = query.where("capacitance_farads", "=", params.capacitance)
+    const delta = params.capacitance * 0.0001
+    query = query
+      .where("capacitance_farads", ">=", params.capacitance - delta)
+      .where("capacitance_farads", "<=", params.capacitance + delta)
   }
 
   // Get unique packages for dropdown

--- a/routes/resistors/list.tsx
+++ b/routes/resistors/list.tsx
@@ -53,7 +53,7 @@ export default withWinterSpec({
   }
 
   // Apply resistance filter with a small tolerance for rounding errors
-  if (params.resistance !== undefined) {
+  if (params.resistance != null) {
     const delta = params.resistance * 0.0001
     query = query
       .where("resistance", ">=", params.resistance - delta)

--- a/routes/resistors/list.tsx
+++ b/routes/resistors/list.tsx
@@ -52,9 +52,12 @@ export default withWinterSpec({
     query = query.where("package", "=", params.package)
   }
 
-  // Apply exact resistance filter
+  // Apply resistance filter with a small tolerance for rounding errors
   if (params.resistance !== undefined) {
-    query = query.where("resistance", "=", params.resistance)
+    const delta = params.resistance * 0.0001
+    query = query
+      .where("resistance", ">=", params.resistance - delta)
+      .where("resistance", "<=", params.resistance + delta)
   }
 
   // Get unique packages for dropdown

--- a/tests/routes/capacitors/list.test.ts
+++ b/tests/routes/capacitors/list.test.ts
@@ -34,3 +34,17 @@ test("GET /capacitors/list with filters returns filtered data", async () => {
     expect(capacitor.package).toBe("0603")
   }
 })
+
+test("GET /capacitors/list with capacitance filter allows small rounding error", async () => {
+  const { axios } = await getTestServer()
+
+  const res = await axios.get("/capacitors/list?json=true&capacitance=10u")
+
+  expect(res.data).toHaveProperty("capacitors")
+  expect(Array.isArray(res.data.capacitors)).toBe(true)
+
+  for (const capacitor of res.data.capacitors) {
+    const delta = Math.abs(capacitor.capacitance - 10e-6)
+    expect(delta).toBeLessThanOrEqual(10e-6 * 0.0001 + 1e-12)
+  }
+})

--- a/tests/routes/resistors/list.test.ts
+++ b/tests/routes/resistors/list.test.ts
@@ -34,3 +34,17 @@ test("GET /resistors/list with filters returns filtered data", async () => {
     expect(resistor.package).toBe("0603")
   }
 })
+
+test("GET /resistors/list with resistance filter allows small rounding error", async () => {
+  const { axios } = await getTestServer()
+
+  const res = await axios.get("/resistors/list?json=true&resistance=1k")
+
+  expect(res.data).toHaveProperty("resistors")
+  expect(Array.isArray(res.data.resistors)).toBe(true)
+
+  for (const resistor of res.data.resistors) {
+    const delta = Math.abs(resistor.resistance - 1000)
+    expect(delta).toBeLessThanOrEqual(1000 * 0.0001 + 1e-9)
+  }
+})


### PR DESCRIPTION
## Summary
- filter capacitors/resistors using a 0.01% range for tolerance
- test that value filters tolerate rounding

## Testing
- `bun test tests/routes/resistors/list.test.ts`
- `bun test tests/routes/capacitors/list.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_6863f2d46628832e847dfc9e11bc113d