### PR TITLE
feat: add LDO regulator search

### DIFF
--- a/lib/db/derivedtables/ldo.ts
+++ b/lib/db/derivedtables/ldo.ts
@@ -7,7 +7,8 @@ export interface Ldo extends Omit<VoltageRegulator, "is_low_dropout"> {}
 export const ldoTableSpec: DerivedTableSpec<Ldo> = {
   tableName: "ldo",
   extraColumns: voltageRegulatorTableSpec.extraColumns.filter(
-    (col) => col.name !== "is_low_dropout",
+    (col): col is { name: keyof Ldo; type: string } =>
+      col.name !== "is_low_dropout",
   ),
   listCandidateComponents: (db) =>
     voltageRegulatorTableSpec.listCandidateComponents(db),

--- a/lib/db/derivedtables/ldo.ts
+++ b/lib/db/derivedtables/ldo.ts
@@ -1,0 +1,20 @@
+import type { DerivedTableSpec } from "./types"
+import { voltageRegulatorTableSpec } from "./voltage_regulator"
+import type { VoltageRegulator } from "./voltage_regulator"
+
+export interface Ldo extends Omit<VoltageRegulator, "is_low_dropout"> {}
+
+export const ldoTableSpec: DerivedTableSpec<Ldo> = {
+  tableName: "ldo",
+  extraColumns: voltageRegulatorTableSpec.extraColumns.filter(
+    (col) => col.name !== "is_low_dropout",
+  ),
+  listCandidateComponents: (db) =>
+    voltageRegulatorTableSpec.listCandidateComponents(db),
+  mapToTable: (components) =>
+    voltageRegulatorTableSpec.mapToTable(components as any).map((c) => {
+      if (!c || !c.is_low_dropout) return null
+      const { is_low_dropout, ...rest } = c
+      return rest
+    }),
+}

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -572,6 +572,18 @@ export interface OledDisplay {
   stock: number | null;
 }
 
+export interface PcieM2Connector {
+  attributes: string | null;
+  description: string | null;
+  in_stock: number | null;
+  is_right_angle: number | null;
+  key: string | null;
+  lcsc: Generated<number | null>;
+  mfr: string | null;
+  price1: number | null;
+  stock: number | null;
+}
+
 export interface Potentiometer {
   attributes: string | null;
   description: string | null;
@@ -583,6 +595,24 @@ export interface Potentiometer {
   package: string | null;
   pin_variant: string | null;
   price1: number | null;
+  stock: number | null;
+}
+
+export interface Relay {
+  attributes: string | null;
+  coil_resistance: number | null;
+  coil_voltage: number | null;
+  contact_form: string | null;
+  description: string | null;
+  in_stock: number | null;
+  lcsc: Generated<number | null>;
+  max_switching_current: number | null;
+  max_switching_voltage: number | null;
+  mfr: string | null;
+  package: string | null;
+  pin_number: number | null;
+  price1: number | null;
+  relay_type: string | null;
   stock: number | null;
 }
 
@@ -627,6 +657,24 @@ export interface Switch {
   switch_type: string | null;
   voltage_rating_v: number | null;
   width_mm: number | null;
+}
+
+export interface UsbCConnector {
+  attributes: string | null;
+  current_rating_a: number | null;
+  description: string | null;
+  gender: string | null;
+  in_stock: number | null;
+  lcsc: Generated<number | null>;
+  mfr: string | null;
+  mounting_style: string | null;
+  number_of_contacts: number | null;
+  number_of_ports: number | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  package: string | null;
+  price1: number | null;
+  stock: number | null;
 }
 
 export interface VComponent {
@@ -735,9 +783,12 @@ export interface DB {
   microcontroller: Microcontroller;
   mosfet: Mosfet;
   oled_display: OledDisplay;
+  pcie_m2_connector: PcieM2Connector;
   potentiometer: Potentiometer;
+  relay: Relay;
   resistor: Resistor;
   switch: Switch;
+  usb_c_connector: UsbCConnector;
   v_components: VComponent;
   voltage_regulator: VoltageRegulator;
   wifi_module: WifiModule;

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -387,6 +387,31 @@ export interface LcdDisplay {
   stock: number | null;
 }
 
+export interface Ldo {
+  attributes: string | null;
+  description: string | null;
+  dropout_voltage: number | null;
+  in_stock: number | null;
+  input_voltage_max: number | null;
+  input_voltage_min: number | null;
+  is_positive: number | null;
+  lcsc: Generated<number | null>;
+  mfr: string | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  output_current_max: number | null;
+  output_noise_uvrms: number | null;
+  output_type: string | null;
+  output_voltage_max: number | null;
+  output_voltage_min: number | null;
+  package: string | null;
+  power_supply_rejection_db: number | null;
+  price1: number | null;
+  quiescent_current: number | null;
+  stock: number | null;
+  topology: string | null;
+}
+
 export interface Led {
   attributes: string | null;
   color: string | null;
@@ -547,18 +572,6 @@ export interface OledDisplay {
   stock: number | null;
 }
 
-export interface PcieM2Connector {
-  attributes: string | null;
-  description: string | null;
-  in_stock: number | null;
-  is_right_angle: number | null;
-  key: string | null;
-  lcsc: Generated<number | null>;
-  mfr: string | null;
-  price1: number | null;
-  stock: number | null;
-}
-
 export interface Potentiometer {
   attributes: string | null;
   description: string | null;
@@ -570,24 +583,6 @@ export interface Potentiometer {
   package: string | null;
   pin_variant: string | null;
   price1: number | null;
-  stock: number | null;
-}
-
-export interface Relay {
-  attributes: string | null;
-  coil_resistance: number | null;
-  coil_voltage: number | null;
-  contact_form: string | null;
-  description: string | null;
-  in_stock: number | null;
-  lcsc: Generated<number | null>;
-  max_switching_current: number | null;
-  max_switching_voltage: number | null;
-  mfr: string | null;
-  package: string | null;
-  pin_number: number | null;
-  price1: number | null;
-  relay_type: string | null;
   stock: number | null;
 }
 
@@ -632,24 +627,6 @@ export interface Switch {
   switch_type: string | null;
   voltage_rating_v: number | null;
   width_mm: number | null;
-}
-
-export interface UsbCConnector {
-  attributes: string | null;
-  current_rating_a: number | null;
-  description: string | null;
-  gender: string | null;
-  in_stock: number | null;
-  lcsc: Generated<number | null>;
-  mfr: string | null;
-  mounting_style: string | null;
-  number_of_contacts: number | null;
-  number_of_ports: number | null;
-  operating_temp_max: number | null;
-  operating_temp_min: number | null;
-  package: string | null;
-  price1: number | null;
-  stock: number | null;
 }
 
 export interface VComponent {
@@ -748,6 +725,7 @@ export interface DB {
   header: Header;
   io_expander: IoExpander;
   lcd_display: LcdDisplay;
+  ldo: Ldo;
   led: Led;
   led_dot_matrix_display: LedDotMatrixDisplay;
   led_driver: LedDriver;
@@ -757,12 +735,9 @@ export interface DB {
   microcontroller: Microcontroller;
   mosfet: Mosfet;
   oled_display: OledDisplay;
-  pcie_m2_connector: PcieM2Connector;
   potentiometer: Potentiometer;
-  relay: Relay;
   resistor: Resistor;
   switch: Switch;
-  usb_c_connector: UsbCConnector;
   v_components: VComponent;
   voltage_regulator: VoltageRegulator;
   wifi_module: WifiModule;

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -34,6 +34,7 @@ export default withWinterSpec({
         <a href="/wifi_modules/list">WiFi Modules</a>
         <a href="/microcontrollers/list">Microcontrollers</a>
         <a href="/voltage_regulators/list">Voltage Regulators</a>
+        <a href="/ldos/list">LDO Regulators</a>
         <a href="/boost_converters/list">Boost DC-DC Converters</a>
         <a href="/buck_boost_converters/list">Buck-Boost DC-DC Converters</a>
         <a href="/led_drivers/list">LED Drivers</a>

--- a/routes/ldos/list.json.tsx
+++ b/routes/ldos/list.json.tsx
@@ -1,0 +1,2 @@
+import list from "./list"
+export default list

--- a/routes/ldos/list.tsx
+++ b/routes/ldos/list.tsx
@@ -1,0 +1,169 @@
+import { Table } from "lib/ui/Table"
+import { withWinterSpec } from "lib/with-winter-spec"
+import { z } from "zod"
+import { formatPrice } from "lib/util/format-price"
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET"],
+  queryParams: z.object({
+    package: z.string().optional(),
+    output_type: z.enum(["fixed", "adjustable", ""]).optional(),
+    output_voltage: z.coerce.number().optional(),
+  }),
+  jsonResponse: z.any(),
+} as const)(async (req, ctx) => {
+  let query = ctx.db
+    .selectFrom("ldo")
+    .selectAll()
+    .limit(100)
+    .orderBy("stock", "desc")
+
+  if (req.query.package) {
+    query = query.where("package", "=", req.query.package)
+  }
+
+  if (req.query.output_type) {
+    query = query.where("output_type", "=", req.query.output_type)
+  }
+
+  if (req.query.output_voltage) {
+    query = query.where((eb) =>
+      eb.or([
+        eb("output_voltage_min", "<=", req.query.output_voltage!),
+        eb("output_voltage_max", ">=", req.query.output_voltage!),
+      ]),
+    )
+  }
+
+  const packages = await ctx.db
+    .selectFrom("ldo")
+    .select("package")
+    .distinct()
+    .orderBy("package")
+    .execute()
+
+  const regulators = await query.execute()
+
+  if (ctx.isApiRequest) {
+    return ctx.json({
+      ldos: regulators.map((r) => ({
+        lcsc: r.lcsc,
+        mfr: r.mfr,
+        package: r.package,
+        output_type: r.output_type,
+        is_positive: r.is_positive === 1,
+        output_voltage_min: r.output_voltage_min,
+        output_voltage_max: r.output_voltage_max,
+        output_current_max: r.output_current_max,
+        dropout_voltage: r.dropout_voltage,
+        input_voltage_min: r.input_voltage_min,
+        input_voltage_max: r.input_voltage_max,
+        quiescent_current: r.quiescent_current,
+        stock: r.stock,
+        price1: r.price1,
+      })),
+    })
+  }
+
+  return ctx.react(
+    <div>
+      <h2>LDO Regulators</h2>
+
+      <form method="GET" className="flex flex-row gap-4">
+        <div>
+          <label>Package:</label>
+          <select name="package">
+            <option value="">All</option>
+            {packages.map((p) => (
+              <option
+                key={p.package}
+                value={p.package ?? ""}
+                selected={p.package === req.query.package}
+              >
+                {p.package}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label>Output Type:</label>
+          <select name="output_type">
+            <option value="">All</option>
+            <option value="fixed" selected={req.query.output_type === "fixed"}>
+              Fixed
+            </option>
+            <option
+              value="adjustable"
+              selected={req.query.output_type === "adjustable"}
+            >
+              Adjustable
+            </option>
+          </select>
+        </div>
+
+        <div>
+          <label>Output Voltage:</label>
+          <input
+            type="number"
+            name="output_voltage"
+            step="0.1"
+            placeholder="V"
+            defaultValue={req.query.output_voltage}
+          />
+        </div>
+
+        <button type="submit">Filter</button>
+      </form>
+
+      <Table
+        rows={regulators.map((r) => ({
+          lcsc: r.lcsc,
+          mfr: r.mfr,
+          package: r.package,
+          type: [
+            r.output_type === "fixed" ? "Fixed" : "Adjustable",
+            r.is_positive ? "Positive" : "Negative",
+          ]
+            .filter(Boolean)
+            .join(", "),
+          output:
+            r.output_voltage_min === r.output_voltage_max ? (
+              <span className="tabular-nums">{r.output_voltage_min}V</span>
+            ) : (
+              <span className="tabular-nums">
+                {r.output_voltage_min}V - {r.output_voltage_max}V
+              </span>
+            ),
+          current: r.output_current_max ? (
+            <span className="tabular-nums">{r.output_current_max}A</span>
+          ) : (
+            ""
+          ),
+          dropout: r.dropout_voltage ? (
+            <span className="tabular-nums">{r.dropout_voltage}V</span>
+          ) : (
+            ""
+          ),
+          input:
+            r.input_voltage_min && r.input_voltage_max ? (
+              <span className="tabular-nums">
+                {r.input_voltage_min}V - {r.input_voltage_max}V
+              </span>
+            ) : (
+              ""
+            ),
+          quiescent: r.quiescent_current ? (
+            <span className="tabular-nums">{r.quiescent_current}A</span>
+          ) : (
+            ""
+          ),
+          stock: <span className="tabular-nums">{r.stock}</span>,
+          price: <span className="tabular-nums">{formatPrice(r.price1)}</span>,
+        }))}
+      />
+    </div>,
+    "JLCPCB LDO Regulator Search",
+  )
+})

--- a/scripts/setup-derived-tables.ts
+++ b/scripts/setup-derived-tables.ts
@@ -13,6 +13,7 @@ import { wifiModuleTableSpec } from "lib/db/derivedtables/wifi_module"
 import { microcontrollerTableSpec } from "lib/db/derivedtables/microcontroller"
 import { voltageRegulatorTableSpec } from "lib/db/derivedtables/voltage_regulator"
 import { ledDriverTableSpec } from "lib/db/derivedtables/led_driver"
+import { ldoTableSpec } from "lib/db/derivedtables/ldo"
 import type { DerivedTableSpec } from "lib/db/derivedtables/types"
 import type { KyselyDatabaseInstance } from "lib/db/kysely-types"
 import { mosfetTableSpec } from "lib/db/derivedtables/mosfet"
@@ -51,6 +52,7 @@ const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   wifiModuleTableSpec,
   microcontrollerTableSpec,
   voltageRegulatorTableSpec,
+  ldoTableSpec,
   ledDriverTableSpec,
   boostConverterTableSpec,
   buckBoostConverterTableSpec,

--- a/tests/routes/ldos/list.test.ts
+++ b/tests/routes/ldos/list.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("GET /ldos/list with json param returns ldo data", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/ldos/list?json=true")
+  expect(res.data).toHaveProperty("ldos")
+  expect(Array.isArray(res.data.ldos)).toBe(true)
+  if (res.data.ldos.length > 0) {
+    const ldo = res.data.ldos[0]
+    expect(ldo).toHaveProperty("lcsc")
+    expect(ldo).toHaveProperty("mfr")
+    expect(ldo).toHaveProperty("package")
+    expect(ldo).toHaveProperty("output_type")
+    expect(ldo).toHaveProperty("is_positive")
+    expect(typeof ldo.lcsc).toBe("number")
+    expect(typeof ldo.is_positive).toBe("boolean")
+  }
+})


### PR DESCRIPTION
## Summary
- add LDO derived table and include it in setup process
- expose LDO regulator list page and API
- link LDO search from home page and test API response

## Testing
- `bun run scripts/setup-derived-tables.ts --reset ldo`
- `bun run generate:db-types`
- `bun test tests/routes/ldos/list.test.ts tests/routes/voltage_regulators/list.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_6890cc99882c832eb2c559d6cddeb53d