### PR TITLE
Fix test cleanup by using global deferred queue

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,5 +1,5 @@
-# [test]
-# preload = ["./tests/fixtures/preload.ts"]
+[test]
+preload = ["./tests/preload.ts"]
 
 [install.lockfile]
 save = false

--- a/tests/fixtures/get-test-server.ts
+++ b/tests/fixtures/get-test-server.ts
@@ -1,4 +1,3 @@
-import { afterEach } from "bun:test"
 import defaultAxios from "redaxios"
 import type { KyselyDatabaseInstance } from "lib/db/kysely-types"
 import * as Path from "node:path"
@@ -47,7 +46,8 @@ export const getTestServer = async (
     headers: {},
   })
 
-  afterEach(async () => {
+  globalThis.deferredCleanupFns ??= []
+  globalThis.deferredCleanupFns.push(async () => {
     await server.stop()
   })
 

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -1,0 +1,19 @@
+import { afterEach } from "bun:test"
+
+declare global {
+  var deferredCleanupFns: Array<() => void | Promise<void>>
+}
+
+globalThis.deferredCleanupFns ??= []
+
+afterEach(async () => {
+  const cleanupFns = [...globalThis.deferredCleanupFns]
+  globalThis.deferredCleanupFns.length = 0
+
+  for (let index = cleanupFns.length - 1; index >= 0; index -= 1) {
+    const cleanup = cleanupFns[index]
+    await cleanup()
+  }
+})
+
+export {}


### PR DESCRIPTION
## Summary
- configure the Bun test runner to load a preload module
- add a preload cleanup queue that runs after each test
- update the test server fixture to register its cleanup with the queue

## Testing
- bunx tsc --noEmit
- bun test tests/routes/health.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68e5889f6c30832e84553ba2a41de01b