### PR TITLE
Adjust caching headers

### DIFF
--- a/lib/middlewares/with-cache-headers.ts
+++ b/lib/middlewares/with-cache-headers.ts
@@ -4,10 +4,10 @@ export const withCacheHeaders: Middleware<{}, {}> = async (req, ctx, next) => {
   const res = await next(req, ctx)
 
   if (req.url.includes("tscircuit.com")) {
-    // Cache for 1 week (604800 seconds) with 24 hour stale-while-revalidate
+    // Cache for 5 minutes, serve stale content while revalidating and on errors
     res.headers.set(
       "Cache-Control",
-      "public, max-age=604800, s-maxage=604800, stale-while-revalidate=86400",
+      "public, max-age=300, s-maxage=300, stale-while-revalidate=300, stale-if-error=86400",
     )
     res.headers.set("Vary", "*")
   }

--- a/lib/middlewares/with-cache-headers.ts
+++ b/lib/middlewares/with-cache-headers.ts
@@ -4,11 +4,22 @@ export const withCacheHeaders: Middleware<{}, {}> = async (req, ctx, next) => {
   const res = await next(req, ctx)
 
   if (req.url.includes("tscircuit.com")) {
-    // Cache for 5 minutes, serve stale content while revalidating and on errors
-    res.headers.set(
-      "Cache-Control",
-      "public, max-age=300, s-maxage=300, stale-while-revalidate=300, stale-if-error=86400",
-    )
+    const path = new URL(req.url).pathname
+
+    if (path === "/") {
+      // Cache the homepage for 5 minutes, serve stale content while revalidating or on errors
+      res.headers.set(
+        "Cache-Control",
+        "public, max-age=300, s-maxage=300, stale-while-revalidate=300, stale-if-error=86400",
+      )
+    } else {
+      // Cache other pages for 1 week with 24h stale-while-revalidate
+      res.headers.set(
+        "Cache-Control",
+        "public, max-age=604800, s-maxage=604800, stale-while-revalidate=86400",
+      )
+    }
+
     res.headers.set("Vary", "*")
   }
 


### PR DESCRIPTION
## Summary
- tweak `withCacheHeaders` middleware to refresh cache after 5 minutes and serve stale content when revalidating or if the origin fails
- run tests for relevant routes
- format repo

## Testing
- `bun test tests/routes/headers/list.test.ts tests/routes/health.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68853c1c5f2c832eacd8cc6ab6a71b14