### PR TITLE
Feat: Add KiCad Footprint and JLC Part Number to Components

### DIFF
--- a/lib/db/derivedtables/accelerometer.ts
+++ b/lib/db/derivedtables/accelerometer.ts
@@ -17,6 +17,8 @@ export interface Accelerometer extends BaseComponent {
 export const accelerometerTableSpec: DerivedTableSpec<Accelerometer> = {
   tableName: "accelerometer",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "supply_voltage_min", type: "real" },
     { name: "supply_voltage_max", type: "real" },
@@ -99,6 +101,8 @@ export const accelerometerTableSpec: DerivedTableSpec<Accelerometer> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         package: c.package || "",
+        kicad_footprint: c.kicad_footprint,
+        jlc_part_number: c.jlc_part_number,
         supply_voltage_min: voltageMin,
         supply_voltage_max: voltageMax,
         operating_temp_min: tempMin,

--- a/lib/db/derivedtables/adc.ts
+++ b/lib/db/derivedtables/adc.ts
@@ -24,6 +24,8 @@ export interface Adc extends BaseComponent {
 export const adcTableSpec: DerivedTableSpec<Adc> = {
   tableName: "adc",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "resolution_bits", type: "integer" },
     { name: "sampling_rate_hz", type: "real" },
@@ -112,6 +114,8 @@ export const adcTableSpec: DerivedTableSpec<Adc> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         package: c.package || "",
+        kicad_footprint: c.kicad_footprint,
+        jlc_part_number: c.jlc_part_number,
         resolution_bits: resolution,
         sampling_rate_hz: samplingRate,
         num_channels: numChannels,

--- a/lib/db/derivedtables/analog_multiplexer.ts
+++ b/lib/db/derivedtables/analog_multiplexer.ts
@@ -24,6 +24,8 @@ export interface AnalogMultiplexer extends BaseComponent {
 export const analogMultiplexerTableSpec: DerivedTableSpec<AnalogMultiplexer> = {
   tableName: "analog_multiplexer",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "num_channels", type: "integer" },
     { name: "num_bits", type: "integer" },
@@ -141,6 +143,8 @@ export const analogMultiplexerTableSpec: DerivedTableSpec<AnalogMultiplexer> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         package: c.package || "",
+        kicad_footprint: c.kicad_footprint,
+        jlc_part_number: c.jlc_part_number,
         num_channels: numChannels,
         num_bits: numBits,
         on_resistance_ohms: onResistance,

--- a/lib/db/derivedtables/bjt_transistor.ts
+++ b/lib/db/derivedtables/bjt_transistor.ts
@@ -17,6 +17,8 @@ export interface BJTTransistor extends BaseComponent {
 export const bjtTransistorTableSpec: DerivedTableSpec<BJTTransistor> = {
   tableName: "bjt_transistor",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "current_gain", type: "integer" },
     { name: "collector_current", type: "integer" },
@@ -71,6 +73,8 @@ export const bjtTransistorTableSpec: DerivedTableSpec<BJTTransistor> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           package: c.package || "",
+          kicad_footprint: c.kicad_footprint,
+          jlc_part_number: c.jlc_part_number,
           current_gain: current_gain,
           collector_current: collector_current,
           collector_emitter_voltage: collector_emitter_voltage,

--- a/lib/db/derivedtables/boost_converter.ts
+++ b/lib/db/derivedtables/boost_converter.ts
@@ -19,6 +19,8 @@ export interface BoostConverter extends BaseComponent {
 export const boostConverterTableSpec: DerivedTableSpec<BoostConverter> = {
   tableName: "boost_converter",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "input_voltage_min", type: "real" },
     { name: "input_voltage_max", type: "real" },
@@ -114,6 +116,8 @@ export const boostConverterTableSpec: DerivedTableSpec<BoostConverter> = {
           price1: extractMinQPrice(c.price),
           in_stock: c.stock > 0,
           package: c.package || "",
+          kicad_footprint: c.kicad_footprint,
+          jlc_part_number: c.jlc_part_number,
           input_voltage_min: inputMin,
           input_voltage_max: inputMax,
           output_voltage_min: outputMin,

--- a/lib/db/derivedtables/buck_boost_converter.ts
+++ b/lib/db/derivedtables/buck_boost_converter.ts
@@ -20,6 +20,8 @@ export const buckBoostConverterTableSpec: DerivedTableSpec<BuckBoostConverter> =
   {
     tableName: "buck_boost_converter",
     extraColumns: [
+      { name: "kicad_footprint", type: "text" },
+      { name: "jlc_part_number", type: "text" },
       { name: "package", type: "text" },
       { name: "input_voltage_min", type: "real" },
       { name: "input_voltage_max", type: "real" },
@@ -118,6 +120,8 @@ export const buckBoostConverterTableSpec: DerivedTableSpec<BuckBoostConverter> =
             price1: extractMinQPrice(c.price),
             in_stock: c.stock > 0,
             package: c.package || "",
+            kicad_footprint: c.kicad_footprint,
+            jlc_part_number: c.jlc_part_number,
             input_voltage_min: inputMin,
             input_voltage_max: inputMax,
             output_voltage_min: outputMin,

--- a/lib/db/derivedtables/capacitor.ts
+++ b/lib/db/derivedtables/capacitor.ts
@@ -21,6 +21,8 @@ export interface Capacitor extends BaseComponent {
 export const capacitorTableSpec: DerivedTableSpec<Capacitor> = {
   tableName: "capacitor",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "capacitance_farads", type: "real" },
     { name: "tolerance_fraction", type: "real" },
     { name: "voltage_rating", type: "real" },
@@ -111,6 +113,8 @@ export const capacitorTableSpec: DerivedTableSpec<Capacitor> = {
         stock: c.stock,
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
+        kicad_footprint: c.kicad_footprint,
+        jlc_part_number: c.jlc_part_number,
         capacitance_farads: capacitance,
         tolerance_fraction: tolerance,
         voltage_rating: voltage,

--- a/lib/db/derivedtables/component-base.ts
+++ b/lib/db/derivedtables/component-base.ts
@@ -6,4 +6,6 @@ export interface BaseComponent {
   price1: number | null
   in_stock: boolean
   attributes: Record<string, string>
+  kicad_footprint: string | null
+  jlc_part_number: string | null
 }

--- a/lib/db/derivedtables/dac.ts
+++ b/lib/db/derivedtables/dac.ts
@@ -23,6 +23,8 @@ export interface Dac extends BaseComponent {
 export const dacTableSpec: DerivedTableSpec<Dac> = {
   tableName: "dac",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "resolution_bits", type: "integer" },
     { name: "num_channels", type: "integer" },
@@ -126,6 +128,8 @@ export const dacTableSpec: DerivedTableSpec<Dac> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         package: c.package || "",
+        kicad_footprint: c.kicad_footprint,
+        jlc_part_number: c.jlc_part_number,
         resolution_bits: resolution,
         num_channels: numChannels,
         settling_time_us: settlingTime,

--- a/lib/db/derivedtables/diode.ts
+++ b/lib/db/derivedtables/diode.ts
@@ -24,6 +24,8 @@ export interface Diode extends BaseComponent {
 export const diodeTableSpec: DerivedTableSpec<Diode> = {
   tableName: "diode",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "forward_voltage", type: "real" },
     { name: "reverse_voltage", type: "real" },
@@ -156,6 +158,8 @@ export const diodeTableSpec: DerivedTableSpec<Diode> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         package: c.package || "",
+        kicad_footprint: c.kicad_footprint,
+        jlc_part_number: c.jlc_part_number,
         forward_voltage: forwardVoltage,
         reverse_voltage: reverseVoltage,
         forward_current: forwardCurrent,

--- a/lib/db/derivedtables/fpc_connector.ts
+++ b/lib/db/derivedtables/fpc_connector.ts
@@ -14,6 +14,8 @@ export interface FpcConnector extends BaseComponent {
 export const fpcConnectorTableSpec: DerivedTableSpec<FpcConnector> = {
   tableName: "fpc_connector",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "pitch_mm", type: "real" },
     { name: "number_of_contacts", type: "integer" },
     { name: "contact_type", type: "text" },
@@ -51,6 +53,8 @@ export const fpcConnectorTableSpec: DerivedTableSpec<FpcConnector> = {
           stock: Number(c.stock || 0),
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
+          kicad_footprint: c.kicad_footprint,
+          jlc_part_number: c.jlc_part_number,
           pitch_mm: parseNum(attrs["Pitch"]),
           number_of_contacts: isNaN(contacts) ? null : contacts,
           contact_type: attrs["Contact Type"] || null,

--- a/lib/db/derivedtables/fuse.ts
+++ b/lib/db/derivedtables/fuse.ts
@@ -16,6 +16,8 @@ export interface Fuse extends BaseComponent {
 export const fuseTableSpec: DerivedTableSpec<Fuse> = {
   tableName: "fuse",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "current_rating", type: "real" },
     { name: "voltage_rating", type: "real" },
     { name: "response_time", type: "text" },
@@ -86,6 +88,8 @@ export const fuseTableSpec: DerivedTableSpec<Fuse> = {
           stock: Number(c.stock || 0),
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
+          kicad_footprint: c.kicad_footprint,
+          jlc_part_number: c.jlc_part_number,
           current_rating: current_rating as number,
           voltage_rating: voltage_rating as number,
           response_time,

--- a/lib/db/derivedtables/gas_sensor.ts
+++ b/lib/db/derivedtables/gas_sensor.ts
@@ -21,6 +21,8 @@ export interface GasSensor extends BaseComponent {
 export const gasSensorTableSpec: DerivedTableSpec<GasSensor> = {
   tableName: "gas_sensor",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "sensor_type", type: "text" },
     { name: "measures_air_quality", type: "boolean" },
@@ -79,6 +81,8 @@ export const gasSensorTableSpec: DerivedTableSpec<GasSensor> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         package: c.package || "",
+        kicad_footprint: c.kicad_footprint,
+        jlc_part_number: c.jlc_part_number,
         sensor_type: sensorType,
         measures_air_quality: measuresAirQuality,
         measures_co2: measuresCo2,

--- a/lib/db/derivedtables/gyroscope.ts
+++ b/lib/db/derivedtables/gyroscope.ts
@@ -17,6 +17,8 @@ export interface Gyroscope extends BaseComponent {
 export const gyroscopeTableSpec: DerivedTableSpec<Gyroscope> = {
   tableName: "gyroscope",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "supply_voltage_min", type: "real" },
     { name: "supply_voltage_max", type: "real" },
@@ -103,6 +105,8 @@ export const gyroscopeTableSpec: DerivedTableSpec<Gyroscope> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         package: c.package || "",
+        kicad_footprint: c.kicad_footprint,
+        jlc_part_number: c.jlc_part_number,
         supply_voltage_min: voltageMin,
         supply_voltage_max: voltageMax,
         operating_temp_min: tempMin,

--- a/lib/db/derivedtables/header.ts
+++ b/lib/db/derivedtables/header.ts
@@ -28,6 +28,8 @@ export interface Header extends BaseComponent {
 export const headerTableSpec: DerivedTableSpec<Header> = {
   tableName: "header",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "pitch_mm", type: "real" },
     { name: "num_rows", type: "integer" },
@@ -195,6 +197,8 @@ export const headerTableSpec: DerivedTableSpec<Header> = {
         in_stock: c.stock > 0,
         price1: extractMinQPrice(c.price)!,
         package: c.package || "",
+        kicad_footprint: c.kicad_footprint,
+        jlc_part_number: c.jlc_part_number,
         pitch_mm: pitch,
         num_rows: numRows,
         num_pins: numPins || 0,

--- a/lib/db/derivedtables/io_expander.ts
+++ b/lib/db/derivedtables/io_expander.ts
@@ -24,6 +24,8 @@ export interface IoExpander extends BaseComponent {
 export const ioExpanderTableSpec: DerivedTableSpec<IoExpander> = {
   tableName: "io_expander",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "num_gpios", type: "integer" },
     { name: "supply_voltage_min", type: "real" },
@@ -136,6 +138,8 @@ export const ioExpanderTableSpec: DerivedTableSpec<IoExpander> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         package: c.package || "",
+        kicad_footprint: c.kicad_footprint,
+        jlc_part_number: c.jlc_part_number,
         num_gpios: numGpios,
         supply_voltage_min: voltageMin,
         supply_voltage_max: voltageMax,

--- a/lib/db/derivedtables/jst_connector.ts
+++ b/lib/db/derivedtables/jst_connector.ts
@@ -15,6 +15,8 @@ export interface JstConnector extends BaseComponent {
 export const jstConnectorTableSpec: DerivedTableSpec<JstConnector> = {
   tableName: "jst_connector",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "pitch_mm", type: "real" },
     { name: "num_rows", type: "integer" },
@@ -66,6 +68,8 @@ export const jstConnectorTableSpec: DerivedTableSpec<JstConnector> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           package: String(c.package || ""),
+          kicad_footprint: c.kicad_footprint,
+          jlc_part_number: c.jlc_part_number,
           pitch_mm: parseNum(attrs["Pitch"]),
           num_rows: isNaN(numRows) ? null : numRows,
           num_pins: isNaN(numPins) ? null : numPins,

--- a/lib/db/derivedtables/lcd_display.ts
+++ b/lib/db/derivedtables/lcd_display.ts
@@ -13,6 +13,8 @@ export interface LCDDisplay extends BaseComponent {
 export const lcdDisplayTableSpec: DerivedTableSpec<LCDDisplay> = {
   tableName: "lcd_display",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "display_size", type: "text" },
     { name: "resolution", type: "text" },
@@ -61,6 +63,8 @@ export const lcdDisplayTableSpec: DerivedTableSpec<LCDDisplay> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           package: String(c.package || ""),
+          kicad_footprint: c.kicad_footprint,
+          jlc_part_number: c.jlc_part_number,
           display_size,
           resolution,
           display_type,

--- a/lib/db/derivedtables/led.ts
+++ b/lib/db/derivedtables/led.ts
@@ -22,6 +22,8 @@ export interface Led extends BaseComponent {
 export const ledTableSpec: DerivedTableSpec<Led> = {
   tableName: "led",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "forward_voltage", type: "real" },
     { name: "forward_current", type: "real" },
@@ -162,6 +164,8 @@ export const ledTableSpec: DerivedTableSpec<Led> = {
         stock: c.stock,
         in_stock: c.stock > 0,
         package: c.package || "",
+        kicad_footprint: c.kicad_footprint,
+        jlc_part_number: c.jlc_part_number,
         forward_voltage: forwardVoltage,
         forward_current: forwardCurrent,
         color: color,

--- a/lib/db/derivedtables/led_dot_matrix_display.ts
+++ b/lib/db/derivedtables/led_dot_matrix_display.ts
@@ -13,6 +13,8 @@ export const ledDotMatrixDisplayTableSpec: DerivedTableSpec<LEDDotMatrixDisplay>
   {
     tableName: "led_dot_matrix_display",
     extraColumns: [
+      { name: "kicad_footprint", type: "text" },
+      { name: "jlc_part_number", type: "text" },
       { name: "package", type: "text" },
       { name: "matrix_size", type: "text" },
       { name: "color", type: "text" },
@@ -54,6 +56,8 @@ export const ledDotMatrixDisplayTableSpec: DerivedTableSpec<LEDDotMatrixDisplay>
             price1: extractMinQPrice(c.price),
             in_stock: Boolean((c.stock || 0) > 0),
             package: String(c.package || ""),
+            kicad_footprint: c.kicad_footprint,
+            jlc_part_number: c.jlc_part_number,
             matrix_size,
             color,
             attributes: attrs,

--- a/lib/db/derivedtables/led_driver.ts
+++ b/lib/db/derivedtables/led_driver.ts
@@ -29,6 +29,8 @@ export interface LedDriver extends BaseComponent {
 export const ledDriverTableSpec: DerivedTableSpec<LedDriver> = {
   tableName: "led_driver",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "supply_voltage_min", type: "real" },
     { name: "supply_voltage_max", type: "real" },
@@ -74,6 +76,8 @@ export const ledDriverTableSpec: DerivedTableSpec<LedDriver> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           package: String(c.package || ""),
+          kicad_footprint: c.kicad_footprint,
+          jlc_part_number: c.jlc_part_number,
           supply_voltage_min: parseValue(attrs["Input Voltage"]?.split("~")[0]),
           supply_voltage_max: parseValue(attrs["Input Voltage"]?.split("~")[1]),
           output_current_max: parseValue(attrs["Output Current"]),

--- a/lib/db/derivedtables/led_segment_display.ts
+++ b/lib/db/derivedtables/led_segment_display.ts
@@ -14,6 +14,8 @@ export interface LEDSegmentDisplay extends BaseComponent {
 export const ledSegmentDisplayTableSpec: DerivedTableSpec<LEDSegmentDisplay> = {
   tableName: "led_segment_display",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "positions", type: "text" },
     { name: "type", type: "text" },
@@ -67,6 +69,8 @@ export const ledSegmentDisplayTableSpec: DerivedTableSpec<LEDSegmentDisplay> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           package: String(c.package || ""),
+          kicad_footprint: c.kicad_footprint,
+          jlc_part_number: c.jlc_part_number,
           positions,
           type,
           size,

--- a/lib/db/derivedtables/led_with_ic.ts
+++ b/lib/db/derivedtables/led_with_ic.ts
@@ -19,6 +19,8 @@ export interface LEDWithIC extends BaseComponent {
 export const ledWithICTableSpec: DerivedTableSpec<LEDWithIC> = {
   tableName: "led_with_ic",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "forward_voltage", type: "real" },
     { name: "forward_current", type: "real" },
@@ -96,6 +98,8 @@ export const ledWithICTableSpec: DerivedTableSpec<LEDWithIC> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           package: String(c.package || ""),
+          kicad_footprint: c.kicad_footprint,
+          jlc_part_number: c.jlc_part_number,
           forward_voltage: forwardVoltage,
           forward_current: forwardCurrent,
           color: color || undefined,

--- a/lib/db/derivedtables/microcontroller.ts
+++ b/lib/db/derivedtables/microcontroller.ts
@@ -35,6 +35,8 @@ export interface Microcontroller extends BaseComponent {
 export const microcontrollerTableSpec: DerivedTableSpec<Microcontroller> = {
   tableName: "microcontroller",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "cpu_core", type: "text" },
     { name: "cpu_speed_hz", type: "real" },
@@ -225,6 +227,8 @@ export const microcontrollerTableSpec: DerivedTableSpec<Microcontroller> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         package: c.package || "",
+        kicad_footprint: c.kicad_footprint,
+        jlc_part_number: c.jlc_part_number,
         cpu_core: cpuCore,
         cpu_speed_hz: cpuSpeed,
         flash_size_bytes: flashSize,

--- a/lib/db/derivedtables/mosfet.ts
+++ b/lib/db/derivedtables/mosfet.ts
@@ -25,6 +25,8 @@ export interface Mosfet extends BaseComponent {
 export const mosfetTableSpec: DerivedTableSpec<Mosfet> = {
   tableName: "mosfet",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "drain_source_voltage", type: "real" },
     { name: "continuous_drain_current", type: "real" },
@@ -65,6 +67,8 @@ export const mosfetTableSpec: DerivedTableSpec<Mosfet> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           package: String(c.package || ""),
+          kicad_footprint: c.kicad_footprint,
+          jlc_part_number: c.jlc_part_number,
           drain_source_voltage: parseValue(
             attrs["Drain Source Voltage (Vdss)"],
           ),

--- a/lib/db/derivedtables/oled_display.ts
+++ b/lib/db/derivedtables/oled_display.ts
@@ -13,6 +13,8 @@ export interface OLEDDisplay extends BaseComponent {
 export const oledDisplayTableSpec: DerivedTableSpec<OLEDDisplay> = {
   tableName: "oled_display",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "protocol", type: "text" },
     { name: "display_width", type: "text" },
@@ -62,6 +64,8 @@ export const oledDisplayTableSpec: DerivedTableSpec<OLEDDisplay> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           package: String(c.package || ""),
+          kicad_footprint: c.kicad_footprint,
+          jlc_part_number: c.jlc_part_number,
           protocol: protocol || undefined,
           display_width,
           pixel_resolution,

--- a/lib/db/derivedtables/pcie_m2_connector.ts
+++ b/lib/db/derivedtables/pcie_m2_connector.ts
@@ -10,6 +10,8 @@ export interface PcieM2Connector extends BaseComponent {
 export const pcieM2ConnectorTableSpec: DerivedTableSpec<PcieM2Connector> = {
   tableName: "pcie_m2_connector",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "key", type: "text" },
     { name: "is_right_angle", type: "boolean" },
   ],
@@ -45,6 +47,8 @@ export const pcieM2ConnectorTableSpec: DerivedTableSpec<PcieM2Connector> = {
         stock: Number(c.stock || 0),
         price1: extractMinQPrice(c.price),
         in_stock: Boolean((c.stock || 0) > 0),
+        kicad_footprint: c.kicad_footprint,
+        jlc_part_number: c.jlc_part_number,
         key,
         is_right_angle: isRightAngle,
         attributes: attrs,

--- a/lib/db/derivedtables/potentiometer.ts
+++ b/lib/db/derivedtables/potentiometer.ts
@@ -13,6 +13,8 @@ export interface Potentiometer extends BaseComponent {
 export const potentiometerTableSpec: DerivedTableSpec<Potentiometer> = {
   tableName: "potentiometer",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "max_resistance", type: "real" },
     { name: "pin_variant", type: "text" },
     { name: "package", type: "text" },
@@ -50,6 +52,8 @@ export const potentiometerTableSpec: DerivedTableSpec<Potentiometer> = {
         stock: c.stock,
         price1: extractMinQPrice(c.price)!,
         in_stock: c.stock > 0,
+        kicad_footprint: c.kicad_footprint,
+        jlc_part_number: c.jlc_part_number,
         max_resistance: maxResistance,
         pin_variant: pinVariant,
         package: c.package || "",

--- a/lib/db/derivedtables/relay.ts
+++ b/lib/db/derivedtables/relay.ts
@@ -19,6 +19,8 @@ export interface Relay extends BaseComponent {
 export const relayTableSpec: DerivedTableSpec<Relay> = {
   tableName: "relay",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "relay_type", type: "text" },
     { name: "contact_form", type: "text" },
@@ -59,6 +61,8 @@ export const relayTableSpec: DerivedTableSpec<Relay> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           package: String(c.package || ""),
+          kicad_footprint: c.kicad_footprint,
+          jlc_part_number: c.jlc_part_number,
           relay_type: (c as any).subcategory || "",
           contact_form: attrs["Contact Form"] || null,
           coil_voltage: parseValue(attrs["Coil Voltage"]),

--- a/lib/db/derivedtables/resistor.ts
+++ b/lib/db/derivedtables/resistor.ts
@@ -19,6 +19,8 @@ export interface Resistor extends BaseComponent {
 export const resistorTableSpec: DerivedTableSpec<Resistor> = {
   tableName: "resistor",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "resistance", type: "real" },
     { name: "tolerance_fraction", type: "real" },
     { name: "power_watts", type: "real" },
@@ -78,6 +80,8 @@ export const resistorTableSpec: DerivedTableSpec<Resistor> = {
         stock: c.stock,
         price1: extractMinQPrice(c.price)!,
         in_stock: c.stock > 0,
+        kicad_footprint: c.kicad_footprint,
+        jlc_part_number: c.jlc_part_number,
         resistance: resistance,
         tolerance_fraction: tolerance,
         power_watts,

--- a/lib/db/derivedtables/switch.ts
+++ b/lib/db/derivedtables/switch.ts
@@ -22,6 +22,8 @@ export interface Switch extends BaseComponent {
 export const switchTableSpec: DerivedTableSpec<Switch> = {
   tableName: "switch",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "switch_type", type: "text" },
     { name: "circuit", type: "text" },
@@ -88,6 +90,8 @@ export const switchTableSpec: DerivedTableSpec<Switch> = {
         price1: extractMinQPrice(c.price)!,
         in_stock: c.stock > 0,
         package: c.package || "",
+        kicad_footprint: c.kicad_footprint,
+        jlc_part_number: c.jlc_part_number,
         switch_type: (c as any).subcategory || "",
         circuit: attrs["Circuit"] || null,
         current_rating_a:

--- a/lib/db/derivedtables/usb_c_connector.ts
+++ b/lib/db/derivedtables/usb_c_connector.ts
@@ -18,6 +18,8 @@ export interface UsbCConnector extends BaseComponent {
 export const usbCConnectorTableSpec: DerivedTableSpec<UsbCConnector> = {
   tableName: "usb_c_connector",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "mounting_style", type: "text" },
     { name: "current_rating_a", type: "real" },
@@ -66,6 +68,8 @@ export const usbCConnectorTableSpec: DerivedTableSpec<UsbCConnector> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           package: String(c.package || ""),
+          kicad_footprint: c.kicad_footprint,
+          jlc_part_number: c.jlc_part_number,
           mounting_style: attrs["Mounting Style"] || null,
           current_rating_a: parseNum(attrs["Current Rating - Power (Max)"]),
           number_of_ports: parseInt(attrs["Number of Ports"] || "") || null,

--- a/lib/db/derivedtables/voltage_regulator.ts
+++ b/lib/db/derivedtables/voltage_regulator.ts
@@ -25,6 +25,8 @@ export interface VoltageRegulator extends BaseComponent {
 export const voltageRegulatorTableSpec: DerivedTableSpec<VoltageRegulator> = {
   tableName: "voltage_regulator",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "output_type", type: "text" },
     { name: "output_voltage_min", type: "real" },
@@ -181,6 +183,8 @@ export const voltageRegulatorTableSpec: DerivedTableSpec<VoltageRegulator> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         package: c.package || "",
+        kicad_footprint: c.kicad_footprint,
+        jlc_part_number: c.jlc_part_number,
         output_type: outputType,
         output_voltage_min: voltageMin,
         output_voltage_max: voltageMax,

--- a/lib/db/derivedtables/wifi_module.ts
+++ b/lib/db/derivedtables/wifi_module.ts
@@ -26,6 +26,8 @@ export interface WifiModule extends BaseComponent {
 export const wifiModuleTableSpec: DerivedTableSpec<WifiModule> = {
   tableName: "wifi_module",
   extraColumns: [
+    { name: "kicad_footprint", type: "text" },
+    { name: "jlc_part_number", type: "text" },
     { name: "package", type: "text" },
     { name: "core_processor", type: "text" },
     { name: "antenna_type", type: "text" },
@@ -137,6 +139,8 @@ export const wifiModuleTableSpec: DerivedTableSpec<WifiModule> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         package: c.package || "",
+        kicad_footprint: c.kicad_footprint,
+        jlc_part_number: c.jlc_part_number,
         core_processor: attrs["Core Processor"] || null,
         antenna_type: attrs["Antenna Type"] || null,
         operating_voltage: voltage,

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -26,11 +26,15 @@ export interface Accelerometer {
   stock: number | null;
   supply_voltage_max: number | null;
   supply_voltage_min: number | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
 }
 
 export interface Adc {
   attributes: string | null;
   description: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   has_i2c: number | null;
   has_parallel_interface: number | null;
   has_serial_interface: number | null;
@@ -56,6 +60,8 @@ export interface AnalogMultiplexer {
   attributes: string | null;
   channel_type: string | null;
   description: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   has_enable: number | null;
   has_i2c: number | null;
   has_parallel_interface: number | null;
@@ -79,6 +85,8 @@ export interface AnalogMultiplexer {
 export interface BjtTransistor {
   attributes: string | null;
   collector_current: number | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   collector_emitter_voltage: number | null;
   current_gain: number | null;
   description: string | null;
@@ -96,6 +104,8 @@ export interface BjtTransistor {
 export interface BoostConverter {
   attributes: string | null;
   description: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   in_stock: number | null;
   input_voltage_max: number | null;
   input_voltage_min: number | null;
@@ -116,6 +126,8 @@ export interface BoostConverter {
 export interface BuckBoostConverter {
   attributes: string | null;
   description: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   in_stock: number | null;
   input_voltage_max: number | null;
   input_voltage_min: number | null;
@@ -136,6 +148,8 @@ export interface BuckBoostConverter {
 export interface Capacitor {
   attributes: string | null;
   capacitance_farads: number | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   capacitor_type: string | null;
   description: string | null;
   esr_ohms: number | null;
@@ -177,6 +191,8 @@ export interface Component {
   preferred: Generated<number>;
   price: string;
   stock: number;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
 }
 
 export interface ComponentsFt {
@@ -218,6 +234,8 @@ export interface ComponentsFtsIdx {
 export interface Dac {
   attributes: string | null;
   description: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   has_i2c: number | null;
   has_parallel_interface: number | null;
   has_spi: number | null;
@@ -241,6 +259,8 @@ export interface Dac {
 export interface Diode {
   attributes: string | null;
   configuration: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   description: string | null;
   diode_type: string | null;
   forward_current: number | null;
@@ -274,11 +294,15 @@ export interface FpcConnector {
   pitch_mm: number | null;
   price1: number | null;
   stock: number | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
 }
 
 export interface Fuse {
   attributes: string | null;
   current_rating: number | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   description: string | null;
   in_stock: number | null;
   is_glass_encased: number | null;
@@ -296,6 +320,8 @@ export interface Fuse {
 export interface GasSensor {
   attributes: string | null;
   description: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   in_stock: number | null;
   lcsc: Generated<number | null>;
   measures_air_quality: number | null;
@@ -319,6 +345,8 @@ export interface GasSensor {
 export interface Gyroscope {
   attributes: string | null;
   axes: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   description: string | null;
   has_i2c: number | null;
   has_spi: number | null;
@@ -338,6 +366,8 @@ export interface Gyroscope {
 export interface Header {
   attributes: string | null;
   contact_material: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   contact_plating: string | null;
   current_rating_amp: number | null;
   description: string | null;
@@ -366,6 +396,8 @@ export interface Header {
 export interface IoExpander {
   attributes: string | null;
   clock_frequency_hz: number | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   description: string | null;
   has_i2c: number | null;
   has_interrupt: number | null;
@@ -400,11 +432,15 @@ export interface JstConnector {
   reference_series: string | null;
   price1: number | null;
   stock: number | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
 }
 
 export interface LcdDisplay {
   attributes: string | null;
   description: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   display_size: string | null;
   display_type: string | null;
   in_stock: number | null;
@@ -419,6 +455,8 @@ export interface LcdDisplay {
 export interface Ldo {
   attributes: string | null;
   description: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   dropout_voltage: number | null;
   in_stock: number | null;
   input_voltage_max: number | null;
@@ -444,6 +482,8 @@ export interface Ldo {
 export interface Led {
   attributes: string | null;
   color: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   description: string | null;
   forward_current: number | null;
   forward_voltage: number | null;
@@ -467,6 +507,8 @@ export interface Led {
 export interface LedDotMatrixDisplay {
   attributes: string | null;
   color: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   description: string | null;
   in_stock: number | null;
   lcsc: Generated<number | null>;
@@ -480,6 +522,8 @@ export interface LedDotMatrixDisplay {
 export interface LedDriver {
   attributes: string | null;
   channel_count: number | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   description: string | null;
   dimming_method: string | null;
   efficiency_percent: number | null;
@@ -501,6 +545,8 @@ export interface LedDriver {
 export interface LedSegmentDisplay {
   attributes: string | null;
   color: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   description: string | null;
   in_stock: number | null;
   lcsc: Generated<number | null>;
@@ -516,6 +562,8 @@ export interface LedSegmentDisplay {
 export interface LedWithIc {
   attributes: string | null;
   color: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   description: string | null;
   forward_current: number | null;
   forward_voltage: number | null;
@@ -537,6 +585,8 @@ export interface Manufacturer {
 export interface Microcontroller {
   adc_resolution_bits: number | null;
   attributes: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   cpu_core: string | null;
   cpu_speed_hz: number | null;
   dac_resolution_bits: number | null;
@@ -572,6 +622,8 @@ export interface Microcontroller {
 export interface Mosfet {
   attributes: string | null;
   continuous_drain_current: number | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   description: string | null;
   drain_source_voltage: number | null;
   gate_threshold_voltage: number | null;
@@ -590,6 +642,8 @@ export interface Mosfet {
 export interface OledDisplay {
   attributes: string | null;
   description: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   display_width: string | null;
   in_stock: number | null;
   lcsc: Generated<number | null>;
@@ -611,11 +665,15 @@ export interface PcieM2Connector {
   mfr: string | null;
   price1: number | null;
   stock: number | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
 }
 
 export interface Potentiometer {
   attributes: string | null;
   description: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   in_stock: number | null;
   is_surface_mount: number | null;
   lcsc: Generated<number | null>;
@@ -630,6 +688,8 @@ export interface Potentiometer {
 export interface Relay {
   attributes: string | null;
   coil_resistance: number | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   coil_voltage: number | null;
   contact_form: string | null;
   description: string | null;
@@ -648,6 +708,8 @@ export interface Relay {
 export interface Resistor {
   attributes: string | null;
   description: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   in_stock: number | null;
   is_multi_resistor_chip: number | null;
   is_potentiometer: number | null;
@@ -668,6 +730,8 @@ export interface Resistor {
 export interface Switch {
   attributes: string | null;
   circuit: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   current_rating_a: number | null;
   description: string | null;
   in_stock: number | null;
@@ -691,6 +755,8 @@ export interface Switch {
 export interface UsbCConnector {
   attributes: string | null;
   current_rating_a: number | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   description: string | null;
   gender: string | null;
   in_stock: number | null;
@@ -728,6 +794,8 @@ export interface VComponent {
 export interface VoltageRegulator {
   attributes: string | null;
   description: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   dropout_voltage: number | null;
   in_stock: number | null;
   input_voltage_max: number | null;
@@ -754,6 +822,8 @@ export interface VoltageRegulator {
 export interface WifiModule {
   antenna_type: string | null;
   attributes: string | null;
+  kicad_footprint: string | null;
+  jlc_part_number: string | null;
   core_processor: string | null;
   description: string | null;
   frequency_ghz: number | null;

--- a/routes/mosfets/list.tsx
+++ b/routes/mosfets/list.tsx
@@ -40,6 +40,8 @@ export default withWinterSpec({
           power_dissipation: z.number().nullable(),
           operating_temp_min: z.number().nullable(),
           operating_temp_max: z.number().nullable(),
+          kicad_footprint: z.string().nullable(),
+          jlc_part_number: z.string().nullable(),
         }),
       ),
     }),
@@ -125,6 +127,8 @@ export default withWinterSpec({
         power_dissipation: mosfet.power_dissipation,
         operating_temp_min: mosfet.operating_temp_min,
         operating_temp_max: mosfet.operating_temp_max,
+        kicad_footprint: (mosfet as any).kicad_footprint ?? null,
+        jlc_part_number: (mosfet as any).jlc_part_number ?? null,
       })),
     })
   }

--- a/tests/routes/mosfets/list.test.ts
+++ b/tests/routes/mosfets/list.test.ts
@@ -61,3 +61,24 @@ test("GET /mosfets/list with voltage filter returns filtered data", async () => 
     }
   }
 })
+
+test("GET /mosfets/list returns new properties", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/mosfets/list?json=true")
+
+  expect(res.data).toHaveProperty("mosfets")
+
+  if (res.data.mosfets.length > 0) {
+    const mosfet = res.data.mosfets[0]
+    expect(mosfet).toHaveProperty("kicad_footprint")
+    expect(mosfet).toHaveProperty("jlc_part_number")
+
+    // The value can be null, so we check for either string or null
+    if (mosfet.kicad_footprint !== null) {
+      expect(typeof mosfet.kicad_footprint).toBe("string")
+    }
+    if (mosfet.jlc_part_number !== null) {
+      expect(typeof mosfet.jlc_part_number).toBe("string")
+    }
+  }
+})


### PR DESCRIPTION
This pull request adds kicad_footprint and jlc_part_number columns to the components table and all derived tables. This allows  
for mapping JLC part numbers to their corresponding KiCad footprints.                                                           

 • A database optimization has been added to scripts/setup-db-optimizations.ts to alter the components table schema.            
 • All derived table specifications in lib/db/derivedtables/ have been updated to include the new kicad_footprint and           
   jlc_part_number columns.                                                                                                     
 • A test has been added to tests/routes/mosfets/list.test.ts to verify that the new properties are correctly exposed through   
   the API.

RE https://github.com/tscircuit/tscircuit/issues/782