### PR TITLE
Add USB-C connector page

### DIFF
--- a/docs/generated/usbc_connectors.md
+++ b/docs/generated/usbc_connectors.md
@@ -1,0 +1,24 @@
+# USB-C Connectors
+
+This page lists example USB Type-C connectors available from JLCPCB.
+
+| Key | Ex1 | Ex2 |
+| --- | --- | --- |
+| lcsc | 668623 | 2765186 |
+| stock | 70577 | 62606 |
+| mfr | TYPE-C 6P(073) | TYPE-C 16PIN 2MD(073) |
+| package | SMD | SMD |
+| joints | 10 | 16 |
+| description | 3A USB 3.1 1 Horizontal attachment 6P Female -25℃~+85℃ Type-C SMD USB Connectors ROHS | 5A 1 Horizontal attachment 16P Female -25℃~+85℃ Type-C SMD USB Connectors ROHS |
+| min_q_price | 0.031304348 | 0.049565217 |
+| extra_title | SHOU HAN TYPE-C 6P(073) | SHOU HAN TYPE-C 16PIN 2MD(073) |
+| extra.number | C668623 | C2765186 |
+| extra.package | SMD | SMD |
+| extra.attributes["Mounting Style"] | Surface Mount | Surface Mount |
+| extra.attributes["Number of Ports"] | 1 | 1 |
+| extra.attributes["Current Rating - Power (Max)"] | 5A | 5A |
+| extra.attributes["Operating Temperature Range"] | -25℃~+85℃ | -25℃~+85℃ |
+| extra.attributes["Connector Type"] | Type-C | Type-C |
+| extra.attributes["Standard"] | - | - |
+| extra.attributes["Number of Contacts"] | 6P | 16P |
+| extra.attributes["Gender"] | Female | Female |

--- a/lib/db/derivedtables/usb_c_connector.ts
+++ b/lib/db/derivedtables/usb_c_connector.ts
@@ -1,0 +1,83 @@
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import type { DerivedTableSpec } from "./types"
+import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import { BaseComponent } from "./component-base"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+
+export interface UsbCConnector extends BaseComponent {
+  package: string
+  mounting_style: string | null
+  current_rating_a: number | null
+  number_of_ports: number | null
+  number_of_contacts: number | null
+  gender: string | null
+  operating_temp_min: number | null
+  operating_temp_max: number | null
+}
+
+export const usbCConnectorTableSpec: DerivedTableSpec<UsbCConnector> = {
+  tableName: "usb_c_connector",
+  extraColumns: [
+    { name: "package", type: "text" },
+    { name: "mounting_style", type: "text" },
+    { name: "current_rating_a", type: "real" },
+    { name: "number_of_ports", type: "integer" },
+    { name: "number_of_contacts", type: "integer" },
+    { name: "gender", type: "text" },
+    { name: "operating_temp_min", type: "real" },
+    { name: "operating_temp_max", type: "real" },
+  ],
+  listCandidateComponents(db: KyselyDatabaseInstance) {
+    return db
+      .selectFrom("components")
+      .innerJoin("categories", "components.category_id", "categories.id")
+      .selectAll()
+      .where("categories.subcategory", "=", "USB Connectors")
+  },
+  mapToTable(components) {
+    return components.map((c) => {
+      try {
+        const extra = c.extra ? JSON.parse(c.extra) : {}
+        const attrs: Record<string, string> = extra.attributes || {}
+
+        const parseNum = (v: string | undefined): number | null => {
+          if (!v || v === "-") return null
+          return parseAndConvertSiUnit(v).value as number
+        }
+
+        let tempMin: number | null = null
+        let tempMax: number | null = null
+        const tempRange = attrs["Operating Temperature Range"]
+        if (tempRange && tempRange.includes("~")) {
+          const [min, max] = tempRange.split("~")
+          tempMin = parseNum(min)
+          tempMax = parseNum(max)
+        }
+
+        const contacts = parseInt(
+          (attrs["Number of Contacts"] || "").replace(/[^0-9]/g, ""),
+        )
+
+        return {
+          lcsc: Number(c.lcsc),
+          mfr: String(c.mfr || ""),
+          description: String(c.description || ""),
+          stock: Number(c.stock || 0),
+          price1: extractMinQPrice(c.price),
+          in_stock: Boolean((c.stock || 0) > 0),
+          package: String(c.package || ""),
+          mounting_style: attrs["Mounting Style"] || null,
+          current_rating_a: parseNum(attrs["Current Rating - Power (Max)"]),
+          number_of_ports: parseInt(attrs["Number of Ports"] || "") || null,
+          number_of_contacts: isNaN(contacts) ? null : contacts,
+          gender: attrs["Gender"] || null,
+          operating_temp_min: tempMin,
+          operating_temp_max: tempMax,
+          attributes: attrs,
+        }
+      } catch {
+        return null
+      }
+    })
+  },
+}

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -17,7 +17,7 @@ export interface Accelerometer {
   has_spi: number | null;
   has_uart: number | null;
   in_stock: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
   operating_temp_min: number | null;
@@ -38,7 +38,7 @@ export interface Adc {
   has_uart: number | null;
   in_stock: number | null;
   is_differential: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   mfr: string | null;
   num_channels: number | null;
   operating_temp_max: number | null;
@@ -61,7 +61,7 @@ export interface AnalogMultiplexer {
   has_parallel_interface: number | null;
   has_spi: number | null;
   in_stock: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   leakage_current_na: number | null;
   mfr: string | null;
   num_bits: number | null;
@@ -83,7 +83,7 @@ export interface BjtTransistor {
   current_gain: number | null;
   description: string | null;
   in_stock: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   mfr: string | null;
   package: string | null;
   power_dissipation: number | null;
@@ -100,7 +100,7 @@ export interface BoostConverter {
   input_voltage_max: number | null;
   input_voltage_min: number | null;
   is_synchronous: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   mfr: string | null;
   number_of_outputs: number | null;
   output_current_max: number | null;
@@ -120,7 +120,7 @@ export interface BuckBoostConverter {
   input_voltage_max: number | null;
   input_voltage_min: number | null;
   is_synchronous: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   mfr: string | null;
   number_of_outputs: number | null;
   output_current_max: number | null;
@@ -142,7 +142,7 @@ export interface Capacitor {
   in_stock: number | null;
   is_polarized: number | null;
   is_surface_mount: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   lifetime_hours: number | null;
   mfr: string | null;
   package: string | null;
@@ -156,7 +156,7 @@ export interface Capacitor {
 
 export interface Category {
   category: string;
-  id: number;
+  id: Generated<number>;
   subcategory: string;
 }
 
@@ -170,7 +170,7 @@ export interface Component {
   joints: number;
   last_on_stock: Generated<number>;
   last_update: number;
-  lcsc: number;
+  lcsc: Generated<number>;
   manufacturer_id: number;
   mfr: string;
   package: string;
@@ -196,16 +196,16 @@ export interface ComponentsFtsContent {
   c1: string | null;
   c2: string | null;
   c3: string | null;
-  id: number | null;
+  id: Generated<number | null>;
 }
 
 export interface ComponentsFtsDatum {
   block: Buffer | null;
-  id: number | null;
+  id: Generated<number | null>;
 }
 
 export interface ComponentsFtsDocsize {
-  id: number | null;
+  id: Generated<number | null>;
   sz: Buffer | null;
 }
 
@@ -222,7 +222,7 @@ export interface Dac {
   has_parallel_interface: number | null;
   has_spi: number | null;
   in_stock: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   mfr: string | null;
   nonlinearity_lsb: number | null;
   num_channels: number | null;
@@ -249,7 +249,7 @@ export interface Diode {
   is_schottky: number | null;
   is_tvs: number | null;
   is_zener: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
   operating_temp_min: number | null;
@@ -270,7 +270,7 @@ export interface Fuse {
   is_glass_encased: number | null;
   is_resettable: number | null;
   is_surface_mount: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   mfr: string | null;
   package: string | null;
   price1: number | null;
@@ -283,7 +283,7 @@ export interface GasSensor {
   attributes: string | null;
   description: string | null;
   in_stock: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   measures_air_quality: number | null;
   measures_carbon_monoxide: number | null;
   measures_co2: number | null;
@@ -310,7 +310,7 @@ export interface Gyroscope {
   has_spi: number | null;
   has_uart: number | null;
   in_stock: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
   operating_temp_min: number | null;
@@ -332,7 +332,7 @@ export interface Header {
   insulation_height_mm: number | null;
   is_right_angle: number | null;
   is_shrouded: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   mfr: string | null;
   mounting_style: string | null;
   num_pins: number | null;
@@ -358,7 +358,7 @@ export interface IoExpander {
   has_smbus: number | null;
   has_spi: number | null;
   in_stock: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   mfr: string | null;
   num_gpios: number | null;
   operating_temp_max: number | null;
@@ -379,7 +379,7 @@ export interface LcdDisplay {
   display_size: string | null;
   display_type: string | null;
   in_stock: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   mfr: string | null;
   package: string | null;
   price1: number | null;
@@ -395,7 +395,7 @@ export interface Led {
   forward_voltage: number | null;
   in_stock: number | null;
   is_rgb: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   lens_color: string | null;
   luminous_intensity_mcd: number | null;
   mfr: string | null;
@@ -415,7 +415,7 @@ export interface LedDotMatrixDisplay {
   color: string | null;
   description: string | null;
   in_stock: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   matrix_size: string | null;
   mfr: string | null;
   package: string | null;
@@ -430,7 +430,7 @@ export interface LedDriver {
   dimming_method: string | null;
   efficiency_percent: number | null;
   in_stock: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   mfr: string | null;
   mounting_style: string | null;
   operating_temp_max: number | null;
@@ -449,7 +449,7 @@ export interface LedSegmentDisplay {
   color: string | null;
   description: string | null;
   in_stock: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   mfr: string | null;
   package: string | null;
   positions: string | null;
@@ -466,7 +466,7 @@ export interface LedWithIc {
   forward_current: number | null;
   forward_voltage: number | null;
   in_stock: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   mfr: string | null;
   mounting_style: string | null;
   package: string | null;
@@ -476,7 +476,7 @@ export interface LedWithIc {
 }
 
 export interface Manufacturer {
-  id: number;
+  id: Generated<number>;
   name: string;
 }
 
@@ -503,7 +503,7 @@ export interface Microcontroller {
   has_usb: number | null;
   has_watchdog: number | null;
   in_stock: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
   operating_temp_min: number | null;
@@ -522,7 +522,7 @@ export interface Mosfet {
   drain_source_voltage: number | null;
   gate_threshold_voltage: number | null;
   in_stock: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   mfr: string | null;
   mounting_style: string | null;
   operating_temp_max: number | null;
@@ -538,7 +538,7 @@ export interface OledDisplay {
   description: string | null;
   display_width: string | null;
   in_stock: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   mfr: string | null;
   package: string | null;
   pixel_resolution: string | null;
@@ -552,7 +552,7 @@ export interface Potentiometer {
   description: string | null;
   in_stock: number | null;
   is_surface_mount: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   max_resistance: number | null;
   mfr: string | null;
   package: string | null;
@@ -568,7 +568,7 @@ export interface Relay {
   contact_form: string | null;
   description: string | null;
   in_stock: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   max_switching_current: number | null;
   max_switching_voltage: number | null;
   mfr: string | null;
@@ -586,7 +586,7 @@ export interface Resistor {
   is_multi_resistor_chip: number | null;
   is_potentiometer: number | null;
   is_surface_mount: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   max_overload_voltage: number | null;
   mfr: string | null;
   number_of_pins: number | null;
@@ -606,7 +606,7 @@ export interface Switch {
   description: string | null;
   in_stock: number | null;
   is_latching: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   mfr: string | null;
   mounting_style: string | null;
   operating_temp_max: number | null;
@@ -617,6 +617,24 @@ export interface Switch {
   stock: number | null;
   switch_type: string | null;
   voltage_rating_v: number | null;
+}
+
+export interface UsbCConnector {
+  attributes: string | null;
+  current_rating_a: number | null;
+  description: string | null;
+  gender: string | null;
+  in_stock: number | null;
+  lcsc: Generated<number | null>;
+  mfr: string | null;
+  mounting_style: string | null;
+  number_of_contacts: number | null;
+  number_of_ports: number | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  package: string | null;
+  price1: number | null;
+  stock: number | null;
 }
 
 export interface VComponent {
@@ -647,7 +665,7 @@ export interface VoltageRegulator {
   input_voltage_min: number | null;
   is_low_dropout: number | null;
   is_positive: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
   operating_temp_min: number | null;
@@ -677,7 +695,7 @@ export interface WifiModule {
   has_spi: number | null;
   has_uart: number | null;
   in_stock: number | null;
-  lcsc: number | null;
+  lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
   operating_temp_min: number | null;
@@ -728,6 +746,7 @@ export interface DB {
   relay: Relay;
   resistor: Resistor;
   switch: Switch;
+  usb_c_connector: UsbCConnector;
   v_components: VComponent;
   voltage_regulator: VoltageRegulator;
   wifi_module: WifiModule;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "better-sqlite3": "^11.7.0",
-    "kysely": "^0.27.4",
+    "kysely": "^0.28.3",
     "kysely-codegen": "^0.17.0",
     "winterspec": "^0.0.96"
   },

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -19,6 +19,7 @@ export default withWinterSpec({
         <a href="/capacitors/list">Capacitors</a>
         <a href="/potentiometers/list">Potentiometers</a>
         <a href="/headers/list">Headers</a>
+        <a href="/usb_c_connectors/list">USB-C Connectors</a>
         <a href="/leds/list">LEDs</a>
         <a href="/adcs/list">ADCs</a>
         <a href="/analog_multiplexers/list">Analog Muxes</a>

--- a/routes/usb_c_connectors/list.json.tsx
+++ b/routes/usb_c_connectors/list.json.tsx
@@ -1,0 +1,2 @@
+import list from "./list"
+export default list

--- a/routes/usb_c_connectors/list.tsx
+++ b/routes/usb_c_connectors/list.tsx
@@ -1,0 +1,129 @@
+import { Table } from "lib/ui/Table"
+import { withWinterSpec } from "lib/with-winter-spec"
+import { z } from "zod"
+import { formatPrice } from "lib/util/format-price"
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET", "POST"],
+  commonParams: z.object({
+    json: z.boolean().optional(),
+    package: z.string().optional(),
+    gender: z.enum(["Male", "Female"]).optional(),
+  }),
+  jsonResponse: z.string().or(
+    z.object({
+      usb_c_connectors: z.array(
+        z.object({
+          lcsc: z.number().int(),
+          mfr: z.string(),
+          package: z.string(),
+          gender: z.string().optional(),
+          number_of_contacts: z.number().optional(),
+          current_rating_a: z.number().optional(),
+          stock: z.number().optional(),
+          price1: z.number().optional(),
+        }),
+      ),
+    }),
+  ),
+} as const)(async (req, ctx) => {
+  let query = ctx.db
+    .selectFrom("usb_c_connector")
+    .selectAll()
+    .limit(100)
+    .orderBy("stock", "desc")
+
+  const params = req.commonParams
+
+  if (params.package) {
+    query = query.where("package", "=", params.package)
+  }
+
+  if (params.gender) {
+    query = query.where("gender", "=", params.gender)
+  }
+
+  const packages = await ctx.db
+    .selectFrom("usb_c_connector")
+    .select("package")
+    .distinct()
+    .where("package", "is not", null)
+    .execute()
+
+  const connectors = await query.execute()
+
+  if (ctx.isApiRequest) {
+    return ctx.json({
+      usb_c_connectors: connectors
+        .map((c) => ({
+          lcsc: c.lcsc ?? 0,
+          mfr: c.mfr ?? "",
+          package: c.package ?? "",
+          gender: c.gender ?? undefined,
+          number_of_contacts: c.number_of_contacts ?? undefined,
+          current_rating_a: c.current_rating_a ?? undefined,
+          stock: c.stock ?? undefined,
+          price1: c.price1 ?? undefined,
+        }))
+        .filter((c) => c.lcsc !== 0 && c.package !== ""),
+    })
+  }
+
+  return ctx.react(
+    <div>
+      <h2>USB-C Connectors</h2>
+
+      <form method="GET" className="flex flex-row gap-4">
+        <div>
+          <label>Package:</label>
+          <select name="package">
+            <option value="">All</option>
+            {packages.map((p) => (
+              <option
+                key={p.package}
+                value={p.package ?? ""}
+                selected={p.package === params.package}
+              >
+                {p.package}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label>Gender:</label>
+          <select name="gender">
+            <option value="">All</option>
+            <option value="Male" selected={params.gender === "Male"}>
+              Male
+            </option>
+            <option value="Female" selected={params.gender === "Female"}>
+              Female
+            </option>
+          </select>
+        </div>
+
+        <button type="submit">Filter</button>
+      </form>
+
+      <Table
+        rows={connectors.map((c) => ({
+          lcsc: c.lcsc,
+          mfr: c.mfr,
+          package: c.package,
+          contacts: (
+            <span className="tabular-nums">{c.number_of_contacts}</span>
+          ),
+          current: c.current_rating_a && (
+            <span className="tabular-nums">{c.current_rating_a}A</span>
+          ),
+          gender: c.gender,
+          stock: <span className="tabular-nums">{c.stock}</span>,
+          price: <span className="tabular-nums">{formatPrice(c.price1)}</span>,
+        }))}
+      />
+    </div>,
+    "JLCPCB USB-C Connector Search",
+  )
+})

--- a/scripts/setup-derived-tables.ts
+++ b/scripts/setup-derived-tables.ts
@@ -31,6 +31,7 @@ import { gasSensorTableSpec } from "lib/db/derivedtables/gas_sensor"
 import { boostConverterTableSpec } from "lib/db/derivedtables/boost_converter"
 import { buckBoostConverterTableSpec } from "lib/db/derivedtables/buck_boost_converter"
 import { relayTableSpec } from "lib/db/derivedtables/relay"
+import { usbCConnectorTableSpec } from "lib/db/derivedtables/usb_c_connector"
 
 const resetArg = process.argv.indexOf("--reset")
 const resetTable = resetArg !== -1 ? process.argv[resetArg + 1] : null
@@ -66,6 +67,7 @@ const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   bjtTransistorTableSpec,
   switchTableSpec,
   relayTableSpec,
+  usbCConnectorTableSpec,
 ]
 
 function jsonParseOrNull(strObject: string) {

--- a/tests/routes/usb_c_connectors/list.test.ts
+++ b/tests/routes/usb_c_connectors/list.test.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("GET /usb_c_connectors/list with json param returns data", async () => {
+  const { axios } = await getTestServer()
+
+  const res = await axios.get("/usb_c_connectors/list?json=true")
+
+  expect(res.data).toHaveProperty("usb_c_connectors")
+  expect(Array.isArray(res.data.usb_c_connectors)).toBe(true)
+
+  if (res.data.usb_c_connectors.length > 0) {
+    const c = res.data.usb_c_connectors[0]
+    expect(c).toHaveProperty("lcsc")
+    expect(c).toHaveProperty("mfr")
+    expect(c).toHaveProperty("package")
+    expect(typeof c.lcsc).toBe("number")
+  }
+})
+
+test("GET /usb_c_connectors/list with gender filter returns filtered data", async () => {
+  const { axios } = await getTestServer()
+
+  const res = await axios.get("/usb_c_connectors/list?json=true&gender=Female")
+
+  expect(res.data).toHaveProperty("usb_c_connectors")
+  expect(Array.isArray(res.data.usb_c_connectors)).toBe(true)
+
+  for (const c of res.data.usb_c_connectors) {
+    if (c.gender) {
+      expect(c.gender).toBe("Female")
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- create `usb_c_connector` derived table
- setup the table in derived table script
- add new USB-C connector route and docs
- link USB-C connectors from the index page
- update DB types
- update `kysely` to latest version
- add tests for the new route

## Testing
- `bun update --latest kysely`
- `bun run scripts/setup-derived-tables.ts --reset usb_c_connector`
- `bun run generate:db-types`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/routes/usb_c_connectors`
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_b_6884fee2f6f8832eb8249f8b61f7897b