### PR TITLE
Fix OpenAPI link and update API title

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "WinterSpec API",
+    "title": "JLCSearch JLCPCB In-Stock Parts Engine API",
     "version": "1.0.0"
   },
   "paths": {

--- a/lib/middlewares/with-ctx-react.tsx
+++ b/lib/middlewares/with-ctx-react.tsx
@@ -121,7 +121,9 @@ button {
                       json
                     </a>
                   )}
-                  <a href="/docs/openapi.json">OpenAPI</a>
+                  <a href="https://raw.githubusercontent.com/tscircuit/jlcsearch/refs/heads/main/docs/openapi.json">
+                    OpenAPI
+                  </a>
                   <a href="https://tscircuit.com">tscircuit</a>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- update the navigation OpenAPI link to point at the raw GitHub URL used in production
- rename the OpenAPI spec title to "JLCSearch JLCPCB In-Stock Parts Engine API"

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_690232d2e424832e99bf8308376c2b36