### PR TITLE
Add analog switches page

### DIFF
--- a/docs/generated/analog_switches.md
+++ b/docs/generated/analog_switches.md
@@ -1,0 +1,16 @@
+# Analog Switches
+
+| Key | Ex1 | Ex2 |
+| --- | --- | --- |
+| lcsc | 19618 | 79910 |
+| stock | 2873 | 2 |
+| mfr | SGM3005XMS/TR | SGM3001XC6/TR |
+| package | MSOP-10 | - |
+| joints | 10 | 6 |
+| description | MSOP-10 Analog Switches, Multiplexers ROHS | Analog Switches, Multiplexers ROHS |
+| min_q_price | 0.971014493 | 0.824637681 |
+| extra_title | SGMICRO SGM3005XMS/TR | SGMICRO SGM3001XC6/TR |
+| extra.number | C19618 | C79910 |
+| extra.package | MSOP-10 | - |
+| extra.attributes["Switch Circuit"] | - | - |
+

--- a/routes/analog_switches/list.json.tsx
+++ b/routes/analog_switches/list.json.tsx
@@ -1,0 +1,2 @@
+import list from "./list"
+export default list

--- a/routes/analog_switches/list.tsx
+++ b/routes/analog_switches/list.tsx
@@ -1,0 +1,137 @@
+import { Table } from "lib/ui/Table"
+import { withWinterSpec } from "lib/with-winter-spec"
+import { z } from "zod"
+import { formatPrice } from "lib/util/format-price"
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET"],
+  queryParams: z.object({
+    package: z.string().optional(),
+    channels: z.coerce.number().optional(),
+  }),
+  jsonResponse: z.any(),
+} as const)(async (req, ctx) => {
+  let query = ctx.db
+    .selectFrom("analog_multiplexer")
+    .selectAll()
+    .limit(100)
+    .orderBy("stock", "desc")
+    .where("num_channels", "<=", 2)
+
+  if (req.query.package) {
+    query = query.where("package", "=", req.query.package)
+  }
+
+  if (req.query.channels) {
+    query = query.where("num_channels", "=", req.query.channels)
+  }
+
+  const packages = await ctx.db
+    .selectFrom("analog_multiplexer")
+    .select("package")
+    .distinct()
+    .orderBy("package")
+    .execute()
+
+  const channels = await ctx.db
+    .selectFrom("analog_multiplexer")
+    .select("num_channels")
+    .distinct()
+    .orderBy("num_channels")
+    .where("num_channels", "<=", 2)
+    .execute()
+
+  const switches = await query.execute()
+
+  if (ctx.isApiRequest) {
+    return ctx.json({
+      switches: switches.map((m) => ({
+        lcsc: m.lcsc,
+        mfr: m.mfr,
+        package: m.package,
+        num_channels: m.num_channels,
+        on_resistance_ohms: m.on_resistance_ohms,
+        supply_voltage_min: m.supply_voltage_min,
+        supply_voltage_max: m.supply_voltage_max,
+        has_spi: m.has_spi === 1,
+        has_i2c: m.has_i2c === 1,
+        has_parallel_interface: m.has_parallel_interface === 1,
+        channel_type: m.channel_type,
+        stock: m.stock,
+        price1: m.price1,
+      })),
+    })
+  }
+
+  return ctx.react(
+    <div>
+      <h2>Analog Switches</h2>
+
+      <form method="GET" className="flex flex-row gap-4">
+        <div>
+          <label>Package:</label>
+          <select name="package">
+            <option value="">All</option>
+            {packages.map((p) => (
+              <option
+                key={p.package}
+                value={p.package ?? ""}
+                selected={p.package === req.query.package}
+              >
+                {p.package}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label>Channels:</label>
+          <select name="channels">
+            <option value="">All</option>
+            {channels.map((c) => (
+              <option
+                key={c.num_channels}
+                value={c.num_channels ?? ""}
+                selected={c.num_channels === req.query.channels}
+              >
+                {c.num_channels}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <button type="submit">Filter</button>
+      </form>
+
+      <Table
+        rows={switches.map((m) => ({
+          lcsc: m.lcsc,
+          mfr: m.mfr,
+          package: m.package,
+          channels: m.num_channels,
+          on_resistance: m.on_resistance_ohms ? `${m.on_resistance_ohms}Ω` : "",
+          voltage:
+            m.supply_voltage_min && m.supply_voltage_max ? (
+              <span className="tabular-nums">
+                {m.supply_voltage_min}V - {m.supply_voltage_max}V
+              </span>
+            ) : (
+              ""
+            ),
+          interface: [
+            m.has_spi && "SPI",
+            m.has_i2c && "I2C",
+            m.has_parallel_interface && "Parallel",
+          ]
+            .filter(Boolean)
+            .join(", "),
+          type: m.channel_type !== "unknown" ? m.channel_type : "",
+          stock: <span className="tabular-nums">{m.stock}</span>,
+          price: <span className="tabular-nums">{formatPrice(m.price1)}</span>,
+        }))}
+      />
+    </div>,
+    "JLCPCB Analog Switch Search",
+  )
+})

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -22,6 +22,7 @@ export default withWinterSpec({
         <a href="/leds/list">LEDs</a>
         <a href="/adcs/list">ADCs</a>
         <a href="/analog_multiplexers/list">Analog Muxes</a>
+        <a href="/analog_switches/list">Analog Switches</a>
         <a href="/io_expanders/list">I/O Expanders</a>
         <a href="/gyroscopes/list">Gyroscopes</a>
         <a href="/accelerometers/list">Accelerometers</a>

--- a/tests/routes/analog_switches/list.test.ts
+++ b/tests/routes/analog_switches/list.test.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("GET /analog_switches/list with json param returns switch data", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/analog_switches/list?json=true")
+  expect(res.data).toHaveProperty("switches")
+  expect(Array.isArray(res.data.switches)).toBe(true)
+  if (res.data.switches.length > 0) {
+    const sw = res.data.switches[0]
+    expect(sw).toHaveProperty("lcsc")
+    expect(sw).toHaveProperty("mfr")
+    expect(sw).toHaveProperty("package")
+    expect(sw).toHaveProperty("num_channels")
+    expect(sw).toHaveProperty("has_spi")
+    expect(typeof sw.lcsc).toBe("number")
+    expect(typeof sw.has_spi).toBe("boolean")
+    expect(typeof sw.has_i2c).toBe("boolean")
+  }
+})


### PR DESCRIPTION
## Summary
- document analog switches in a new generated file
- add /analog_switches route with filtering
- link to Analog Switches from the index page
- test the new route

## Testing
- `bun test tests/routes/analog_switches/list.test.ts`
- `bun test tests/routes/analog_multiplexers/list.test.ts`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68840ff3c9d4832ea1a9552a860347aa