### PR TITLE
Fix LEDs with IC route

### DIFF
--- a/lib/db/derivedtables/led_with_ic.ts
+++ b/lib/db/derivedtables/led_with_ic.ts
@@ -31,13 +31,7 @@ export const ledWithICTableSpec: DerivedTableSpec<LEDWithIC> = {
       .selectFrom("components")
       .innerJoin("categories", "components.category_id", "categories.id")
       .selectAll()
-      .where((eb) =>
-        eb.or([
-          eb("categories.subcategory", "=", "LEDs (Built-in IC)"),
-          eb("description", "like", "%LED%"),
-          eb("description", "like", "%IC%"),
-        ]),
-      )
+      .where("categories.subcategory", "=", "RGB LEDs(Built-In IC)")
   },
   mapToTable(components) {
     return components.map((c) => {

--- a/routes/led_with_ic/list.tsx
+++ b/routes/led_with_ic/list.tsx
@@ -32,47 +32,37 @@ export default withWinterSpec({
   const params = req.commonParams
   const limit = 100
 
-  // Hardcoding the search value to "LEDs(Built-in IC)"
-  const search = "LEDs(Built-in IC)"
-  const searchPattern = `%${search}%`
-
   let query = ctx.db
     .selectFrom("led_with_ic")
+    .innerJoin("components", "led_with_ic.lcsc", "components.lcsc")
+    .innerJoin("categories", "components.category_id", "categories.id")
     .select([
-      "lcsc",
-      "mfr",
-      "package",
-      "description",
-      "stock",
-      "price1",
-      "color",
-      "protocol",
-      "forward_voltage",
-      "forward_current",
+      "led_with_ic.lcsc",
+      "led_with_ic.mfr",
+      "led_with_ic.package",
+      "led_with_ic.description",
+      "led_with_ic.stock",
+      "led_with_ic.price1",
+      "led_with_ic.color",
+      "led_with_ic.protocol",
+      "led_with_ic.forward_voltage",
+      "led_with_ic.forward_current",
     ] as const)
     .limit(limit)
-    .orderBy("stock", "desc")
-    .where("stock", ">", 0)
-    .where((eb) =>
-      eb("description", "like", searchPattern)
-        .or("mfr", "like", searchPattern)
-        .or(
-          search.match(/^\d+$/)
-            ? eb("lcsc", "=", parseInt(search))
-            : eb("description", "like", searchPattern),
-        ),
-    )
+    .orderBy("led_with_ic.stock", "desc")
+    .where("categories.subcategory", "=", "RGB LEDs(Built-In IC)")
+    .where("led_with_ic.stock", ">", 0)
 
   if (params.package) {
-    query = query.where("package", "=", params.package)
+    query = query.where("led_with_ic.package", "=", params.package)
   }
 
   if (params.color) {
-    query = query.where("color", "=", params.color)
+    query = query.where("led_with_ic.color", "=", params.color)
   }
 
   if (params.protocol) {
-    query = query.where("protocol", "=", params.protocol)
+    query = query.where("led_with_ic.protocol", "=", params.protocol)
   }
 
   const fullComponents = await query.execute()
@@ -115,23 +105,32 @@ export default withWinterSpec({
 
   const packages = await ctx.db
     .selectFrom("led_with_ic")
-    .select("package")
+    .innerJoin("components", "led_with_ic.lcsc", "components.lcsc")
+    .innerJoin("categories", "components.category_id", "categories.id")
+    .select("led_with_ic.package")
     .distinct()
-    .orderBy("package")
+    .where("categories.subcategory", "=", "RGB LEDs(Built-In IC)")
+    .orderBy("led_with_ic.package")
     .execute()
 
   const colors = await ctx.db
     .selectFrom("led_with_ic")
-    .select("color")
+    .innerJoin("components", "led_with_ic.lcsc", "components.lcsc")
+    .innerJoin("categories", "components.category_id", "categories.id")
+    .select("led_with_ic.color")
     .distinct()
-    .orderBy("color")
+    .where("categories.subcategory", "=", "RGB LEDs(Built-In IC)")
+    .orderBy("led_with_ic.color")
     .execute()
 
   const protocols = await ctx.db
     .selectFrom("led_with_ic")
-    .select("protocol")
+    .innerJoin("components", "led_with_ic.lcsc", "components.lcsc")
+    .innerJoin("categories", "components.category_id", "categories.id")
+    .select("led_with_ic.protocol")
     .distinct()
-    .orderBy("protocol")
+    .where("categories.subcategory", "=", "RGB LEDs(Built-In IC)")
+    .orderBy("led_with_ic.protocol")
     .execute()
 
   return ctx.react(

--- a/tests/routes/led_with_ic/list.test.ts
+++ b/tests/routes/led_with_ic/list.test.ts
@@ -32,24 +32,26 @@ test("GET /led_with_ic/list.json with filters returns filtered data", async () =
   const { axios } = await getTestServer()
 
   // Test with package filter
-  const res = await axios.get("/led_with_ic/list.json?json=true&package=0603")
+  const res = await axios.get(
+    "/led_with_ic/list.json?json=true&package=SMD5050",
+  )
 
   expect(res.data).toHaveProperty("leds_with_ic")
   expect(Array.isArray(res.data.leds_with_ic)).toBe(true)
 
   // Verify all returned LEDs with IC have the specified package
   for (const ledWithIC of res.data.leds_with_ic) {
-    expect(ledWithIC.package).toBe("0603")
+    expect(ledWithIC.package).toBe("SMD5050")
   }
 
   // Test with color filter
-  const colorRes = await axios.get("/led_with_ic/list.json?json=true&color=RED")
+  const colorRes = await axios.get("/led_with_ic/list.json?json=true&color=RGB")
 
   expect(colorRes.data).toHaveProperty("leds_with_ic")
   expect(Array.isArray(colorRes.data.leds_with_ic)).toBe(true)
 
   // Verify all returned LEDs with IC have the specified color
   for (const ledWithIC of colorRes.data.leds_with_ic) {
-    expect(ledWithIC.color).toBe("RED")
+    expect(ledWithIC.color).toBe("RGB")
   }
 })


### PR DESCRIPTION
## Summary
- restrict LED-with-IC derived table to RGB LED category
- rewrite `led_with_ic/list` route query to join components and filter by category
- update test to use existing packages and color

## Testing
- `bun test tests/routes/led_with_ic/list.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_6886cf946824832e97eedfdd6ae8f4ff