### PR TITLE
Add PCIe M.2 connector page

### DIFF
--- a/docs/generated/pci_express__pci_connectors_pcie_m2_connectors.md
+++ b/docs/generated/pci_express__pci_connectors_pcie_m2_connectors.md
@@ -1,0 +1,14 @@
+# PCI Express / PCI Connectors PCIe M2 Connectors
+
+This page lists example PCIe M.2 connectors from JLCPCB.
+
+| Key | Ex1 | Ex2 |
+| --- | --- | --- |
+| lcsc | 41430838 | 41430860 |
+| key | B | M |
+| orientation | Right Angle | Right Angle |
+| description | With column Horizontal attachment Female M.2-B Key 67P 6.7mm SMD Hard Disk Connector (SAS/SATA/M.2) | With column Horizontal attachment Female 67P 8.5mm M.2-M Key SMD Hard Disk Connector (SAS/SATA/M.2) |
+| stock | 0 | 0 |
+| mfr | HYCW33B-05NGFF-670B | HYCW15M-05NGFF-850B |
+| price1 | 0.0 | 0.0 |
+

--- a/lib/db/derivedtables/pcie_m2_connector.ts
+++ b/lib/db/derivedtables/pcie_m2_connector.ts
@@ -1,0 +1,54 @@
+import type { DerivedTableSpec } from "./types"
+import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import { BaseComponent } from "./component-base"
+
+export interface PcieM2Connector extends BaseComponent {
+  key: string | null
+  is_right_angle: boolean
+}
+
+export const pcieM2ConnectorTableSpec: DerivedTableSpec<PcieM2Connector> = {
+  tableName: "pcie_m2_connector",
+  extraColumns: [
+    { name: "key", type: "text" },
+    { name: "is_right_angle", type: "boolean" },
+  ],
+  listCandidateComponents: (db) =>
+    db
+      .selectFrom("components")
+      .innerJoin("categories", "components.category_id", "categories.id")
+      .selectAll()
+      .where(
+        "categories.subcategory",
+        "=",
+        "Hard Disk Connector (SAS/SATA/M.2)",
+      ),
+  mapToTable(components) {
+    return components.map((c) => {
+      if (!c.extra) return null
+      const extra = JSON.parse(c.extra ?? "{}")
+      const attrs: Record<string, string> = extra.attributes || {}
+
+      const interfaceForm = attrs["Interface Form"] || ""
+      let key: string | null = null
+      const keyMatch = interfaceForm.match(/M\.2-(\w) Key/i)
+      if (keyMatch) key = keyMatch[1]
+
+      const mounting =
+        attrs["Mounting Type"] || attrs["Mounting Style"] || c.description
+      const isRightAngle = /horizontal/i.test(mounting)
+
+      return {
+        lcsc: Number(c.lcsc),
+        mfr: String(c.mfr || ""),
+        description: String(c.description || ""),
+        stock: Number(c.stock || 0),
+        price1: extractMinQPrice(c.price),
+        in_stock: Boolean((c.stock || 0) > 0),
+        key,
+        is_right_angle: isRightAngle,
+        attributes: attrs,
+      }
+    })
+  },
+}

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -547,6 +547,18 @@ export interface OledDisplay {
   stock: number | null;
 }
 
+export interface PcieM2Connector {
+  attributes: string | null;
+  description: string | null;
+  in_stock: number | null;
+  is_right_angle: number | null;
+  key: string | null;
+  lcsc: Generated<number | null>;
+  mfr: string | null;
+  price1: number | null;
+  stock: number | null;
+}
+
 export interface Potentiometer {
   attributes: string | null;
   description: string | null;
@@ -742,6 +754,7 @@ export interface DB {
   microcontroller: Microcontroller;
   mosfet: Mosfet;
   oled_display: OledDisplay;
+  pcie_m2_connector: PcieM2Connector;
   potentiometer: Potentiometer;
   relay: Relay;
   resistor: Resistor;

--- a/routes/pcie_m2_connectors/list.json.tsx
+++ b/routes/pcie_m2_connectors/list.json.tsx
@@ -1,0 +1,2 @@
+import list from "./list"
+export default list

--- a/routes/pcie_m2_connectors/list.tsx
+++ b/routes/pcie_m2_connectors/list.tsx
@@ -1,0 +1,119 @@
+import { Table } from "lib/ui/Table"
+import { withWinterSpec } from "lib/with-winter-spec"
+import { z } from "zod"
+import { formatPrice } from "lib/util/format-price"
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET", "POST"],
+  commonParams: z.object({
+    json: z.boolean().optional(),
+    key: z.string().optional(),
+    is_right_angle: z.boolean().optional(),
+  }),
+  jsonResponse: z.string().or(
+    z.object({
+      pcie_m2_connectors: z.array(
+        z.object({
+          lcsc: z.number().int(),
+          mfr: z.string(),
+          key: z.string().optional(),
+          is_right_angle: z.boolean().optional(),
+          stock: z.number().optional(),
+          price1: z.number().optional(),
+        }),
+      ),
+    }),
+  ),
+} as const)(async (req, ctx) => {
+  let query = ctx.db
+    .selectFrom("pcie_m2_connector")
+    .selectAll()
+    .limit(100)
+    .orderBy("stock", "desc")
+
+  const params = req.commonParams
+
+  if (params.key) {
+    query = query.where("key", "=", params.key)
+  }
+
+  if (params.is_right_angle !== undefined) {
+    query = query.where("is_right_angle", "=", params.is_right_angle ? 1 : 0)
+  }
+
+  const keys = await ctx.db
+    .selectFrom("pcie_m2_connector")
+    .select("key")
+    .distinct()
+    .where("key", "is not", null)
+    .execute()
+
+  const connectors = await query.execute()
+
+  if (ctx.isApiRequest) {
+    return ctx.json({
+      pcie_m2_connectors: connectors
+        .map((c) => ({
+          lcsc: c.lcsc ?? 0,
+          mfr: c.mfr ?? "",
+          key: c.key ?? undefined,
+          is_right_angle: Boolean(c.is_right_angle),
+          stock: c.stock ?? undefined,
+          price1: c.price1 ?? undefined,
+        }))
+        .filter((c) => c.lcsc !== 0),
+    })
+  }
+
+  return ctx.react(
+    <div>
+      <h2>PCIe M.2 Connectors</h2>
+
+      <form method="GET" className="flex flex-row gap-4">
+        <div>
+          <label>Key:</label>
+          <select name="key">
+            <option value="">All</option>
+            {keys.map((k) => (
+              <option
+                key={k.key}
+                value={k.key ?? ""}
+                selected={k.key === params.key}
+              >
+                {k.key}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label>Right Angle:</label>
+          <select name="is_right_angle">
+            <option value="">All</option>
+            <option value="true" selected={params.is_right_angle === true}>
+              Yes
+            </option>
+            <option value="false" selected={params.is_right_angle === false}>
+              No
+            </option>
+          </select>
+        </div>
+
+        <button type="submit">Filter</button>
+      </form>
+
+      <Table
+        rows={connectors.map((c) => ({
+          lcsc: c.lcsc,
+          mfr: c.mfr,
+          key: c.key,
+          orientation: c.is_right_angle ? "Right Angle" : "Straight",
+          stock: <span className="tabular-nums">{c.stock}</span>,
+          price: <span className="tabular-nums">{formatPrice(c.price1)}</span>,
+        }))}
+      />
+    </div>,
+    "JLCPCB PCIe M.2 Connector Search",
+  )
+})

--- a/scripts/setup-derived-tables.ts
+++ b/scripts/setup-derived-tables.ts
@@ -32,6 +32,7 @@ import { boostConverterTableSpec } from "lib/db/derivedtables/boost_converter"
 import { buckBoostConverterTableSpec } from "lib/db/derivedtables/buck_boost_converter"
 import { relayTableSpec } from "lib/db/derivedtables/relay"
 import { usbCConnectorTableSpec } from "lib/db/derivedtables/usb_c_connector"
+import { pcieM2ConnectorTableSpec } from "lib/db/derivedtables/pcie_m2_connector"
 
 const resetArg = process.argv.indexOf("--reset")
 const resetTable = resetArg !== -1 ? process.argv[resetArg + 1] : null
@@ -68,6 +69,7 @@ const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   switchTableSpec,
   relayTableSpec,
   usbCConnectorTableSpec,
+  pcieM2ConnectorTableSpec,
 ]
 
 function jsonParseOrNull(strObject: string) {

--- a/tests/routes/pcie_m2_connectors/list.test.ts
+++ b/tests/routes/pcie_m2_connectors/list.test.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("GET /pcie_m2_connectors/list with json param returns data", async () => {
+  const { axios } = await getTestServer()
+
+  const res = await axios.get("/pcie_m2_connectors/list?json=true")
+
+  expect(res.data).toHaveProperty("pcie_m2_connectors")
+  expect(Array.isArray(res.data.pcie_m2_connectors)).toBe(true)
+
+  if (res.data.pcie_m2_connectors.length > 0) {
+    const c = res.data.pcie_m2_connectors[0]
+    expect(c).toHaveProperty("lcsc")
+    expect(c).toHaveProperty("key")
+    expect(typeof c.lcsc).toBe("number")
+  }
+})


### PR DESCRIPTION
## Summary
- add derived table for PCIe M.2 connectors
- update setup script to build new table
- create list page and JSON endpoint
- document PCIe M.2 connectors
- add basic test for the new route

## Testing
- `bun test tests/routes/pcie_m2_connectors/list.test.ts`
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_b_68852eaa61f8832e9d0eb5d45918f23e