### PR TITLE
Fix gender filter validation for headers

### DIFF
--- a/routes/headers/list.tsx
+++ b/routes/headers/list.tsx
@@ -11,7 +11,7 @@ export default withWinterSpec({
     pitch: z.string().optional(),
     num_pins: z.coerce.number().optional(),
     is_right_angle: z.boolean().optional(),
-    gender: z.enum(["male", "female"]).optional(),
+    gender: z.enum(["male", "female", ""]).optional(),
   }),
   jsonResponse: z.string().or(
     z.object({

--- a/tests/routes/headers/list.test.ts
+++ b/tests/routes/headers/list.test.ts
@@ -43,3 +43,17 @@ test("GET /headers/list with filters returns filtered data", async () => {
     expect(header.gender).toBe("male")
   }
 })
+
+test("GET /headers/list allows empty gender parameter", async () => {
+  const { axios } = await getTestServer()
+
+  const res = await axios.get("/headers/list", {
+    params: {
+      json: true,
+      gender: "",
+    },
+  })
+
+  expect(res.data).toHaveProperty("headers")
+  expect(Array.isArray(res.data.headers)).toBe(true)
+})


### PR DESCRIPTION
## Summary
- allow empty gender query on `/headers/list`
- test that empty gender query doesn't error

## Testing
- `bun test tests/routes/headers/list.test.ts`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_688551722f64832eb8987b4e90a5f63a