### PR TITLE
feat: add FPC connectors category

### DIFF
--- a/docs/generated/fpc_connectors.md
+++ b/docs/generated/fpc_connectors.md
@@ -1,0 +1,16 @@
+# FPC Connectors
+
+This page lists example FFC/FPC connectors available from JLCPCB.
+
+| Key | Ex1 | Ex2 |
+| --- | --- | --- |
+| lcsc | 9160 | 11047 |
+| pitch_mm | 0.5 | 0.5 |
+| contacts | 40 | 4 |
+| contact_type | Bottom Contact | Bottom Contact |
+| locking_feature | Clamshell | Slide Lock |
+| description | Clamshell -25℃~+85℃ 40P Bottom Contact Surface Mount 0.5mm SMD,P=0.5mm FFC/FPC Connectors ROHS | Slide Lock 4P Bottom Contact Surface Mount 0.5mm SMD,P=0.5mm FFC/FPC Connectors ROHS |
+| stock | 5700 | 11039 |
+| mfr | 0.5-40PFGPZ | AFC07-S04FCC-00 |
+| price1 | 0.1851 | 0.0862 |
+

--- a/lib/db/derivedtables/fpc_connector.ts
+++ b/lib/db/derivedtables/fpc_connector.ts
@@ -1,0 +1,65 @@
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import type { DerivedTableSpec } from "./types"
+import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import { BaseComponent } from "./component-base"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+
+export interface FpcConnector extends BaseComponent {
+  pitch_mm: number | null
+  number_of_contacts: number | null
+  contact_type: string | null
+  locking_feature: string | null
+}
+
+export const fpcConnectorTableSpec: DerivedTableSpec<FpcConnector> = {
+  tableName: "fpc_connector",
+  extraColumns: [
+    { name: "pitch_mm", type: "real" },
+    { name: "number_of_contacts", type: "integer" },
+    { name: "contact_type", type: "text" },
+    { name: "locking_feature", type: "text" },
+  ],
+  listCandidateComponents(db: KyselyDatabaseInstance) {
+    return db
+      .selectFrom("components")
+      .innerJoin("categories", "components.category_id", "categories.id")
+      .selectAll()
+      .where("categories.subcategory", "in", [
+        "FFC/FPC Connectors",
+        "FFC, FPC Connectors",
+      ])
+  },
+  mapToTable(components) {
+    return components.map((c) => {
+      try {
+        const extra = c.extra ? JSON.parse(c.extra) : {}
+        const attrs: Record<string, string> = extra.attributes || {}
+
+        const parseNum = (v: string | undefined): number | null => {
+          if (!v || v === "-") return null
+          return parseAndConvertSiUnit(v).value as number
+        }
+
+        const contacts = parseInt(
+          (attrs["Number of Contacts"] || "").replace(/[^0-9]/g, ""),
+        )
+
+        return {
+          lcsc: Number(c.lcsc),
+          mfr: String(c.mfr || ""),
+          description: String(c.description || ""),
+          stock: Number(c.stock || 0),
+          price1: extractMinQPrice(c.price),
+          in_stock: Boolean((c.stock || 0) > 0),
+          pitch_mm: parseNum(attrs["Pitch"]),
+          number_of_contacts: isNaN(contacts) ? null : contacts,
+          contact_type: attrs["Contact Type"] || null,
+          locking_feature: attrs["Locking Feature"] || null,
+          attributes: attrs,
+        }
+      } catch {
+        return null
+      }
+    })
+  },
+}

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -262,6 +262,20 @@ export interface Diode {
   stock: number | null;
 }
 
+export interface FpcConnector {
+  attributes: string | null;
+  contact_type: string | null;
+  description: string | null;
+  in_stock: number | null;
+  lcsc: Generated<number | null>;
+  locking_feature: string | null;
+  mfr: string | null;
+  number_of_contacts: number | null;
+  pitch_mm: number | null;
+  price1: number | null;
+  stock: number | null;
+}
+
 export interface Fuse {
   attributes: string | null;
   current_rating: number | null;
@@ -767,6 +781,7 @@ export interface DB {
   components_fts_idx: ComponentsFtsIdx;
   dac: Dac;
   diode: Diode;
+  fpc_connector: FpcConnector;
   fuse: Fuse;
   gas_sensor: GasSensor;
   gyroscope: Gyroscope;

--- a/routes/fpc_connectors/list.tsx
+++ b/routes/fpc_connectors/list.tsx
@@ -1,0 +1,142 @@
+import { Table } from "lib/ui/Table"
+import { withWinterSpec } from "lib/with-winter-spec"
+import { z } from "zod"
+import { formatPrice } from "lib/util/format-price"
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET", "POST"],
+  commonParams: z.object({
+    json: z.boolean().optional(),
+    pitch: z.string().optional(),
+    contact_type: z.string().optional(),
+  }),
+  jsonResponse: z.string().or(
+    z.object({
+      fpc_connectors: z.array(
+        z.object({
+          lcsc: z.number().int(),
+          mfr: z.string(),
+          pitch_mm: z.number().optional(),
+          number_of_contacts: z.number().optional(),
+          contact_type: z.string().optional(),
+          locking_feature: z.string().optional(),
+          stock: z.number().optional(),
+          price1: z.number().optional(),
+        }),
+      ),
+    }),
+  ),
+} as const)(async (req, ctx) => {
+  let query = ctx.db
+    .selectFrom("fpc_connector")
+    .selectAll()
+    .limit(100)
+    .orderBy("stock", "desc")
+
+  const params = req.commonParams
+
+  if (params.pitch) {
+    const p = Number(params.pitch)
+    if (!isNaN(p)) {
+      query = query.where("pitch_mm", "=", p)
+    }
+  }
+
+  if (params.contact_type) {
+    query = query.where("contact_type", "=", params.contact_type)
+  }
+
+  const pitches = await ctx.db
+    .selectFrom("fpc_connector")
+    .select("pitch_mm")
+    .distinct()
+    .where("pitch_mm", "is not", null)
+    .execute()
+
+  const contactTypes = await ctx.db
+    .selectFrom("fpc_connector")
+    .select("contact_type")
+    .distinct()
+    .where("contact_type", "is not", null)
+    .execute()
+
+  const connectors = await query.execute()
+
+  if (ctx.isApiRequest) {
+    return ctx.json({
+      fpc_connectors: connectors
+        .map((c) => ({
+          lcsc: c.lcsc ?? 0,
+          mfr: c.mfr ?? "",
+          pitch_mm: c.pitch_mm ?? undefined,
+          number_of_contacts: c.number_of_contacts ?? undefined,
+          contact_type: c.contact_type ?? undefined,
+          locking_feature: c.locking_feature ?? undefined,
+          stock: c.stock ?? undefined,
+          price1: c.price1 ?? undefined,
+        }))
+        .filter((c) => c.lcsc !== 0),
+    })
+  }
+
+  return ctx.react(
+    <div>
+      <h2>FPC Connectors</h2>
+
+      <form method="GET" className="flex flex-row gap-4">
+        <div>
+          <label>Pitch:</label>
+          <select name="pitch">
+            <option value="">All</option>
+            {pitches.map((p) => (
+              <option
+                key={p.pitch_mm}
+                value={p.pitch_mm ?? ""}
+                selected={String(p.pitch_mm) === params.pitch}
+              >
+                {p.pitch_mm}mm
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label>Contact Type:</label>
+          <select name="contact_type">
+            <option value="">All</option>
+            {contactTypes.map((t) => (
+              <option
+                key={t.contact_type}
+                value={t.contact_type ?? ""}
+                selected={t.contact_type === params.contact_type}
+              >
+                {t.contact_type}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <button type="submit">Filter</button>
+      </form>
+
+      <Table
+        rows={connectors.map((c) => ({
+          lcsc: c.lcsc,
+          mfr: c.mfr,
+          pitch: c.pitch_mm && (
+            <span className="tabular-nums">{c.pitch_mm}mm</span>
+          ),
+          contacts: (
+            <span className="tabular-nums">{c.number_of_contacts}</span>
+          ),
+          contact_type: c.contact_type,
+          locking: c.locking_feature,
+          stock: <span className="tabular-nums">{c.stock}</span>,
+          price: <span className="tabular-nums">{formatPrice(c.price1)}</span>,
+        }))}
+      />
+    </div>,
+    "JLCPCB FPC Connector Search",
+  )
+})

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -21,6 +21,7 @@ export default withWinterSpec({
         <a href="/headers/list">Headers</a>
         <a href="/usb_c_connectors/list">USB-C Connectors</a>
         <a href="/pcie_m2_connectors/list">PCIe M.2 Connectors</a>
+        <a href="/fpc_connectors/list">FPC Connectors</a>
         <a href="/leds/list">LEDs</a>
         <a href="/adcs/list">ADCs</a>
         <a href="/analog_multiplexers/list">Analog Muxes</a>

--- a/scripts/setup-derived-tables.ts
+++ b/scripts/setup-derived-tables.ts
@@ -34,6 +34,7 @@ import { buckBoostConverterTableSpec } from "lib/db/derivedtables/buck_boost_con
 import { relayTableSpec } from "lib/db/derivedtables/relay"
 import { usbCConnectorTableSpec } from "lib/db/derivedtables/usb_c_connector"
 import { pcieM2ConnectorTableSpec } from "lib/db/derivedtables/pcie_m2_connector"
+import { fpcConnectorTableSpec } from "lib/db/derivedtables/fpc_connector"
 
 const resetArg = process.argv.indexOf("--reset")
 const resetTable = resetArg !== -1 ? process.argv[resetArg + 1] : null
@@ -70,6 +71,7 @@ const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   bjtTransistorTableSpec,
   switchTableSpec,
   relayTableSpec,
+  fpcConnectorTableSpec,
   usbCConnectorTableSpec,
   pcieM2ConnectorTableSpec,
 ]

--- a/tests/routes/fpc_connectors/list.test.ts
+++ b/tests/routes/fpc_connectors/list.test.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("GET /fpc_connectors/list with json param returns data", async () => {
+  const { axios } = await getTestServer()
+
+  const res = await axios.get("/fpc_connectors/list?json=true")
+
+  expect(res.data).toHaveProperty("fpc_connectors")
+  expect(Array.isArray(res.data.fpc_connectors)).toBe(true)
+
+  if (res.data.fpc_connectors.length > 0) {
+    const c = res.data.fpc_connectors[0]
+    expect(c).toHaveProperty("lcsc")
+    expect(c).toHaveProperty("mfr")
+    expect(typeof c.lcsc).toBe("number")
+  }
+})
+
+test("GET /fpc_connectors/list with contact_type filter returns filtered data", async () => {
+  const { axios } = await getTestServer()
+
+  const res = await axios.get(
+    "/fpc_connectors/list?json=true&contact_type=Bottom%20Contact",
+  )
+
+  expect(res.data).toHaveProperty("fpc_connectors")
+  expect(Array.isArray(res.data.fpc_connectors)).toBe(true)
+
+  for (const c of res.data.fpc_connectors) {
+    if (c.contact_type) {
+      expect(c.contact_type).toBe("Bottom Contact")
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- add derived table for FPC connectors
- expose FPC connector list route with filtering
- document and test new FPC connector category

## Testing
- `bun run scripts/setup-derived-tables.ts --reset fpc_connector`
- `bun run generate:db-types`
- `bun run format`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68a6f9116ae08327ab59b17837df4c5f