### PR TITLE
Add script for Winterspec OpenAPI generation

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,12480 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "WinterSpec API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/[...anyroute]": {
+      "get": {
+        "summary": "/[...anyroute]",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "error_code": {
+                      "type": ["string"]
+                    },
+                    "message": {
+                      "type": ["string"]
+                    }
+                  },
+                  "required": ["error_code", "message"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "operationId": "by...anyrouteGet"
+      },
+      "post": {
+        "summary": "/[...anyroute]",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "error_code": {
+                      "type": ["string"]
+                    },
+                    "message": {
+                      "type": ["string"]
+                    }
+                  },
+                  "required": ["error_code", "message"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "operationId": "by...anyroutePost"
+      }
+    },
+    "/accelerometers/list.json": {
+      "get": {
+        "summary": "/accelerometers/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "interface",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["spi", "i2c", "uart", ""]
+            }
+          }
+        ],
+        "operationId": "accelerometersList.jsonGet"
+      }
+    },
+    "/accelerometers/list": {
+      "get": {
+        "summary": "/accelerometers/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "interface",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["spi", "i2c", "uart", ""]
+            }
+          }
+        ],
+        "operationId": "accelerometersListGet"
+      }
+    },
+    "/adcs/list.json": {
+      "get": {
+        "summary": "/adcs/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "resolution",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "interface",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["spi", "i2c", "parallel", "serial", "uart", ""]
+            }
+          },
+          {
+            "name": "is_differential",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "channels",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          }
+        ],
+        "operationId": "adcsList.jsonGet"
+      }
+    },
+    "/adcs/list": {
+      "get": {
+        "summary": "/adcs/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "resolution",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "interface",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["spi", "i2c", "parallel", "serial", "uart", ""]
+            }
+          },
+          {
+            "name": "is_differential",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "channels",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          }
+        ],
+        "operationId": "adcsListGet"
+      }
+    },
+    "/admin": {
+      "head": {
+        "summary": "/admin",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "operationId": "adminHead"
+      },
+      "get": {
+        "summary": "/admin",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "operationId": "adminGet"
+      },
+      "post": {
+        "summary": "/admin",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "operationId": "adminPost"
+      }
+    },
+    "/admin/system/create-indexes": {
+      "get": {
+        "summary": "/admin/system/create-indexes",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "operationId": "adminSystemCreateIndexesGet"
+      },
+      "post": {
+        "summary": "/admin/system/create-indexes",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "operationId": "adminSystemCreateIndexesPost"
+      }
+    },
+    "/analog_multiplexers/list.json": {
+      "get": {
+        "summary": "/analog_multiplexers/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "channels",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "interface",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["spi", "i2c", "parallel", ""]
+            }
+          },
+          {
+            "name": "channel_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["single", "differential", ""]
+            }
+          }
+        ],
+        "operationId": "analogMultiplexersList.jsonGet"
+      }
+    },
+    "/analog_multiplexers/list": {
+      "get": {
+        "summary": "/analog_multiplexers/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "channels",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "interface",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["spi", "i2c", "parallel", ""]
+            }
+          },
+          {
+            "name": "channel_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["single", "differential", ""]
+            }
+          }
+        ],
+        "operationId": "analogMultiplexersListGet"
+      }
+    },
+    "/analog_switches/list.json": {
+      "get": {
+        "summary": "/analog_switches/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "channels",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          }
+        ],
+        "operationId": "analogSwitchesList.jsonGet"
+      }
+    },
+    "/analog_switches/list": {
+      "get": {
+        "summary": "/analog_switches/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "channels",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          }
+        ],
+        "operationId": "analogSwitchesListGet"
+      }
+    },
+    "/api/search": {
+      "get": {
+        "summary": "/api/search",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "full",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "is_basic",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          }
+        ],
+        "operationId": "apiSearchGet"
+      }
+    },
+    "/arm_processors/list.json": {
+      "get": {
+        "summary": "/arm_processors/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "flash_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "ram_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "interface",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["uart", "i2c", "spi", "can", "usb", ""]
+            }
+          }
+        ],
+        "operationId": "armProcessorsList.jsonGet"
+      }
+    },
+    "/arm_processors/list": {
+      "get": {
+        "summary": "/arm_processors/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "flash_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "ram_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "interface",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["uart", "i2c", "spi", "can", "usb", ""]
+            }
+          }
+        ],
+        "operationId": "armProcessorsListGet"
+      }
+    },
+    "/bjt_transistors/list.json": {
+      "get": {
+        "summary": "/bjt_transistors/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "bjt_transistors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["number"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "description": {
+                                "type": ["string"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number", "null"]
+                              },
+                              "in_stock": {
+                                "type": ["boolean"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "current_gain": {
+                                "type": ["number", "null"]
+                              },
+                              "collector_current": {
+                                "type": ["number"]
+                              },
+                              "collector_emitter_voltage": {
+                                "type": ["number", "null"]
+                              },
+                              "transition_frequency": {
+                                "type": ["number", "null"]
+                              },
+                              "power_dissipation": {
+                                "type": ["number", "null"]
+                              },
+                              "temperature_range": {
+                                "type": ["string", "null"]
+                              }
+                            },
+                            "required": [
+                              "lcsc",
+                              "mfr",
+                              "description",
+                              "stock",
+                              "price1",
+                              "in_stock",
+                              "package",
+                              "current_gain",
+                              "collector_current",
+                              "collector_emitter_voltage",
+                              "transition_frequency",
+                              "power_dissipation",
+                              "temperature_range"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["bjt_transistors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "current_gain_min": {
+                    "type": ["number"]
+                  },
+                  "collector_current_min": {
+                    "type": ["number"]
+                  },
+                  "collector_emitter_voltage_min": {
+                    "type": ["number"]
+                  },
+                  "transition_frequency_min": {
+                    "type": ["number"]
+                  },
+                  "power_dissipation_min": {
+                    "type": ["number"]
+                  },
+                  "temperature_range": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "search": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "current_gain_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "collector_current_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "collector_emitter_voltage_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "transition_frequency_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "power_dissipation_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "temperature_range",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "bjtTransistorsList.jsonGet"
+      }
+    },
+    "/bjt_transistors/list": {
+      "get": {
+        "summary": "/bjt_transistors/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "bjt_transistors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["number"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "description": {
+                                "type": ["string"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number", "null"]
+                              },
+                              "in_stock": {
+                                "type": ["boolean"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "current_gain": {
+                                "type": ["number", "null"]
+                              },
+                              "collector_current": {
+                                "type": ["number"]
+                              },
+                              "collector_emitter_voltage": {
+                                "type": ["number", "null"]
+                              },
+                              "transition_frequency": {
+                                "type": ["number", "null"]
+                              },
+                              "power_dissipation": {
+                                "type": ["number", "null"]
+                              },
+                              "temperature_range": {
+                                "type": ["string", "null"]
+                              }
+                            },
+                            "required": [
+                              "lcsc",
+                              "mfr",
+                              "description",
+                              "stock",
+                              "price1",
+                              "in_stock",
+                              "package",
+                              "current_gain",
+                              "collector_current",
+                              "collector_emitter_voltage",
+                              "transition_frequency",
+                              "power_dissipation",
+                              "temperature_range"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["bjt_transistors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "current_gain_min": {
+                    "type": ["number"]
+                  },
+                  "collector_current_min": {
+                    "type": ["number"]
+                  },
+                  "collector_emitter_voltage_min": {
+                    "type": ["number"]
+                  },
+                  "transition_frequency_min": {
+                    "type": ["number"]
+                  },
+                  "power_dissipation_min": {
+                    "type": ["number"]
+                  },
+                  "temperature_range": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "search": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "current_gain_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "collector_current_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "collector_emitter_voltage_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "transition_frequency_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "power_dissipation_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "temperature_range",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "bjtTransistorsListGet"
+      }
+    },
+    "/boost_converters/list.json": {
+      "get": {
+        "summary": "/boost_converters/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "boost_converters": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number", "null"]
+                          },
+                          "in_stock": {
+                            "type": ["boolean"]
+                          },
+                          "package": {
+                            "type": ["string", "null"]
+                          },
+                          "input_voltage_min": {
+                            "type": ["number", "null"]
+                          },
+                          "input_voltage_max": {
+                            "type": ["number", "null"]
+                          },
+                          "output_voltage_min": {
+                            "type": ["number", "null"]
+                          },
+                          "output_voltage_max": {
+                            "type": ["number", "null"]
+                          },
+                          "output_current_max": {
+                            "type": ["number", "null"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "description",
+                          "stock",
+                          "price1",
+                          "in_stock",
+                          "package",
+                          "input_voltage_min",
+                          "input_voltage_max",
+                          "output_voltage_min",
+                          "output_voltage_max",
+                          "output_current_max"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["boost_converters"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "input_voltage": {
+                    "type": ["number"]
+                  },
+                  "output_voltage": {
+                    "type": ["number"]
+                  },
+                  "output_current": {
+                    "type": ["number"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "input_voltage",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "output_voltage",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "output_current",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          }
+        ],
+        "operationId": "boostConvertersList.jsonGet"
+      }
+    },
+    "/boost_converters/list": {
+      "get": {
+        "summary": "/boost_converters/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "boost_converters": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number", "null"]
+                          },
+                          "in_stock": {
+                            "type": ["boolean"]
+                          },
+                          "package": {
+                            "type": ["string", "null"]
+                          },
+                          "input_voltage_min": {
+                            "type": ["number", "null"]
+                          },
+                          "input_voltage_max": {
+                            "type": ["number", "null"]
+                          },
+                          "output_voltage_min": {
+                            "type": ["number", "null"]
+                          },
+                          "output_voltage_max": {
+                            "type": ["number", "null"]
+                          },
+                          "output_current_max": {
+                            "type": ["number", "null"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "description",
+                          "stock",
+                          "price1",
+                          "in_stock",
+                          "package",
+                          "input_voltage_min",
+                          "input_voltage_max",
+                          "output_voltage_min",
+                          "output_voltage_max",
+                          "output_current_max"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["boost_converters"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "input_voltage": {
+                    "type": ["number"]
+                  },
+                  "output_voltage": {
+                    "type": ["number"]
+                  },
+                  "output_current": {
+                    "type": ["number"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "input_voltage",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "output_voltage",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "output_current",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          }
+        ],
+        "operationId": "boostConvertersListGet"
+      }
+    },
+    "/buck_boost_converters/list.json": {
+      "get": {
+        "summary": "/buck_boost_converters/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "buck_boost_converters": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number", "null"]
+                          },
+                          "in_stock": {
+                            "type": ["boolean"]
+                          },
+                          "package": {
+                            "type": ["string", "null"]
+                          },
+                          "input_voltage_min": {
+                            "type": ["number", "null"]
+                          },
+                          "input_voltage_max": {
+                            "type": ["number", "null"]
+                          },
+                          "output_voltage_min": {
+                            "type": ["number", "null"]
+                          },
+                          "output_voltage_max": {
+                            "type": ["number", "null"]
+                          },
+                          "output_current_max": {
+                            "type": ["number", "null"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "description",
+                          "stock",
+                          "price1",
+                          "in_stock",
+                          "package",
+                          "input_voltage_min",
+                          "input_voltage_max",
+                          "output_voltage_min",
+                          "output_voltage_max",
+                          "output_current_max"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["buck_boost_converters"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "input_voltage": {
+                    "type": ["number"]
+                  },
+                  "output_voltage": {
+                    "type": ["number"]
+                  },
+                  "output_current": {
+                    "type": ["number"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "input_voltage",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "output_voltage",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "output_current",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          }
+        ],
+        "operationId": "buckBoostConvertersList.jsonGet"
+      }
+    },
+    "/buck_boost_converters/list": {
+      "get": {
+        "summary": "/buck_boost_converters/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "buck_boost_converters": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number", "null"]
+                          },
+                          "in_stock": {
+                            "type": ["boolean"]
+                          },
+                          "package": {
+                            "type": ["string", "null"]
+                          },
+                          "input_voltage_min": {
+                            "type": ["number", "null"]
+                          },
+                          "input_voltage_max": {
+                            "type": ["number", "null"]
+                          },
+                          "output_voltage_min": {
+                            "type": ["number", "null"]
+                          },
+                          "output_voltage_max": {
+                            "type": ["number", "null"]
+                          },
+                          "output_current_max": {
+                            "type": ["number", "null"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "description",
+                          "stock",
+                          "price1",
+                          "in_stock",
+                          "package",
+                          "input_voltage_min",
+                          "input_voltage_max",
+                          "output_voltage_min",
+                          "output_voltage_max",
+                          "output_current_max"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["buck_boost_converters"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "input_voltage": {
+                    "type": ["number"]
+                  },
+                  "output_voltage": {
+                    "type": ["number"]
+                  },
+                  "output_current": {
+                    "type": ["number"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "input_voltage",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "output_voltage",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "output_current",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          }
+        ],
+        "operationId": "buckBoostConvertersListGet"
+      }
+    },
+    "/capacitors/list.json": {
+      "get": {
+        "summary": "/capacitors/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "capacitors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "is_basic": {
+                                "type": ["boolean"]
+                              },
+                              "capacitance": {
+                                "type": ["number"]
+                              },
+                              "voltage": {
+                                "type": ["number"]
+                              },
+                              "type": {
+                                "type": ["string"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": [
+                              "lcsc",
+                              "mfr",
+                              "package",
+                              "is_basic",
+                              "capacitance"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["capacitors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "is_basic": {
+                    "type": ["boolean"]
+                  },
+                  "capacitance": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "is_basic",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "capacitance",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "capacitorsList.jsonGet"
+      }
+    },
+    "/capacitors/list": {
+      "get": {
+        "summary": "/capacitors/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "capacitors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "is_basic": {
+                                "type": ["boolean"]
+                              },
+                              "capacitance": {
+                                "type": ["number"]
+                              },
+                              "voltage": {
+                                "type": ["number"]
+                              },
+                              "type": {
+                                "type": ["string"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": [
+                              "lcsc",
+                              "mfr",
+                              "package",
+                              "is_basic",
+                              "capacitance"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["capacitors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "is_basic": {
+                    "type": ["boolean"]
+                  },
+                  "capacitance": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "is_basic",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "capacitance",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "capacitorsListGet"
+      }
+    },
+    "/categories/list.json": {
+      "get": {
+        "summary": "/categories/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "category_name",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "categoriesList.jsonGet"
+      },
+      "post": {
+        "summary": "/categories/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "category_name",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "categoriesList.jsonPost"
+      }
+    },
+    "/categories/list": {
+      "get": {
+        "summary": "/categories/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "category_name",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "categoriesListGet"
+      },
+      "post": {
+        "summary": "/categories/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "category_name",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "categoriesListPost"
+      }
+    },
+    "/components/list.json": {
+      "get": {
+        "summary": "/components/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "subcategory_name",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "full",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "is_basic",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          }
+        ],
+        "operationId": "componentsList.jsonGet"
+      }
+    },
+    "/components/list": {
+      "get": {
+        "summary": "/components/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "subcategory_name",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "full",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "is_basic",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          }
+        ],
+        "operationId": "componentsListGet"
+      }
+    },
+    "/dacs/list.json": {
+      "get": {
+        "summary": "/dacs/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "dacs": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "resolution_bits": {
+                                "type": ["number"]
+                              },
+                              "num_channels": {
+                                "type": ["number"]
+                              },
+                              "settling_time_us": {
+                                "type": ["number"]
+                              },
+                              "supply_voltage_min": {
+                                "type": ["number"]
+                              },
+                              "supply_voltage_max": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "package"]
+                          }
+                        }
+                      },
+                      "required": ["dacs"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "resolution": {
+                    "type": ["number"]
+                  },
+                  "interface": {
+                    "type": ["string"],
+                    "enum": ["spi", "i2c", "parallel", ""]
+                  },
+                  "channels": {
+                    "type": ["number"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "resolution",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "interface",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["spi", "i2c", "parallel", ""]
+            }
+          },
+          {
+            "name": "channels",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          }
+        ],
+        "operationId": "dacsList.jsonGet"
+      }
+    },
+    "/dacs/list": {
+      "get": {
+        "summary": "/dacs/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "dacs": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "resolution_bits": {
+                                "type": ["number"]
+                              },
+                              "num_channels": {
+                                "type": ["number"]
+                              },
+                              "settling_time_us": {
+                                "type": ["number"]
+                              },
+                              "supply_voltage_min": {
+                                "type": ["number"]
+                              },
+                              "supply_voltage_max": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "package"]
+                          }
+                        }
+                      },
+                      "required": ["dacs"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "resolution": {
+                    "type": ["number"]
+                  },
+                  "interface": {
+                    "type": ["string"],
+                    "enum": ["spi", "i2c", "parallel", ""]
+                  },
+                  "channels": {
+                    "type": ["number"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "resolution",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "interface",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["spi", "i2c", "parallel", ""]
+            }
+          },
+          {
+            "name": "channels",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          }
+        ],
+        "operationId": "dacsListGet"
+      }
+    },
+    "/diodes/list.json": {
+      "get": {
+        "summary": "/diodes/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "diodes": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "diode_type": {
+                                "type": ["string"]
+                              },
+                              "forward_voltage": {
+                                "type": ["number"]
+                              },
+                              "reverse_voltage": {
+                                "type": ["number"]
+                              },
+                              "forward_current": {
+                                "type": ["number"]
+                              },
+                              "recovery_time_ns": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "package", "diode_type"]
+                          }
+                        }
+                      },
+                      "required": ["diodes"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "diode_type": {
+                    "type": ["string"],
+                    "enum": [
+                      "general_purpose",
+                      "schottky_barrier",
+                      "zener",
+                      "tvs",
+                      "switching",
+                      "fast_recovery",
+                      "bridge_rectifier",
+                      "All",
+                      ""
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "diode_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": [
+                "general_purpose",
+                "schottky_barrier",
+                "zener",
+                "tvs",
+                "switching",
+                "fast_recovery",
+                "bridge_rectifier",
+                "All",
+                ""
+              ]
+            }
+          }
+        ],
+        "operationId": "diodesList.jsonGet"
+      }
+    },
+    "/diodes/list": {
+      "get": {
+        "summary": "/diodes/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "diodes": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "diode_type": {
+                                "type": ["string"]
+                              },
+                              "forward_voltage": {
+                                "type": ["number"]
+                              },
+                              "reverse_voltage": {
+                                "type": ["number"]
+                              },
+                              "forward_current": {
+                                "type": ["number"]
+                              },
+                              "recovery_time_ns": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "package", "diode_type"]
+                          }
+                        }
+                      },
+                      "required": ["diodes"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "diode_type": {
+                    "type": ["string"],
+                    "enum": [
+                      "general_purpose",
+                      "schottky_barrier",
+                      "zener",
+                      "tvs",
+                      "switching",
+                      "fast_recovery",
+                      "bridge_rectifier",
+                      "All",
+                      ""
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "diode_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": [
+                "general_purpose",
+                "schottky_barrier",
+                "zener",
+                "tvs",
+                "switching",
+                "fast_recovery",
+                "bridge_rectifier",
+                "All",
+                ""
+              ]
+            }
+          }
+        ],
+        "operationId": "diodesListGet"
+      }
+    },
+    "/footprint_index/list": {
+      "get": {
+        "summary": "/footprint_index/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "operationId": "footprintIndexListGet"
+      }
+    },
+    "/fpc_connectors/list": {
+      "get": {
+        "summary": "/fpc_connectors/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "fpc_connectors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "pitch_mm": {
+                                "type": ["number"]
+                              },
+                              "number_of_contacts": {
+                                "type": ["number"]
+                              },
+                              "contact_type": {
+                                "type": ["string"]
+                              },
+                              "locking_feature": {
+                                "type": ["string"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr"]
+                          }
+                        }
+                      },
+                      "required": ["fpc_connectors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "pitch": {
+                    "type": ["string"]
+                  },
+                  "contact_type": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "pitch",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "contact_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "fpcConnectorsListGet"
+      },
+      "post": {
+        "summary": "/fpc_connectors/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "fpc_connectors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "pitch_mm": {
+                                "type": ["number"]
+                              },
+                              "number_of_contacts": {
+                                "type": ["number"]
+                              },
+                              "contact_type": {
+                                "type": ["string"]
+                              },
+                              "locking_feature": {
+                                "type": ["string"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr"]
+                          }
+                        }
+                      },
+                      "required": ["fpc_connectors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "pitch": {
+                    "type": ["string"]
+                  },
+                  "contact_type": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "pitch",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "contact_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "fpcConnectorsListPost"
+      }
+    },
+    "/fuses/list.json": {
+      "get": {
+        "summary": "/fuses/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "fuses": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "current_rating": {
+                            "type": ["number"]
+                          },
+                          "voltage_rating": {
+                            "type": ["number"]
+                          },
+                          "response_time": {
+                            "type": ["string"]
+                          },
+                          "is_surface_mount": {
+                            "type": ["boolean"]
+                          },
+                          "is_glass_encased": {
+                            "type": ["boolean"]
+                          },
+                          "is_resettable": {
+                            "type": ["boolean"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1",
+                          "current_rating",
+                          "voltage_rating",
+                          "response_time",
+                          "is_surface_mount",
+                          "is_glass_encased",
+                          "is_resettable"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["fuses"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "current_rating": {
+                    "type": ["string"]
+                  },
+                  "voltage_rating": {
+                    "type": ["string"]
+                  },
+                  "response_time": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "description": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "current_rating",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "voltage_rating",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "response_time",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "fusesList.jsonGet"
+      },
+      "post": {
+        "summary": "/fuses/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "fuses": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "current_rating": {
+                            "type": ["number"]
+                          },
+                          "voltage_rating": {
+                            "type": ["number"]
+                          },
+                          "response_time": {
+                            "type": ["string"]
+                          },
+                          "is_surface_mount": {
+                            "type": ["boolean"]
+                          },
+                          "is_glass_encased": {
+                            "type": ["boolean"]
+                          },
+                          "is_resettable": {
+                            "type": ["boolean"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1",
+                          "current_rating",
+                          "voltage_rating",
+                          "response_time",
+                          "is_surface_mount",
+                          "is_glass_encased",
+                          "is_resettable"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["fuses"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "current_rating": {
+                    "type": ["string"]
+                  },
+                  "voltage_rating": {
+                    "type": ["string"]
+                  },
+                  "response_time": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "description": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "current_rating",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "voltage_rating",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "response_time",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "fusesList.jsonPost"
+      }
+    },
+    "/fuses/list": {
+      "get": {
+        "summary": "/fuses/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "fuses": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "current_rating": {
+                            "type": ["number"]
+                          },
+                          "voltage_rating": {
+                            "type": ["number"]
+                          },
+                          "response_time": {
+                            "type": ["string"]
+                          },
+                          "is_surface_mount": {
+                            "type": ["boolean"]
+                          },
+                          "is_glass_encased": {
+                            "type": ["boolean"]
+                          },
+                          "is_resettable": {
+                            "type": ["boolean"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1",
+                          "current_rating",
+                          "voltage_rating",
+                          "response_time",
+                          "is_surface_mount",
+                          "is_glass_encased",
+                          "is_resettable"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["fuses"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "current_rating": {
+                    "type": ["string"]
+                  },
+                  "voltage_rating": {
+                    "type": ["string"]
+                  },
+                  "response_time": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "description": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "current_rating",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "voltage_rating",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "response_time",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "fusesListGet"
+      },
+      "post": {
+        "summary": "/fuses/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "fuses": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "current_rating": {
+                            "type": ["number"]
+                          },
+                          "voltage_rating": {
+                            "type": ["number"]
+                          },
+                          "response_time": {
+                            "type": ["string"]
+                          },
+                          "is_surface_mount": {
+                            "type": ["boolean"]
+                          },
+                          "is_glass_encased": {
+                            "type": ["boolean"]
+                          },
+                          "is_resettable": {
+                            "type": ["boolean"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1",
+                          "current_rating",
+                          "voltage_rating",
+                          "response_time",
+                          "is_surface_mount",
+                          "is_glass_encased",
+                          "is_resettable"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["fuses"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "current_rating": {
+                    "type": ["string"]
+                  },
+                  "voltage_rating": {
+                    "type": ["string"]
+                  },
+                  "response_time": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "description": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "current_rating",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "voltage_rating",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "response_time",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "fusesListPost"
+      }
+    },
+    "/gas_sensors/list.json": {
+      "get": {
+        "summary": "/gas_sensors/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "sensor_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "measurement",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": [
+                "",
+                "air_quality",
+                "co2",
+                "oxygen",
+                "carbon_monoxide",
+                "methane",
+                "nitrogen_oxides",
+                "sulfur_hexafluoride",
+                "volatile_organic_compounds",
+                "formaldehyde",
+                "hydrogen",
+                "explosive_gases"
+              ]
+            }
+          }
+        ],
+        "operationId": "gasSensorsList.jsonGet"
+      }
+    },
+    "/gas_sensors/list": {
+      "get": {
+        "summary": "/gas_sensors/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "sensor_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "measurement",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": [
+                "",
+                "air_quality",
+                "co2",
+                "oxygen",
+                "carbon_monoxide",
+                "methane",
+                "nitrogen_oxides",
+                "sulfur_hexafluoride",
+                "volatile_organic_compounds",
+                "formaldehyde",
+                "hydrogen",
+                "explosive_gases"
+              ]
+            }
+          }
+        ],
+        "operationId": "gasSensorsListGet"
+      }
+    },
+    "/gyroscopes/list.json": {
+      "get": {
+        "summary": "/gyroscopes/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "interface",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["spi", "i2c", "uart", ""]
+            }
+          }
+        ],
+        "operationId": "gyroscopesList.jsonGet"
+      }
+    },
+    "/gyroscopes/list": {
+      "get": {
+        "summary": "/gyroscopes/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "interface",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["spi", "i2c", "uart", ""]
+            }
+          }
+        ],
+        "operationId": "gyroscopesListGet"
+      }
+    },
+    "/headers/list.json": {
+      "get": {
+        "summary": "/headers/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "headers": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "pitch_mm": {
+                                "type": ["number"]
+                              },
+                              "num_pins": {
+                                "type": ["number"]
+                              },
+                              "gender": {
+                                "type": ["string"]
+                              },
+                              "is_right_angle": {
+                                "type": ["boolean"]
+                              },
+                              "voltage_rating": {
+                                "type": ["number"]
+                              },
+                              "current_rating": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "package"]
+                          }
+                        }
+                      },
+                      "required": ["headers"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "pitch": {
+                    "type": ["string"]
+                  },
+                  "num_pins": {
+                    "type": ["number"]
+                  },
+                  "is_right_angle": {
+                    "type": ["boolean"]
+                  },
+                  "gender": {
+                    "type": ["string"],
+                    "enum": ["male", "female", ""]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "pitch",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "num_pins",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "is_right_angle",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "gender",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["male", "female", ""]
+            }
+          }
+        ],
+        "operationId": "headersList.jsonGet"
+      },
+      "post": {
+        "summary": "/headers/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "headers": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "pitch_mm": {
+                                "type": ["number"]
+                              },
+                              "num_pins": {
+                                "type": ["number"]
+                              },
+                              "gender": {
+                                "type": ["string"]
+                              },
+                              "is_right_angle": {
+                                "type": ["boolean"]
+                              },
+                              "voltage_rating": {
+                                "type": ["number"]
+                              },
+                              "current_rating": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "package"]
+                          }
+                        }
+                      },
+                      "required": ["headers"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "pitch": {
+                    "type": ["string"]
+                  },
+                  "num_pins": {
+                    "type": ["number"]
+                  },
+                  "is_right_angle": {
+                    "type": ["boolean"]
+                  },
+                  "gender": {
+                    "type": ["string"],
+                    "enum": ["male", "female", ""]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "pitch",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "num_pins",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "is_right_angle",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "gender",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["male", "female", ""]
+            }
+          }
+        ],
+        "operationId": "headersList.jsonPost"
+      }
+    },
+    "/headers/list": {
+      "get": {
+        "summary": "/headers/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "headers": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "pitch_mm": {
+                                "type": ["number"]
+                              },
+                              "num_pins": {
+                                "type": ["number"]
+                              },
+                              "gender": {
+                                "type": ["string"]
+                              },
+                              "is_right_angle": {
+                                "type": ["boolean"]
+                              },
+                              "voltage_rating": {
+                                "type": ["number"]
+                              },
+                              "current_rating": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "package"]
+                          }
+                        }
+                      },
+                      "required": ["headers"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "pitch": {
+                    "type": ["string"]
+                  },
+                  "num_pins": {
+                    "type": ["number"]
+                  },
+                  "is_right_angle": {
+                    "type": ["boolean"]
+                  },
+                  "gender": {
+                    "type": ["string"],
+                    "enum": ["male", "female", ""]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "pitch",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "num_pins",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "is_right_angle",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "gender",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["male", "female", ""]
+            }
+          }
+        ],
+        "operationId": "headersListGet"
+      },
+      "post": {
+        "summary": "/headers/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "headers": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "pitch_mm": {
+                                "type": ["number"]
+                              },
+                              "num_pins": {
+                                "type": ["number"]
+                              },
+                              "gender": {
+                                "type": ["string"]
+                              },
+                              "is_right_angle": {
+                                "type": ["boolean"]
+                              },
+                              "voltage_rating": {
+                                "type": ["number"]
+                              },
+                              "current_rating": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "package"]
+                          }
+                        }
+                      },
+                      "required": ["headers"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "pitch": {
+                    "type": ["string"]
+                  },
+                  "num_pins": {
+                    "type": ["number"]
+                  },
+                  "is_right_angle": {
+                    "type": ["boolean"]
+                  },
+                  "gender": {
+                    "type": ["string"],
+                    "enum": ["male", "female", ""]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "pitch",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "num_pins",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "is_right_angle",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "gender",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["male", "female", ""]
+            }
+          }
+        ],
+        "operationId": "headersListPost"
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "/health",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "ok": {
+                      "type": ["boolean"]
+                    }
+                  },
+                  "required": ["ok"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "operationId": "healthGet"
+      },
+      "post": {
+        "summary": "/health",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "ok": {
+                      "type": ["boolean"]
+                    }
+                  },
+                  "required": ["ok"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "operationId": "healthPost"
+      }
+    },
+    "/io_expanders/list.json": {
+      "get": {
+        "summary": "/io_expanders/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "num_gpios",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "interface",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["spi", "i2c", "smbus", ""]
+            }
+          },
+          {
+            "name": "has_interrupt",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          }
+        ],
+        "operationId": "ioExpandersList.jsonGet"
+      }
+    },
+    "/io_expanders/list": {
+      "get": {
+        "summary": "/io_expanders/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "num_gpios",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "interface",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["spi", "i2c", "smbus", ""]
+            }
+          },
+          {
+            "name": "has_interrupt",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          }
+        ],
+        "operationId": "ioExpandersListGet"
+      }
+    },
+    "/jst_connectors/list.json": {
+      "get": {
+        "summary": "/jst_connectors/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "jst_connectors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "pitch_mm": {
+                                "type": ["number"]
+                              },
+                              "num_rows": {
+                                "type": ["number"]
+                              },
+                              "num_pins": {
+                                "type": ["number"]
+                              },
+                              "reference_series": {
+                                "type": ["string"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr"]
+                          }
+                        }
+                      },
+                      "required": ["jst_connectors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "pitch": {
+                    "type": ["string"]
+                  },
+                  "series": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "pitch",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "series",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "jstConnectorsList.jsonGet"
+      },
+      "post": {
+        "summary": "/jst_connectors/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "jst_connectors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "pitch_mm": {
+                                "type": ["number"]
+                              },
+                              "num_rows": {
+                                "type": ["number"]
+                              },
+                              "num_pins": {
+                                "type": ["number"]
+                              },
+                              "reference_series": {
+                                "type": ["string"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr"]
+                          }
+                        }
+                      },
+                      "required": ["jst_connectors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "pitch": {
+                    "type": ["string"]
+                  },
+                  "series": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "pitch",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "series",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "jstConnectorsList.jsonPost"
+      }
+    },
+    "/jst_connectors/list": {
+      "get": {
+        "summary": "/jst_connectors/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "jst_connectors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "pitch_mm": {
+                                "type": ["number"]
+                              },
+                              "num_rows": {
+                                "type": ["number"]
+                              },
+                              "num_pins": {
+                                "type": ["number"]
+                              },
+                              "reference_series": {
+                                "type": ["string"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr"]
+                          }
+                        }
+                      },
+                      "required": ["jst_connectors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "pitch": {
+                    "type": ["string"]
+                  },
+                  "series": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "pitch",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "series",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "jstConnectorsListGet"
+      },
+      "post": {
+        "summary": "/jst_connectors/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "jst_connectors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "pitch_mm": {
+                                "type": ["number"]
+                              },
+                              "num_rows": {
+                                "type": ["number"]
+                              },
+                              "num_pins": {
+                                "type": ["number"]
+                              },
+                              "reference_series": {
+                                "type": ["string"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr"]
+                          }
+                        }
+                      },
+                      "required": ["jst_connectors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "pitch": {
+                    "type": ["string"]
+                  },
+                  "series": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "pitch",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "series",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "jstConnectorsListPost"
+      }
+    },
+    "/lcd_display/list.json": {
+      "get": {
+        "summary": "/lcd_display/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "lcd_displays": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "display_size": {
+                            "type": ["string"]
+                          },
+                          "resolution": {
+                            "type": ["string"]
+                          },
+                          "display_type": {
+                            "type": ["string"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["lcd_displays"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "display_size": {
+                    "type": ["string"]
+                  },
+                  "resolution": {
+                    "type": ["string"]
+                  },
+                  "display_type": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "description": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "display_size",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "resolution",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "display_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "lcdDisplayList.jsonGet"
+      },
+      "post": {
+        "summary": "/lcd_display/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "lcd_displays": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "display_size": {
+                            "type": ["string"]
+                          },
+                          "resolution": {
+                            "type": ["string"]
+                          },
+                          "display_type": {
+                            "type": ["string"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["lcd_displays"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "display_size": {
+                    "type": ["string"]
+                  },
+                  "resolution": {
+                    "type": ["string"]
+                  },
+                  "display_type": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "description": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "display_size",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "resolution",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "display_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "lcdDisplayList.jsonPost"
+      }
+    },
+    "/lcd_display/list": {
+      "get": {
+        "summary": "/lcd_display/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "lcd_displays": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "display_size": {
+                            "type": ["string"]
+                          },
+                          "resolution": {
+                            "type": ["string"]
+                          },
+                          "display_type": {
+                            "type": ["string"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["lcd_displays"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "display_size": {
+                    "type": ["string"]
+                  },
+                  "resolution": {
+                    "type": ["string"]
+                  },
+                  "display_type": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "description": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "display_size",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "resolution",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "display_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "lcdDisplayListGet"
+      },
+      "post": {
+        "summary": "/lcd_display/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "lcd_displays": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "display_size": {
+                            "type": ["string"]
+                          },
+                          "resolution": {
+                            "type": ["string"]
+                          },
+                          "display_type": {
+                            "type": ["string"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["lcd_displays"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "display_size": {
+                    "type": ["string"]
+                  },
+                  "resolution": {
+                    "type": ["string"]
+                  },
+                  "display_type": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "description": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "display_size",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "resolution",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "display_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "lcdDisplayListPost"
+      }
+    },
+    "/ldos/list.json": {
+      "get": {
+        "summary": "/ldos/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "output_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["fixed", "adjustable", ""]
+            }
+          },
+          {
+            "name": "output_voltage",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          }
+        ],
+        "operationId": "ldosList.jsonGet"
+      }
+    },
+    "/ldos/list": {
+      "get": {
+        "summary": "/ldos/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "output_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["fixed", "adjustable", ""]
+            }
+          },
+          {
+            "name": "output_voltage",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          }
+        ],
+        "operationId": "ldosListGet"
+      }
+    },
+    "/led_dot_matrix_display/list.json": {
+      "get": {
+        "summary": "/led_dot_matrix_display/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "led_dot_matrix_displays": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "matrix_size": {
+                            "type": ["string"]
+                          },
+                          "color": {
+                            "type": ["string"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["led_dot_matrix_displays"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "matrix_size": {
+                    "type": ["string"]
+                  },
+                  "color": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "description": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "matrix_size",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "color",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "ledDotMatrixDisplayList.jsonGet"
+      },
+      "post": {
+        "summary": "/led_dot_matrix_display/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "led_dot_matrix_displays": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "matrix_size": {
+                            "type": ["string"]
+                          },
+                          "color": {
+                            "type": ["string"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["led_dot_matrix_displays"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "matrix_size": {
+                    "type": ["string"]
+                  },
+                  "color": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "description": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "matrix_size",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "color",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "ledDotMatrixDisplayList.jsonPost"
+      }
+    },
+    "/led_dot_matrix_display/list": {
+      "get": {
+        "summary": "/led_dot_matrix_display/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "led_dot_matrix_displays": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "matrix_size": {
+                            "type": ["string"]
+                          },
+                          "color": {
+                            "type": ["string"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["led_dot_matrix_displays"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "matrix_size": {
+                    "type": ["string"]
+                  },
+                  "color": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "description": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "matrix_size",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "color",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "ledDotMatrixDisplayListGet"
+      },
+      "post": {
+        "summary": "/led_dot_matrix_display/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "led_dot_matrix_displays": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "matrix_size": {
+                            "type": ["string"]
+                          },
+                          "color": {
+                            "type": ["string"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["led_dot_matrix_displays"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "matrix_size": {
+                    "type": ["string"]
+                  },
+                  "color": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "description": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "matrix_size",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "color",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "ledDotMatrixDisplayListPost"
+      }
+    },
+    "/led_drivers/list.json": {
+      "get": {
+        "summary": "/led_drivers/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "led_drivers": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["number"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "description": {
+                                "type": ["string"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number", "null"]
+                              },
+                              "in_stock": {
+                                "type": ["boolean"]
+                              },
+                              "package": {
+                                "type": ["string", "null"]
+                              },
+                              "supply_voltage_min": {
+                                "type": ["number", "null"]
+                              },
+                              "supply_voltage_max": {
+                                "type": ["number", "null"]
+                              },
+                              "output_current_max": {
+                                "type": ["number", "null"]
+                              },
+                              "channel_count": {
+                                "type": ["number", "null"]
+                              },
+                              "dimming_method": {
+                                "type": ["string", "null"]
+                              },
+                              "efficiency_percent": {
+                                "type": ["number", "null"]
+                              }
+                            },
+                            "required": [
+                              "lcsc",
+                              "mfr",
+                              "description",
+                              "stock",
+                              "price1",
+                              "in_stock",
+                              "package",
+                              "supply_voltage_min",
+                              "supply_voltage_max",
+                              "output_current_max",
+                              "channel_count",
+                              "dimming_method",
+                              "efficiency_percent"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["led_drivers"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "supply_voltage_min": {
+                    "type": ["number"]
+                  },
+                  "supply_voltage_max": {
+                    "type": ["number"]
+                  },
+                  "output_current_min": {
+                    "type": ["number"]
+                  },
+                  "output_current_max": {
+                    "type": ["number"]
+                  },
+                  "channel_count": {
+                    "type": ["number"]
+                  },
+                  "dimming_method": {
+                    "type": ["string"]
+                  },
+                  "efficiency_min": {
+                    "type": ["number"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "supply_voltage_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "supply_voltage_max",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "output_current_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "output_current_max",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "channel_count",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "dimming_method",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "efficiency_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          }
+        ],
+        "operationId": "ledDriversList.jsonGet"
+      }
+    },
+    "/led_drivers/list": {
+      "get": {
+        "summary": "/led_drivers/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "led_drivers": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["number"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "description": {
+                                "type": ["string"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number", "null"]
+                              },
+                              "in_stock": {
+                                "type": ["boolean"]
+                              },
+                              "package": {
+                                "type": ["string", "null"]
+                              },
+                              "supply_voltage_min": {
+                                "type": ["number", "null"]
+                              },
+                              "supply_voltage_max": {
+                                "type": ["number", "null"]
+                              },
+                              "output_current_max": {
+                                "type": ["number", "null"]
+                              },
+                              "channel_count": {
+                                "type": ["number", "null"]
+                              },
+                              "dimming_method": {
+                                "type": ["string", "null"]
+                              },
+                              "efficiency_percent": {
+                                "type": ["number", "null"]
+                              }
+                            },
+                            "required": [
+                              "lcsc",
+                              "mfr",
+                              "description",
+                              "stock",
+                              "price1",
+                              "in_stock",
+                              "package",
+                              "supply_voltage_min",
+                              "supply_voltage_max",
+                              "output_current_max",
+                              "channel_count",
+                              "dimming_method",
+                              "efficiency_percent"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["led_drivers"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "supply_voltage_min": {
+                    "type": ["number"]
+                  },
+                  "supply_voltage_max": {
+                    "type": ["number"]
+                  },
+                  "output_current_min": {
+                    "type": ["number"]
+                  },
+                  "output_current_max": {
+                    "type": ["number"]
+                  },
+                  "channel_count": {
+                    "type": ["number"]
+                  },
+                  "dimming_method": {
+                    "type": ["string"]
+                  },
+                  "efficiency_min": {
+                    "type": ["number"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "supply_voltage_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "supply_voltage_max",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "output_current_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "output_current_max",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "channel_count",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "dimming_method",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "efficiency_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          }
+        ],
+        "operationId": "ledDriversListGet"
+      }
+    },
+    "/led_segment_display/list.json": {
+      "get": {
+        "summary": "/led_segment_display/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "led_segment_displays": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "positions": {
+                            "type": ["string"]
+                          },
+                          "type": {
+                            "type": ["string"]
+                          },
+                          "size": {
+                            "type": ["string"]
+                          },
+                          "color": {
+                            "type": ["string"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["led_segment_displays"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "positions": {
+                    "type": ["string"]
+                  },
+                  "type": {
+                    "type": ["string"]
+                  },
+                  "size": {
+                    "type": ["string"]
+                  },
+                  "color": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "description": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "positions",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "color",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "ledSegmentDisplayList.jsonGet"
+      },
+      "post": {
+        "summary": "/led_segment_display/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "led_segment_displays": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "positions": {
+                            "type": ["string"]
+                          },
+                          "type": {
+                            "type": ["string"]
+                          },
+                          "size": {
+                            "type": ["string"]
+                          },
+                          "color": {
+                            "type": ["string"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["led_segment_displays"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "positions": {
+                    "type": ["string"]
+                  },
+                  "type": {
+                    "type": ["string"]
+                  },
+                  "size": {
+                    "type": ["string"]
+                  },
+                  "color": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "description": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "positions",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "color",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "ledSegmentDisplayList.jsonPost"
+      }
+    },
+    "/led_segment_display/list": {
+      "get": {
+        "summary": "/led_segment_display/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "led_segment_displays": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "positions": {
+                            "type": ["string"]
+                          },
+                          "type": {
+                            "type": ["string"]
+                          },
+                          "size": {
+                            "type": ["string"]
+                          },
+                          "color": {
+                            "type": ["string"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["led_segment_displays"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "positions": {
+                    "type": ["string"]
+                  },
+                  "type": {
+                    "type": ["string"]
+                  },
+                  "size": {
+                    "type": ["string"]
+                  },
+                  "color": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "description": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "positions",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "color",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "ledSegmentDisplayListGet"
+      },
+      "post": {
+        "summary": "/led_segment_display/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "led_segment_displays": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "positions": {
+                            "type": ["string"]
+                          },
+                          "type": {
+                            "type": ["string"]
+                          },
+                          "size": {
+                            "type": ["string"]
+                          },
+                          "color": {
+                            "type": ["string"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["led_segment_displays"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "positions": {
+                    "type": ["string"]
+                  },
+                  "type": {
+                    "type": ["string"]
+                  },
+                  "size": {
+                    "type": ["string"]
+                  },
+                  "color": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "description": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "positions",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "color",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "ledSegmentDisplayListPost"
+      }
+    },
+    "/led_with_ic/list.json": {
+      "get": {
+        "summary": "/led_with_ic/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "leds_with_ic": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "color": {
+                            "type": ["string"]
+                          },
+                          "protocol": {
+                            "type": ["string"]
+                          },
+                          "forward_voltage": {
+                            "type": ["number"]
+                          },
+                          "forward_current": {
+                            "type": ["number"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["leds_with_ic"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "color": {
+                    "type": ["string"]
+                  },
+                  "protocol": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "color",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "protocol",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "ledWithIcList.jsonGet"
+      },
+      "post": {
+        "summary": "/led_with_ic/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "leds_with_ic": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "color": {
+                            "type": ["string"]
+                          },
+                          "protocol": {
+                            "type": ["string"]
+                          },
+                          "forward_voltage": {
+                            "type": ["number"]
+                          },
+                          "forward_current": {
+                            "type": ["number"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["leds_with_ic"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "color": {
+                    "type": ["string"]
+                  },
+                  "protocol": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "color",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "protocol",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "ledWithIcList.jsonPost"
+      }
+    },
+    "/led_with_ic/list": {
+      "get": {
+        "summary": "/led_with_ic/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "leds_with_ic": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "color": {
+                            "type": ["string"]
+                          },
+                          "protocol": {
+                            "type": ["string"]
+                          },
+                          "forward_voltage": {
+                            "type": ["number"]
+                          },
+                          "forward_current": {
+                            "type": ["number"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["leds_with_ic"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "color": {
+                    "type": ["string"]
+                  },
+                  "protocol": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "color",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "protocol",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "ledWithIcListGet"
+      },
+      "post": {
+        "summary": "/led_with_ic/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "leds_with_ic": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "color": {
+                            "type": ["string"]
+                          },
+                          "protocol": {
+                            "type": ["string"]
+                          },
+                          "forward_voltage": {
+                            "type": ["number"]
+                          },
+                          "forward_current": {
+                            "type": ["number"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["leds_with_ic"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "color": {
+                    "type": ["string"]
+                  },
+                  "protocol": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "color",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "protocol",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "ledWithIcListPost"
+      }
+    },
+    "/leds/list.json": {
+      "get": {
+        "summary": "/leds/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "leds": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "color": {
+                                "type": ["string"]
+                              },
+                              "wavelength_nm": {
+                                "type": ["number"]
+                              },
+                              "forward_voltage": {
+                                "type": ["number"]
+                              },
+                              "forward_current": {
+                                "type": ["number"]
+                              },
+                              "luminous_intensity_mcd": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "package"]
+                          }
+                        }
+                      },
+                      "required": ["leds"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "color": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "color",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "ledsList.jsonGet"
+      },
+      "post": {
+        "summary": "/leds/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "leds": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "color": {
+                                "type": ["string"]
+                              },
+                              "wavelength_nm": {
+                                "type": ["number"]
+                              },
+                              "forward_voltage": {
+                                "type": ["number"]
+                              },
+                              "forward_current": {
+                                "type": ["number"]
+                              },
+                              "luminous_intensity_mcd": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "package"]
+                          }
+                        }
+                      },
+                      "required": ["leds"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "color": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "color",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "ledsList.jsonPost"
+      }
+    },
+    "/leds/list": {
+      "get": {
+        "summary": "/leds/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "leds": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "color": {
+                                "type": ["string"]
+                              },
+                              "wavelength_nm": {
+                                "type": ["number"]
+                              },
+                              "forward_voltage": {
+                                "type": ["number"]
+                              },
+                              "forward_current": {
+                                "type": ["number"]
+                              },
+                              "luminous_intensity_mcd": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "package"]
+                          }
+                        }
+                      },
+                      "required": ["leds"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "color": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "color",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "ledsListGet"
+      },
+      "post": {
+        "summary": "/leds/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "leds": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "color": {
+                                "type": ["string"]
+                              },
+                              "wavelength_nm": {
+                                "type": ["number"]
+                              },
+                              "forward_voltage": {
+                                "type": ["number"]
+                              },
+                              "forward_current": {
+                                "type": ["number"]
+                              },
+                              "luminous_intensity_mcd": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "package"]
+                          }
+                        }
+                      },
+                      "required": ["leds"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "color": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "color",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "ledsListPost"
+      }
+    },
+    "/microcontrollers/list.json": {
+      "get": {
+        "summary": "/microcontrollers/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "core",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "flash_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "ram_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "interface",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["uart", "i2c", "spi", "can", "usb", ""]
+            }
+          }
+        ],
+        "operationId": "microcontrollersList.jsonGet"
+      }
+    },
+    "/microcontrollers/list": {
+      "get": {
+        "summary": "/microcontrollers/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "core",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "flash_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "ram_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "interface",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["uart", "i2c", "spi", "can", "usb", ""]
+            }
+          }
+        ],
+        "operationId": "microcontrollersListGet"
+      }
+    },
+    "/mosfets/list.json": {
+      "get": {
+        "summary": "/mosfets/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "mosfets": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["number"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "description": {
+                                "type": ["string"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number", "null"]
+                              },
+                              "in_stock": {
+                                "type": ["boolean"]
+                              },
+                              "package": {
+                                "type": ["string", "null"]
+                              },
+                              "drain_source_voltage": {
+                                "type": ["number", "null"]
+                              },
+                              "continuous_drain_current": {
+                                "type": ["number", "null"]
+                              },
+                              "gate_threshold_voltage": {
+                                "type": ["number", "null"]
+                              },
+                              "power_dissipation": {
+                                "type": ["number", "null"]
+                              },
+                              "operating_temp_min": {
+                                "type": ["number", "null"]
+                              },
+                              "operating_temp_max": {
+                                "type": ["number", "null"]
+                              }
+                            },
+                            "required": [
+                              "lcsc",
+                              "mfr",
+                              "description",
+                              "stock",
+                              "price1",
+                              "in_stock",
+                              "package",
+                              "drain_source_voltage",
+                              "continuous_drain_current",
+                              "gate_threshold_voltage",
+                              "power_dissipation",
+                              "operating_temp_min",
+                              "operating_temp_max"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["mosfets"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "drain_source_voltage_min": {
+                    "type": ["number"]
+                  },
+                  "drain_source_voltage_max": {
+                    "type": ["number"]
+                  },
+                  "continuous_drain_current_min": {
+                    "type": ["number"]
+                  },
+                  "continuous_drain_current_max": {
+                    "type": ["number"]
+                  },
+                  "gate_threshold_voltage_min": {
+                    "type": ["number"]
+                  },
+                  "gate_threshold_voltage_max": {
+                    "type": ["number"]
+                  },
+                  "power_dissipation_min": {
+                    "type": ["number"]
+                  },
+                  "power_dissipation_max": {
+                    "type": ["number"]
+                  },
+                  "mounting_style": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "drain_source_voltage_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "drain_source_voltage_max",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "continuous_drain_current_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "continuous_drain_current_max",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "gate_threshold_voltage_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "gate_threshold_voltage_max",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "power_dissipation_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "power_dissipation_max",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "mounting_style",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "mosfetsList.jsonGet"
+      }
+    },
+    "/mosfets/list": {
+      "get": {
+        "summary": "/mosfets/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "mosfets": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["number"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "description": {
+                                "type": ["string"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number", "null"]
+                              },
+                              "in_stock": {
+                                "type": ["boolean"]
+                              },
+                              "package": {
+                                "type": ["string", "null"]
+                              },
+                              "drain_source_voltage": {
+                                "type": ["number", "null"]
+                              },
+                              "continuous_drain_current": {
+                                "type": ["number", "null"]
+                              },
+                              "gate_threshold_voltage": {
+                                "type": ["number", "null"]
+                              },
+                              "power_dissipation": {
+                                "type": ["number", "null"]
+                              },
+                              "operating_temp_min": {
+                                "type": ["number", "null"]
+                              },
+                              "operating_temp_max": {
+                                "type": ["number", "null"]
+                              }
+                            },
+                            "required": [
+                              "lcsc",
+                              "mfr",
+                              "description",
+                              "stock",
+                              "price1",
+                              "in_stock",
+                              "package",
+                              "drain_source_voltage",
+                              "continuous_drain_current",
+                              "gate_threshold_voltage",
+                              "power_dissipation",
+                              "operating_temp_min",
+                              "operating_temp_max"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["mosfets"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "drain_source_voltage_min": {
+                    "type": ["number"]
+                  },
+                  "drain_source_voltage_max": {
+                    "type": ["number"]
+                  },
+                  "continuous_drain_current_min": {
+                    "type": ["number"]
+                  },
+                  "continuous_drain_current_max": {
+                    "type": ["number"]
+                  },
+                  "gate_threshold_voltage_min": {
+                    "type": ["number"]
+                  },
+                  "gate_threshold_voltage_max": {
+                    "type": ["number"]
+                  },
+                  "power_dissipation_min": {
+                    "type": ["number"]
+                  },
+                  "power_dissipation_max": {
+                    "type": ["number"]
+                  },
+                  "mounting_style": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "drain_source_voltage_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "drain_source_voltage_max",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "continuous_drain_current_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "continuous_drain_current_max",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "gate_threshold_voltage_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "gate_threshold_voltage_max",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "power_dissipation_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "power_dissipation_max",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "mounting_style",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "mosfetsListGet"
+      }
+    },
+    "/oled_display/list.json": {
+      "get": {
+        "summary": "/oled_display/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "oled_displays": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "protocol": {
+                            "type": ["string"]
+                          },
+                          "display_width": {
+                            "type": ["string"]
+                          },
+                          "pixel_resolution": {
+                            "type": ["string"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["oled_displays"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "protocol": {
+                    "type": ["string"]
+                  },
+                  "display_width": {
+                    "type": ["string"]
+                  },
+                  "pixel_resolution": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "description": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "protocol",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "display_width",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "pixel_resolution",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "oledDisplayList.jsonGet"
+      },
+      "post": {
+        "summary": "/oled_display/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "oled_displays": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "protocol": {
+                            "type": ["string"]
+                          },
+                          "display_width": {
+                            "type": ["string"]
+                          },
+                          "pixel_resolution": {
+                            "type": ["string"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["oled_displays"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "protocol": {
+                    "type": ["string"]
+                  },
+                  "display_width": {
+                    "type": ["string"]
+                  },
+                  "pixel_resolution": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "description": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "protocol",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "display_width",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "pixel_resolution",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "oledDisplayList.jsonPost"
+      }
+    },
+    "/oled_display/list": {
+      "get": {
+        "summary": "/oled_display/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "oled_displays": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "protocol": {
+                            "type": ["string"]
+                          },
+                          "display_width": {
+                            "type": ["string"]
+                          },
+                          "pixel_resolution": {
+                            "type": ["string"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["oled_displays"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "protocol": {
+                    "type": ["string"]
+                  },
+                  "display_width": {
+                    "type": ["string"]
+                  },
+                  "pixel_resolution": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "description": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "protocol",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "display_width",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "pixel_resolution",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "oledDisplayListGet"
+      },
+      "post": {
+        "summary": "/oled_display/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object"],
+                  "properties": {
+                    "oled_displays": {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["object"],
+                        "properties": {
+                          "lcsc": {
+                            "type": ["number"]
+                          },
+                          "mfr": {
+                            "type": ["string"]
+                          },
+                          "package": {
+                            "type": ["string"]
+                          },
+                          "description": {
+                            "type": ["string"]
+                          },
+                          "stock": {
+                            "type": ["number"]
+                          },
+                          "price1": {
+                            "type": ["number"]
+                          },
+                          "protocol": {
+                            "type": ["string"]
+                          },
+                          "display_width": {
+                            "type": ["string"]
+                          },
+                          "pixel_resolution": {
+                            "type": ["string"]
+                          }
+                        },
+                        "required": [
+                          "lcsc",
+                          "mfr",
+                          "package",
+                          "description",
+                          "stock",
+                          "price1"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["oled_displays"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "protocol": {
+                    "type": ["string"]
+                  },
+                  "display_width": {
+                    "type": ["string"]
+                  },
+                  "pixel_resolution": {
+                    "type": ["string"]
+                  },
+                  "mfr": {
+                    "type": ["string"]
+                  },
+                  "description": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "protocol",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "display_width",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "pixel_resolution",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "mfr",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "oledDisplayListPost"
+      }
+    },
+    "/pcie_m2_connectors/list.json": {
+      "get": {
+        "summary": "/pcie_m2_connectors/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "pcie_m2_connectors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "key": {
+                                "type": ["string", "null"]
+                              },
+                              "is_right_angle": {
+                                "type": ["boolean"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "key"]
+                          }
+                        }
+                      },
+                      "required": ["pcie_m2_connectors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "key": {
+                    "type": ["string"]
+                  },
+                  "is_right_angle": {
+                    "type": ["boolean"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "is_right_angle",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          }
+        ],
+        "operationId": "pcieM2ConnectorsList.jsonGet"
+      },
+      "post": {
+        "summary": "/pcie_m2_connectors/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "pcie_m2_connectors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "key": {
+                                "type": ["string", "null"]
+                              },
+                              "is_right_angle": {
+                                "type": ["boolean"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "key"]
+                          }
+                        }
+                      },
+                      "required": ["pcie_m2_connectors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "key": {
+                    "type": ["string"]
+                  },
+                  "is_right_angle": {
+                    "type": ["boolean"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "is_right_angle",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          }
+        ],
+        "operationId": "pcieM2ConnectorsList.jsonPost"
+      }
+    },
+    "/pcie_m2_connectors/list": {
+      "get": {
+        "summary": "/pcie_m2_connectors/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "pcie_m2_connectors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "key": {
+                                "type": ["string", "null"]
+                              },
+                              "is_right_angle": {
+                                "type": ["boolean"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "key"]
+                          }
+                        }
+                      },
+                      "required": ["pcie_m2_connectors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "key": {
+                    "type": ["string"]
+                  },
+                  "is_right_angle": {
+                    "type": ["boolean"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "is_right_angle",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          }
+        ],
+        "operationId": "pcieM2ConnectorsListGet"
+      },
+      "post": {
+        "summary": "/pcie_m2_connectors/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "pcie_m2_connectors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "key": {
+                                "type": ["string", "null"]
+                              },
+                              "is_right_angle": {
+                                "type": ["boolean"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "key"]
+                          }
+                        }
+                      },
+                      "required": ["pcie_m2_connectors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "key": {
+                    "type": ["string"]
+                  },
+                  "is_right_angle": {
+                    "type": ["boolean"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "is_right_angle",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          }
+        ],
+        "operationId": "pcieM2ConnectorsListPost"
+      }
+    },
+    "/potentiometers/list.json": {
+      "get": {
+        "summary": "/potentiometers/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "potentiometers": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "maxResistance": {
+                                "type": ["number"]
+                              },
+                              "pinVariant": {
+                                "type": ["string"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": [
+                              "lcsc",
+                              "mfr",
+                              "package",
+                              "maxResistance",
+                              "pinVariant"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["potentiometers"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "maxResistance": {
+                    "type": ["string"]
+                  },
+                  "pinVariant": {
+                    "type": ["string"],
+                    "enum": ["two_pin", "three_pin"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "maxResistance",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "pinVariant",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["two_pin", "three_pin"]
+            }
+          }
+        ],
+        "operationId": "potentiometersList.jsonGet"
+      }
+    },
+    "/potentiometers/list": {
+      "get": {
+        "summary": "/potentiometers/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "potentiometers": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "maxResistance": {
+                                "type": ["number"]
+                              },
+                              "pinVariant": {
+                                "type": ["string"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": [
+                              "lcsc",
+                              "mfr",
+                              "package",
+                              "maxResistance",
+                              "pinVariant"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["potentiometers"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "maxResistance": {
+                    "type": ["string"]
+                  },
+                  "pinVariant": {
+                    "type": ["string"],
+                    "enum": ["two_pin", "three_pin"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "maxResistance",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "pinVariant",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["two_pin", "three_pin"]
+            }
+          }
+        ],
+        "operationId": "potentiometersListGet"
+      }
+    },
+    "/relays/list.json": {
+      "get": {
+        "summary": "/relays/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "relays": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "relay_type": {
+                                "type": ["string"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "package", "relay_type"]
+                          }
+                        }
+                      },
+                      "required": ["relays"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "relay_type": {
+                    "type": ["string"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "relay_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "relaysList.jsonGet"
+      },
+      "post": {
+        "summary": "/relays/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "relays": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "relay_type": {
+                                "type": ["string"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "package", "relay_type"]
+                          }
+                        }
+                      },
+                      "required": ["relays"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "relay_type": {
+                    "type": ["string"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "relay_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "relaysList.jsonPost"
+      }
+    },
+    "/relays/list": {
+      "get": {
+        "summary": "/relays/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "relays": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "relay_type": {
+                                "type": ["string"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "package", "relay_type"]
+                          }
+                        }
+                      },
+                      "required": ["relays"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "relay_type": {
+                    "type": ["string"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "relay_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "relaysListGet"
+      },
+      "post": {
+        "summary": "/relays/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "relays": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "relay_type": {
+                                "type": ["string"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "package", "relay_type"]
+                          }
+                        }
+                      },
+                      "required": ["relays"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "relay_type": {
+                    "type": ["string"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "relay_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "relaysListPost"
+      }
+    },
+    "/resistors/list.json": {
+      "get": {
+        "summary": "/resistors/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "resistors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "is_basic": {
+                                "type": ["boolean"]
+                              },
+                              "resistance": {
+                                "type": ["number"]
+                              },
+                              "tolerance_fraction": {
+                                "type": ["number"]
+                              },
+                              "power_watts": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": [
+                              "lcsc",
+                              "mfr",
+                              "package",
+                              "is_basic",
+                              "resistance"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["resistors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "is_basic": {
+                    "type": ["boolean"]
+                  },
+                  "resistance": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "is_basic",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "resistance",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "resistorsList.jsonGet"
+      },
+      "post": {
+        "summary": "/resistors/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "resistors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "is_basic": {
+                                "type": ["boolean"]
+                              },
+                              "resistance": {
+                                "type": ["number"]
+                              },
+                              "tolerance_fraction": {
+                                "type": ["number"]
+                              },
+                              "power_watts": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": [
+                              "lcsc",
+                              "mfr",
+                              "package",
+                              "is_basic",
+                              "resistance"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["resistors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "is_basic": {
+                    "type": ["boolean"]
+                  },
+                  "resistance": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "is_basic",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "resistance",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "resistorsList.jsonPost"
+      }
+    },
+    "/resistors/list": {
+      "get": {
+        "summary": "/resistors/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "resistors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "is_basic": {
+                                "type": ["boolean"]
+                              },
+                              "resistance": {
+                                "type": ["number"]
+                              },
+                              "tolerance_fraction": {
+                                "type": ["number"]
+                              },
+                              "power_watts": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": [
+                              "lcsc",
+                              "mfr",
+                              "package",
+                              "is_basic",
+                              "resistance"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["resistors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "is_basic": {
+                    "type": ["boolean"]
+                  },
+                  "resistance": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "is_basic",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "resistance",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "resistorsListGet"
+      },
+      "post": {
+        "summary": "/resistors/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "resistors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "is_basic": {
+                                "type": ["boolean"]
+                              },
+                              "resistance": {
+                                "type": ["number"]
+                              },
+                              "tolerance_fraction": {
+                                "type": ["number"]
+                              },
+                              "power_watts": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": [
+                              "lcsc",
+                              "mfr",
+                              "package",
+                              "is_basic",
+                              "resistance"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["resistors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "is_basic": {
+                    "type": ["boolean"]
+                  },
+                  "resistance": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "is_basic",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "resistance",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "resistorsListPost"
+      }
+    },
+    "/risc_v_processors/list.json": {
+      "get": {
+        "summary": "/risc_v_processors/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "flash_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "ram_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "interface",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["uart", "i2c", "spi", "can", "usb", ""]
+            }
+          }
+        ],
+        "operationId": "riscVProcessorsList.jsonGet"
+      }
+    },
+    "/risc_v_processors/list": {
+      "get": {
+        "summary": "/risc_v_processors/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "flash_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "ram_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "interface",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["uart", "i2c", "spi", "can", "usb", ""]
+            }
+          }
+        ],
+        "operationId": "riscVProcessorsListGet"
+      }
+    },
+    "/switches/list.json": {
+      "get": {
+        "summary": "/switches/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "switches": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "switch_type": {
+                                "type": ["string"]
+                              },
+                              "circuit": {
+                                "type": ["string"]
+                              },
+                              "pin_count": {
+                                "type": ["number"]
+                              },
+                              "width_mm": {
+                                "type": ["number"]
+                              },
+                              "length_mm": {
+                                "type": ["number"]
+                              },
+                              "switch_height_mm": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": [
+                              "lcsc",
+                              "mfr",
+                              "package",
+                              "switch_type"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["switches"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "switch_type": {
+                    "type": ["string"]
+                  },
+                  "circuit": {
+                    "type": ["string"]
+                  },
+                  "pin_count": {
+                    "type": ["number"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "switch_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "circuit",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "pin_count",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "switchesList.jsonGet"
+      },
+      "post": {
+        "summary": "/switches/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "switches": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "switch_type": {
+                                "type": ["string"]
+                              },
+                              "circuit": {
+                                "type": ["string"]
+                              },
+                              "pin_count": {
+                                "type": ["number"]
+                              },
+                              "width_mm": {
+                                "type": ["number"]
+                              },
+                              "length_mm": {
+                                "type": ["number"]
+                              },
+                              "switch_height_mm": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": [
+                              "lcsc",
+                              "mfr",
+                              "package",
+                              "switch_type"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["switches"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "switch_type": {
+                    "type": ["string"]
+                  },
+                  "circuit": {
+                    "type": ["string"]
+                  },
+                  "pin_count": {
+                    "type": ["number"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "switch_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "circuit",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "pin_count",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "switchesList.jsonPost"
+      }
+    },
+    "/switches/list": {
+      "get": {
+        "summary": "/switches/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "switches": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "switch_type": {
+                                "type": ["string"]
+                              },
+                              "circuit": {
+                                "type": ["string"]
+                              },
+                              "pin_count": {
+                                "type": ["number"]
+                              },
+                              "width_mm": {
+                                "type": ["number"]
+                              },
+                              "length_mm": {
+                                "type": ["number"]
+                              },
+                              "switch_height_mm": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": [
+                              "lcsc",
+                              "mfr",
+                              "package",
+                              "switch_type"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["switches"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "switch_type": {
+                    "type": ["string"]
+                  },
+                  "circuit": {
+                    "type": ["string"]
+                  },
+                  "pin_count": {
+                    "type": ["number"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "switch_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "circuit",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "pin_count",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "switchesListGet"
+      },
+      "post": {
+        "summary": "/switches/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "switches": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "switch_type": {
+                                "type": ["string"]
+                              },
+                              "circuit": {
+                                "type": ["string"]
+                              },
+                              "pin_count": {
+                                "type": ["number"]
+                              },
+                              "width_mm": {
+                                "type": ["number"]
+                              },
+                              "length_mm": {
+                                "type": ["number"]
+                              },
+                              "switch_height_mm": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": [
+                              "lcsc",
+                              "mfr",
+                              "package",
+                              "switch_type"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["switches"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "switch_type": {
+                    "type": ["string"]
+                  },
+                  "circuit": {
+                    "type": ["string"]
+                  },
+                  "pin_count": {
+                    "type": ["number"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "switch_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "circuit",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "pin_count",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          }
+        ],
+        "operationId": "switchesListPost"
+      }
+    },
+    "/usb_c_connectors/list.json": {
+      "get": {
+        "summary": "/usb_c_connectors/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "usb_c_connectors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "gender": {
+                                "type": ["string"]
+                              },
+                              "number_of_contacts": {
+                                "type": ["number"]
+                              },
+                              "current_rating_a": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "package"]
+                          }
+                        }
+                      },
+                      "required": ["usb_c_connectors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "gender": {
+                    "type": ["string"],
+                    "enum": ["Male", "Female"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "gender",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["Male", "Female"]
+            }
+          }
+        ],
+        "operationId": "usbCConnectorsList.jsonGet"
+      },
+      "post": {
+        "summary": "/usb_c_connectors/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "usb_c_connectors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "gender": {
+                                "type": ["string"]
+                              },
+                              "number_of_contacts": {
+                                "type": ["number"]
+                              },
+                              "current_rating_a": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "package"]
+                          }
+                        }
+                      },
+                      "required": ["usb_c_connectors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "gender": {
+                    "type": ["string"],
+                    "enum": ["Male", "Female"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "gender",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["Male", "Female"]
+            }
+          }
+        ],
+        "operationId": "usbCConnectorsList.jsonPost"
+      }
+    },
+    "/usb_c_connectors/list": {
+      "get": {
+        "summary": "/usb_c_connectors/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "usb_c_connectors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "gender": {
+                                "type": ["string"]
+                              },
+                              "number_of_contacts": {
+                                "type": ["number"]
+                              },
+                              "current_rating_a": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "package"]
+                          }
+                        }
+                      },
+                      "required": ["usb_c_connectors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "gender": {
+                    "type": ["string"],
+                    "enum": ["Male", "Female"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "gender",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["Male", "Female"]
+            }
+          }
+        ],
+        "operationId": "usbCConnectorsListGet"
+      },
+      "post": {
+        "summary": "/usb_c_connectors/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": ["string"]
+                    },
+                    {
+                      "type": ["object"],
+                      "properties": {
+                        "usb_c_connectors": {
+                          "type": ["array"],
+                          "items": {
+                            "type": ["object"],
+                            "properties": {
+                              "lcsc": {
+                                "type": ["integer"]
+                              },
+                              "mfr": {
+                                "type": ["string"]
+                              },
+                              "package": {
+                                "type": ["string"]
+                              },
+                              "gender": {
+                                "type": ["string"]
+                              },
+                              "number_of_contacts": {
+                                "type": ["number"]
+                              },
+                              "current_rating_a": {
+                                "type": ["number"]
+                              },
+                              "stock": {
+                                "type": ["number"]
+                              },
+                              "price1": {
+                                "type": ["number"]
+                              }
+                            },
+                            "required": ["lcsc", "mfr", "package"]
+                          }
+                        }
+                      },
+                      "required": ["usb_c_connectors"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": ["object"],
+                "properties": {
+                  "json": {
+                    "type": ["boolean"]
+                  },
+                  "package": {
+                    "type": ["string"]
+                  },
+                  "gender": {
+                    "type": ["string"],
+                    "enum": ["Male", "Female"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "json",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "gender",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["Male", "Female"]
+            }
+          }
+        ],
+        "operationId": "usbCConnectorsListPost"
+      }
+    },
+    "/voltage_regulators/list.json": {
+      "get": {
+        "summary": "/voltage_regulators/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "output_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["fixed", "adjustable", ""]
+            }
+          },
+          {
+            "name": "is_ldo",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "output_voltage",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          }
+        ],
+        "operationId": "voltageRegulatorsList.jsonGet"
+      }
+    },
+    "/voltage_regulators/list": {
+      "get": {
+        "summary": "/voltage_regulators/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "output_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["fixed", "adjustable", ""]
+            }
+          },
+          {
+            "name": "is_ldo",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "output_voltage",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          }
+        ],
+        "operationId": "voltageRegulatorsListGet"
+      }
+    },
+    "/wifi_modules/list.json": {
+      "get": {
+        "summary": "/wifi_modules/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "core_processor",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "antenna_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "interface",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["uart", "spi", "i2c", "gpio", "adc", "pwm", ""]
+            }
+          }
+        ],
+        "operationId": "wifiModulesList.jsonGet"
+      }
+    },
+    "/wifi_modules/list": {
+      "get": {
+        "summary": "/wifi_modules/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "core_processor",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "antenna_type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "interface",
+            "in": "query",
+            "schema": {
+              "type": ["string"],
+              "enum": ["uart", "spi", "i2c", "gpio", "adc", "pwm", ""]
+            }
+          }
+        ],
+        "operationId": "wifiModulesListGet"
+      }
+    },
+    "/": {
+      "head": {
+        "summary": "/",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "operationId": "Head"
+      },
+      "get": {
+        "summary": "/",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "operationId": "Get"
+      },
+      "post": {
+        "summary": "/",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "operationId": "Post"
+      }
+    }
+  }
+}

--- a/lib/db/get-db-client.ts
+++ b/lib/db/get-db-client.ts
@@ -1,17 +1,71 @@
-import { Database } from "bun:sqlite"
-import { Kysely, SqliteDialect } from "kysely"
+import type { Database as BunDatabase } from "bun:sqlite"
+import type { Kysely } from "kysely"
+import type { BunSqliteDialect } from "kysely-bun-sqlite"
 import Path from "node:path"
 import type { DB } from "./generated/kysely"
-import { BunSqliteDialect } from "kysely-bun-sqlite"
+
+let DatabaseCtor: typeof BunDatabase | undefined
+let databaseImportError: unknown
+
+let KyselyCtor: typeof Kysely | undefined
+let kyselyImportError: unknown
+
+let BunSqliteDialectCtor: typeof BunSqliteDialect | undefined
+let bunSqliteImportError: unknown
+
+if (process.env.WINTERSPEC_CODEGEN !== "true") {
+  try {
+    const sqliteModule = await import("bun:sqlite")
+    DatabaseCtor = sqliteModule.Database
+  } catch (err) {
+    databaseImportError = err
+  }
+
+  try {
+    const kyselyModule = await import("kysely")
+    KyselyCtor = kyselyModule.Kysely
+  } catch (err) {
+    kyselyImportError = err
+  }
+
+  try {
+    const bunSqliteModule = await import("kysely-bun-sqlite")
+    BunSqliteDialectCtor = bunSqliteModule.BunSqliteDialect
+  } catch (err) {
+    bunSqliteImportError = err
+  }
+}
+
+const getDatabaseCtor = (): typeof BunDatabase => {
+  if (!DatabaseCtor) {
+    throw databaseImportError instanceof Error
+      ? databaseImportError
+      : new Error("bun:sqlite is not available in this environment")
+  }
+  return DatabaseCtor
+}
 
 export const getDbClient = () => {
-  return new Kysely<DB>({
-    dialect: new BunSqliteDialect({
-      database: getBunDatabaseClient(),
+  const Database = getDatabaseCtor()
+  const KyselyCtorRef = KyselyCtor
+  const BunSqliteDialectRef = BunSqliteDialectCtor
+
+  if (!KyselyCtorRef || !BunSqliteDialectRef) {
+    throw (
+      kyselyImportError ||
+      bunSqliteImportError ||
+      new Error("Database dependencies are not available in this environment")
+    )
+  }
+
+  return new KyselyCtorRef<DB>({
+    dialect: new BunSqliteDialectRef({
+      database: new Database(Path.join(import.meta.dir, "../../db.sqlite3")),
     }),
   })
 }
 
 export const getBunDatabaseClient = () => {
+  const Database = getDatabaseCtor()
   return new Database(Path.join(import.meta.dir, "../../db.sqlite3"))
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "setup:optimize-db": "bun run scripts/setup-db-optimizations.ts",
     "setup:derived-tables": "bun run scripts/setup-derived-tables.ts",
     "setup:download": "curl -o db.sqlite \"https://jlcsearch.fly.dev/database/$DATABASE_DOWNLOAD_TOKEN\"",
+    "generate:openapi": "mkdir -p .tmp && TMPDIR=$(pwd)/.tmp WINTERSPEC_CODEGEN=true bunx winterspec codegen openapi --root . --routes-directory ./routes --platform node --tsconfig tsconfig.json --output docs/openapi.json",
     "format": "biome format --write .",
     "format:check": "biome format ."
   },

--- a/winterspec.config.ts
+++ b/winterspec.config.ts
@@ -1,6 +1,4 @@
-import { defineConfig } from "winterspec"
-
-export default defineConfig({
+export default {
   routesDirectory: "./routes",
   platform: "node",
-})
+}


### PR DESCRIPTION
## Summary
- add a package script that wraps the Winterspec CLI to regenerate docs/openapi.json with the right environment configuration
- defer loading of Kysely and its Bun dialect when running in Winterspec codegen mode so Node-based tooling can import the database helper safely

## Testing
- bunx tsc --noEmit
- bun run generate:openapi
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68e574291d4c832ebf16509f859631e9