### PR TITLE
Add dimensions to switch table

### DIFF
--- a/lib/db/derivedtables/switch.ts
+++ b/lib/db/derivedtables/switch.ts
@@ -14,6 +14,9 @@ export interface Switch extends BaseComponent {
   operating_temp_min: number | null
   operating_temp_max: number | null
   pin_count: number | null
+  width_mm: number | null
+  length_mm: number | null
+  switch_height_mm: number | null
 }
 
 export const switchTableSpec: DerivedTableSpec<Switch> = {
@@ -29,6 +32,9 @@ export const switchTableSpec: DerivedTableSpec<Switch> = {
     { name: "operating_temp_min", type: "real" },
     { name: "operating_temp_max", type: "real" },
     { name: "pin_count", type: "integer" },
+    { name: "width_mm", type: "real" },
+    { name: "length_mm", type: "real" },
+    { name: "switch_height_mm", type: "real" },
   ],
   listCandidateComponents(db) {
     return db
@@ -70,6 +76,10 @@ export const switchTableSpec: DerivedTableSpec<Switch> = {
         tempMax = parseNum(max)
       }
 
+      const width = parseNum(attrs["Switch Width"])
+      const length = parseNum(attrs["Switch Length"])
+      const switchHeight = parseNum(attrs["Switch Height"])
+
       return {
         lcsc: c.lcsc,
         mfr: c.mfr,
@@ -91,6 +101,9 @@ export const switchTableSpec: DerivedTableSpec<Switch> = {
         operating_temp_min: tempMin,
         operating_temp_max: tempMax,
         pin_count: c.joints ?? null,
+        width_mm: width,
+        length_mm: length,
+        switch_height_mm: switchHeight,
         attributes: attrs,
       }
     })

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -619,6 +619,7 @@ export interface Switch {
   in_stock: number | null;
   is_latching: number | null;
   lcsc: Generated<number | null>;
+  length_mm: number | null;
   mfr: string | null;
   mounting_style: string | null;
   operating_temp_max: number | null;
@@ -627,8 +628,10 @@ export interface Switch {
   pin_count: number | null;
   price1: number | null;
   stock: number | null;
+  switch_height_mm: number | null;
   switch_type: string | null;
   voltage_rating_v: number | null;
+  width_mm: number | null;
 }
 
 export interface UsbCConnector {

--- a/routes/switches/list.tsx
+++ b/routes/switches/list.tsx
@@ -23,6 +23,9 @@ export default withWinterSpec({
           switch_type: z.string(),
           circuit: z.string().optional(),
           pin_count: z.number().optional(),
+          width_mm: z.number().optional(),
+          length_mm: z.number().optional(),
+          switch_height_mm: z.number().optional(),
           stock: z.number().optional(),
           price1: z.number().optional(),
         }),
@@ -95,6 +98,9 @@ export default withWinterSpec({
           pin_count: s.pin_count ?? undefined,
           switch_type: s.switch_type ?? "",
           circuit: s.circuit ?? undefined,
+          width_mm: s.width_mm ?? undefined,
+          length_mm: s.length_mm ?? undefined,
+          switch_height_mm: s.switch_height_mm ?? undefined,
           stock: s.stock ?? undefined,
           price1: s.price1 ?? undefined,
         }))
@@ -181,6 +187,21 @@ export default withWinterSpec({
           package: s.package,
           type: s.switch_type,
           pins: s.pin_count,
+          width: s.width_mm ? (
+            <span className="tabular-nums">{s.width_mm}mm</span>
+          ) : (
+            ""
+          ),
+          length: s.length_mm ? (
+            <span className="tabular-nums">{s.length_mm}mm</span>
+          ) : (
+            ""
+          ),
+          height: s.switch_height_mm ? (
+            <span className="tabular-nums">{s.switch_height_mm}mm</span>
+          ) : (
+            ""
+          ),
           circuit: s.circuit ?? "",
           stock: <span className="tabular-nums">{s.stock}</span>,
           price: <span className="tabular-nums">{formatPrice(s.price1)}</span>,


### PR DESCRIPTION
## Summary
- store switch width/length/height from attributes
- expose width/length/height in `/switches/list` API and table
- update generated Kysely types

## Testing
- `bun test tests/routes/switches/list.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_6886abafa138832e8a28fe8af1e7cea8