### PR TITLE
Add PCIe M.2 connector docs

### DIFF
--- a/docs/generated/pci_express__pci_connectors_pcie_m2_connectors.md
+++ b/docs/generated/pci_express__pci_connectors_pcie_m2_connectors.md
@@ -4,11 +4,11 @@ This page lists example PCIe M.2 connectors from JLCPCB.
 
 | Key | Ex1 | Ex2 |
 | --- | --- | --- |
-| lcsc | 41430838 | 41430860 |
-| key | B | M |
-| orientation | Right Angle | Right Angle |
-| description | With column Horizontal attachment Female M.2-B Key 67P 6.7mm SMD Hard Disk Connector (SAS/SATA/M.2) | With column Horizontal attachment Female 67P 8.5mm M.2-M Key SMD Hard Disk Connector (SAS/SATA/M.2) |
-| stock | 0 | 0 |
-| mfr | HYCW33B-05NGFF-670B | HYCW15M-05NGFF-850B |
-| price1 | 0.0 | 0.0 |
+| lcsc | 41430838 | 22438715 |
+| key | B |  |
+| orientation | Right Angle | Straight |
+| description | With column Horizontal attachment Female M.2-B Key 67P 6.7mm SMD Hard Disk Connector (SAS/SATA/M.2) | Plugin Hard Disk Connector (SAS/SATA/M.2) ROHS |
+| stock | 100 | 172 |
+| mfr | HYCW33B-05NGFF-670B | HDGCYLSY-SATA-113 |
+| price1 | 1.248571429 | 0.434285714 |
 

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -20,6 +20,7 @@ export default withWinterSpec({
         <a href="/potentiometers/list">Potentiometers</a>
         <a href="/headers/list">Headers</a>
         <a href="/usb_c_connectors/list">USB-C Connectors</a>
+        <a href="/pcie_m2_connectors/list">PCIe M.2 Connectors</a>
         <a href="/leds/list">LEDs</a>
         <a href="/adcs/list">ADCs</a>
         <a href="/analog_multiplexers/list">Analog Muxes</a>


### PR DESCRIPTION
## Summary
- document PCIe M.2 connectors with orientation examples
- link to PCIe M.2 connectors from homepage

## Testing
- `bun run format`
- `bun test tests/routes/pcie_m2_connectors/list.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_688a60a00fd8832e88717ef3f0c91215