### PR TITLE
feat: add screw terminal block connector category

### DIFF
--- a/lib/db/derivedtables/screw_terminal_block.ts
+++ b/lib/db/derivedtables/screw_terminal_block.ts
@@ -1,0 +1,76 @@
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import type { DerivedTableSpec } from "./types"
+import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import { BaseComponent } from "./component-base"
+
+export interface ScrewTerminalBlock extends BaseComponent {
+  pitch_mm: number | null
+  number_of_pins: number | null
+  current_rating_a: number | null
+  voltage_rating_v: number | null
+}
+
+export const screwTerminalBlockTableSpec: DerivedTableSpec<ScrewTerminalBlock> =
+  {
+    tableName: "screw_terminal_block",
+    extraColumns: [
+      { name: "pitch_mm", type: "real" },
+      { name: "number_of_pins", type: "integer" },
+      { name: "current_rating_a", type: "real" },
+      { name: "voltage_rating_v", type: "real" },
+    ],
+    listCandidateComponents: (db) =>
+      db
+        .selectFrom("components")
+        .innerJoin("categories", "components.category_id", "categories.id")
+        .selectAll()
+        .where("categories.subcategory", "=", "Screw Terminal Blocks"),
+    mapToTable(components) {
+      return components.map((c) => {
+        try {
+          const extra = c.extra ? JSON.parse(c.extra) : {}
+          const attrs: Record<string, string> = extra.attributes || {}
+
+          const parsePitch = (v: string | undefined): number | null => {
+            if (!v) return null
+            const match = v.match(/([0-9.]+)\s*mm/i)
+            return match ? parseFloat(match[1]) : null
+          }
+
+          const parseNum = (v: string | undefined): number | null => {
+            if (!v || v === "-") return null
+            return parseAndConvertSiUnit(v).value as number
+          }
+
+          const pitch = parsePitch(attrs["Pitch"])
+
+          const pinsStr =
+            attrs["Number of Pins"] ||
+            attrs["Number of PINs Per Row"] ||
+            attrs["Number of Positions or Pins"] ||
+            ""
+          const pins = parseInt(pinsStr.replace(/[^0-9]/g, ""))
+          const current = parseNum(
+            attrs["Current Rating (Max)"] || attrs["Rated Current"],
+          )
+          const voltage = parseNum(attrs["Voltage Rating (Max)"])
+
+          return {
+            lcsc: Number(c.lcsc),
+            mfr: String(c.mfr || ""),
+            description: String(c.description || ""),
+            stock: Number(c.stock || 0),
+            price1: extractMinQPrice(c.price),
+            in_stock: Boolean((c.stock || 0) > 0),
+            pitch_mm: pitch,
+            number_of_pins: isNaN(pins) ? null : pins,
+            current_rating_a: current,
+            voltage_rating_v: voltage,
+            attributes: attrs,
+          }
+        } catch {
+          return null
+        }
+      })
+    },
+  }

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -650,6 +650,20 @@ export interface Resistor {
   tolerance_fraction: number | null;
 }
 
+export interface ScrewTerminalBlock {
+  attributes: string | null;
+  current_rating_a: number | null;
+  description: string | null;
+  in_stock: number | null;
+  lcsc: Generated<number | null>;
+  mfr: string | null;
+  number_of_pins: number | null;
+  pitch_mm: number | null;
+  price1: number | null;
+  stock: number | null;
+  voltage_rating_v: number | null;
+}
+
 export interface Switch {
   attributes: string | null;
   circuit: string | null;
@@ -802,6 +816,7 @@ export interface DB {
   potentiometer: Potentiometer;
   relay: Relay;
   resistor: Resistor;
+  screw_terminal_block: ScrewTerminalBlock;
   switch: Switch;
   usb_c_connector: UsbCConnector;
   v_components: VComponent;

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -22,6 +22,7 @@ export default withWinterSpec({
         <a href="/usb_c_connectors/list">USB-C Connectors</a>
         <a href="/pcie_m2_connectors/list">PCIe M.2 Connectors</a>
         <a href="/fpc_connectors/list">FPC Connectors</a>
+        <a href="/screw_terminal_blocks/list">Screw Terminal Blocks</a>
         <a href="/leds/list">LEDs</a>
         <a href="/adcs/list">ADCs</a>
         <a href="/analog_multiplexers/list">Analog Muxes</a>

--- a/routes/screw_terminal_blocks/list.tsx
+++ b/routes/screw_terminal_blocks/list.tsx
@@ -1,0 +1,116 @@
+import { Table } from "lib/ui/Table"
+import { withWinterSpec } from "lib/with-winter-spec"
+import { z } from "zod"
+import { formatPrice } from "lib/util/format-price"
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET", "POST"],
+  commonParams: z.object({
+    json: z.boolean().optional(),
+    pitch: z.string().optional(),
+  }),
+  jsonResponse: z.string().or(
+    z.object({
+      screw_terminal_blocks: z.array(
+        z.object({
+          lcsc: z.number().int(),
+          mfr: z.string(),
+          pitch_mm: z.number().optional(),
+          number_of_pins: z.number().optional(),
+          current_rating_a: z.number().optional(),
+          voltage_rating_v: z.number().optional(),
+          stock: z.number().optional(),
+          price1: z.number().optional(),
+        }),
+      ),
+    }),
+  ),
+} as const)(async (req, ctx) => {
+  let query = ctx.db
+    .selectFrom("screw_terminal_block")
+    .selectAll()
+    .limit(100)
+    .orderBy("stock", "desc")
+
+  const params = req.commonParams
+
+  if (params.pitch) {
+    const p = Number(params.pitch)
+    if (!isNaN(p)) {
+      query = query.where("pitch_mm", "=", p)
+    }
+  }
+
+  const pitches = await ctx.db
+    .selectFrom("screw_terminal_block")
+    .select("pitch_mm")
+    .distinct()
+    .where("pitch_mm", "is not", null)
+    .execute()
+
+  const blocks = await query.execute()
+
+  if (ctx.isApiRequest) {
+    return ctx.json({
+      screw_terminal_blocks: blocks
+        .map((c) => ({
+          lcsc: c.lcsc ?? 0,
+          mfr: c.mfr ?? "",
+          pitch_mm: c.pitch_mm ?? undefined,
+          number_of_pins: c.number_of_pins ?? undefined,
+          current_rating_a: c.current_rating_a ?? undefined,
+          voltage_rating_v: c.voltage_rating_v ?? undefined,
+          stock: c.stock ?? undefined,
+          price1: c.price1 ?? undefined,
+        }))
+        .filter((c) => c.lcsc !== 0),
+    })
+  }
+
+  return ctx.react(
+    <div>
+      <h2>Screw Terminal Blocks</h2>
+
+      <form method="GET" className="flex flex-row gap-4">
+        <div>
+          <label>Pitch:</label>
+          <select name="pitch">
+            <option value="">All</option>
+            {pitches.map((p) => (
+              <option
+                key={p.pitch_mm}
+                value={p.pitch_mm ?? ""}
+                selected={String(p.pitch_mm) === params.pitch}
+              >
+                {p.pitch_mm}mm
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <button type="submit">Filter</button>
+      </form>
+
+      <Table
+        rows={blocks.map((c) => ({
+          lcsc: c.lcsc,
+          mfr: c.mfr,
+          pitch: c.pitch_mm && (
+            <span className="tabular-nums">{c.pitch_mm}mm</span>
+          ),
+          pins: <span className="tabular-nums">{c.number_of_pins}</span>,
+          current: c.current_rating_a && (
+            <span className="tabular-nums">{c.current_rating_a}A</span>
+          ),
+          voltage: c.voltage_rating_v && (
+            <span className="tabular-nums">{c.voltage_rating_v}V</span>
+          ),
+          stock: <span className="tabular-nums">{c.stock}</span>,
+          price: <span className="tabular-nums">{formatPrice(c.price1)}</span>,
+        }))}
+      />
+    </div>,
+    "JLCPCB Screw Terminal Block Search",
+  )
+})

--- a/scripts/setup-derived-tables.ts
+++ b/scripts/setup-derived-tables.ts
@@ -35,6 +35,7 @@ import { relayTableSpec } from "lib/db/derivedtables/relay"
 import { usbCConnectorTableSpec } from "lib/db/derivedtables/usb_c_connector"
 import { pcieM2ConnectorTableSpec } from "lib/db/derivedtables/pcie_m2_connector"
 import { fpcConnectorTableSpec } from "lib/db/derivedtables/fpc_connector"
+import { screwTerminalBlockTableSpec } from "lib/db/derivedtables/screw_terminal_block"
 
 const resetArg = process.argv.indexOf("--reset")
 const resetTable = resetArg !== -1 ? process.argv[resetArg + 1] : null
@@ -74,6 +75,7 @@ const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   fpcConnectorTableSpec,
   usbCConnectorTableSpec,
   pcieM2ConnectorTableSpec,
+  screwTerminalBlockTableSpec,
 ]
 
 function jsonParseOrNull(strObject: string) {

--- a/tests/routes/screw_terminal_blocks/list.test.ts
+++ b/tests/routes/screw_terminal_blocks/list.test.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("GET /screw_terminal_blocks/list with json param returns data", async () => {
+  const { axios } = await getTestServer()
+
+  const res = await axios.get("/screw_terminal_blocks/list?json=true")
+
+  expect(res.data).toHaveProperty("screw_terminal_blocks")
+  expect(Array.isArray(res.data.screw_terminal_blocks)).toBe(true)
+
+  if (res.data.screw_terminal_blocks.length > 0) {
+    const c = res.data.screw_terminal_blocks[0]
+    expect(c).toHaveProperty("lcsc")
+    expect(c).toHaveProperty("mfr")
+    expect(typeof c.lcsc).toBe("number")
+  }
+})


### PR DESCRIPTION
## Summary
- add screw terminal block derived table and list route
- link screw terminal blocks in index and setup scripts
- include screw terminal block types and tests

## Testing
- `bun run format`
- `bun test` *(fails: no such table: screw_terminal_block and other missing derived tables)*

------
https://chatgpt.com/codex/tasks/task_b_68ac4d83d76483278d7137417ed458a3