### PR TITLE
Add OpenAPI link to header navigation

### DIFF
--- a/lib/middlewares/with-ctx-react.tsx
+++ b/lib/middlewares/with-ctx-react.tsx
@@ -121,6 +121,7 @@ button {
                       json
                     </a>
                   )}
+                  <a href="/docs/openapi.json">OpenAPI</a>
                   <a href="https://tscircuit.com">tscircuit</a>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- add an OpenAPI schema link to the site header navigation

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68e5a9d2275c832e8c87924663b122d6