### PR TITLE
Add reflective optical interrupters page

### DIFF
--- a/docs/generated/component-overview.md
+++ b/docs/generated/component-overview.md
@@ -27,6 +27,7 @@ This document provides examples of components available in each category.
 - [Relays](./relays.md)
 - [Pushbutton Switches & Relays](./pushbutton_switches__relays.md)
 - [Sensors](./sensors.md)
+- [Reflective Optical Interrupters](./reflective_optical_interrupters.md)
 - [Amplifiers](./amplifiers.md)
 - [Clock and Timing](./clock_and_timing.md)
 - [Interface ICs](./interface_ics.md)

--- a/docs/generated/reflective_optical_interrupters.md
+++ b/docs/generated/reflective_optical_interrupters.md
@@ -1,0 +1,14 @@
+# Reflective Optical Interrupters
+
+| Key | Ex1 | Ex2 |
+| --- | --- | --- |
+| lcsc | 81632 | 475373 |
+| stock | 74754 | 15870 |
+| mfr | ITR8307/S17/TR8(B) | ITR1204SR10A/TR(BY) |
+| package | SMD-4P | SMD |
+| joints | 4 | 4 |
+| description | SMD-4P Reflective Optical Interrupters ROHS | SMD Reflective Optical Interrupters ROHS |
+| min_q_price | 0.080434783 | 0.088695652 |
+| extra_title | Everlight Elec ITR8307/S17/TR8(B) | Everlight Elec ITR1204SR10A/TR(BY) |
+| extra.number | C81632 | C475373 |
+| extra.package | SMD-4P | SMD |

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -29,6 +29,9 @@ export default withWinterSpec({
         <a href="/gyroscopes/list">Gyroscopes</a>
         <a href="/accelerometers/list">Accelerometers</a>
         <a href="/gas_sensors/list">Gas Sensors</a>
+        <a href="/reflective_optical_interrupters/list">
+          Reflective Optical Interrupters
+        </a>
         <a href="/diodes/list">Diodes</a>
         <a href="/dacs/list">DACs</a>
         <a href="/wifi_modules/list">WiFi Modules</a>

--- a/routes/reflective_optical_interrupters/list.json.tsx
+++ b/routes/reflective_optical_interrupters/list.json.tsx
@@ -1,0 +1,2 @@
+import list from "./list"
+export default list

--- a/routes/reflective_optical_interrupters/list.tsx
+++ b/routes/reflective_optical_interrupters/list.tsx
@@ -1,0 +1,142 @@
+import { Table } from "lib/ui/Table"
+import { withWinterSpec } from "lib/with-winter-spec"
+import { z } from "zod"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { formatSiUnit } from "lib/util/format-si-unit"
+import { formatPrice } from "lib/util/format-price"
+import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET", "POST"],
+  commonParams: z.object({
+    json: z.boolean().optional(),
+    package: z.string().optional(),
+  }),
+  jsonResponse: z.string().or(
+    z.object({
+      reflective_optical_interrupters: z.array(
+        z.object({
+          lcsc: z.number().int(),
+          mfr: z.string(),
+          package: z.string(),
+          sensing_distance_mm: z.number().optional(),
+          collector_current_ma: z.number().optional(),
+          stock: z.number().optional(),
+          price1: z.number().optional(),
+        }),
+      ),
+    }),
+  ),
+} as const)(async (req, ctx) => {
+  const params = req.commonParams
+
+  let query = ctx.db
+    .selectFrom("components")
+    .innerJoin("categories", "components.category_id", "categories.id")
+    .select([
+      "components.lcsc as lcsc",
+      "components.mfr as mfr",
+      "components.package as package",
+      "components.description as description",
+      "components.stock as stock",
+      "components.price as price",
+      "components.extra as extra",
+    ])
+    .where("categories.subcategory", "=", "Reflective Optical Interrupters")
+    .limit(100)
+    .orderBy("components.stock", "desc")
+
+  if (params.package) {
+    query = query.where("components.package", "=", params.package)
+  }
+
+  const packages = await ctx.db
+    .selectFrom("components")
+    .innerJoin("categories", "components.category_id", "categories.id")
+    .select("components.package")
+    .where("categories.subcategory", "=", "Reflective Optical Interrupters")
+    .distinct()
+    .where("components.package", "is not", null)
+    .orderBy("components.package")
+    .execute()
+
+  const rows = await query.execute()
+
+  const mapped = rows
+    .map((r) => {
+      let sensing: number | undefined
+      let collector: number | undefined
+      if (r.extra) {
+        try {
+          const extra = JSON.parse(r.extra as string)
+          const attrs = extra.attributes || {}
+          if (attrs["Sensing Distance"]) {
+            const val = parseAndConvertSiUnit(attrs["Sensing Distance"]).value
+            if (!Number.isNaN(val)) sensing = val
+          }
+          if (attrs["Collector Current (Max)"]) {
+            const val =
+              parseAndConvertSiUnit(attrs["Collector Current (Max)"]).value *
+              1000
+            if (!Number.isNaN(val)) collector = val
+          }
+        } catch {}
+      }
+      return {
+        lcsc: r.lcsc ?? 0,
+        mfr: r.mfr ?? "",
+        package: r.package ?? "",
+        sensing_distance_mm: sensing,
+        collector_current_ma: collector,
+        stock: r.stock ?? undefined,
+        price1: r.price ? (extractMinQPrice(r.price) ?? undefined) : undefined,
+      }
+    })
+    .filter((r) => r.lcsc !== 0 && r.package !== "")
+
+  if (ctx.isApiRequest) {
+    return ctx.json({
+      reflective_optical_interrupters: mapped,
+    })
+  }
+
+  return ctx.react(
+    <div>
+      <h2>Reflective Optical Interrupters</h2>
+      <form method="GET" className="flex flex-row gap-4">
+        <div>
+          <label>Package:</label>
+          <select name="package">
+            <option value="">All</option>
+            {packages.map((p) => (
+              <option
+                key={p.package}
+                value={p.package ?? ""}
+                selected={p.package === params.package}
+              >
+                {p.package}
+              </option>
+            ))}
+          </select>
+        </div>
+        <button type="submit">Filter</button>
+      </form>
+      <Table
+        rows={mapped.map((c) => ({
+          lcsc: c.lcsc,
+          mfr: c.mfr,
+          package: c.package,
+          sensing_distance: c.sensing_distance_mm
+            ? `${formatSiUnit(c.sensing_distance_mm)}mm`
+            : "",
+          collector_current: c.collector_current_ma
+            ? `${formatSiUnit(c.collector_current_ma)}A`
+            : "",
+          stock: <span className="tabular-nums">{c.stock}</span>,
+          price: <span className="tabular-nums">{formatPrice(c.price1)}</span>,
+        }))}
+      />
+    </div>,
+  )
+})

--- a/tests/routes/reflective_optical_interrupters/list.test.ts
+++ b/tests/routes/reflective_optical_interrupters/list.test.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("GET /reflective_optical_interrupters/list returns data", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/reflective_optical_interrupters/list?json=true")
+  expect(res.data).toHaveProperty("reflective_optical_interrupters")
+  expect(Array.isArray(res.data.reflective_optical_interrupters)).toBe(true)
+  if (res.data.reflective_optical_interrupters.length > 0) {
+    const item = res.data.reflective_optical_interrupters[0]
+    expect(item).toHaveProperty("lcsc")
+    expect(item).toHaveProperty("mfr")
+    expect(item).toHaveProperty("package")
+  }
+})
+
+test("GET /reflective_optical_interrupters/list with package filter works", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get(
+    "/reflective_optical_interrupters/list?json=true&package=SMD-4P",
+  )
+  for (const item of res.data.reflective_optical_interrupters) {
+    expect(item.package).toBe("SMD-4P")
+  }
+})


### PR DESCRIPTION
## Summary
- add route and API for reflective optical interrupters with package filter
- document reflective optical interrupters and link from overview and index
- cover new route with tests

## Testing
- `bun test tests/routes/reflective_optical_interrupters/list.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_689f55eb29f4832ebf847a000db1015e