### PR TITLE
Add FPGA listing page and API

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "JLCSearch JLCPCB In-Stock Parts Engine API",
+    "title": "WinterSpec API",
     "version": "1.0.0"
   },
   "paths": {
@@ -605,6 +605,13 @@
           },
           {
             "name": "is_basic",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "is_preferred",
             "in": "query",
             "schema": {
               "type": ["boolean"]
@@ -1763,6 +1770,9 @@
                               "is_basic": {
                                 "type": ["boolean"]
                               },
+                              "is_preferred": {
+                                "type": ["boolean"]
+                              },
                               "capacitance": {
                                 "type": ["number"]
                               },
@@ -1784,6 +1794,7 @@
                               "mfr",
                               "package",
                               "is_basic",
+                              "is_preferred",
                               "capacitance"
                             ]
                           }
@@ -1818,6 +1829,9 @@
                   "is_basic": {
                     "type": ["boolean"]
                   },
+                  "is_preferred": {
+                    "type": ["boolean"]
+                  },
                   "capacitance": {
                     "type": ["string"]
                   }
@@ -1843,6 +1857,13 @@
           },
           {
             "name": "is_basic",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "is_preferred",
             "in": "query",
             "schema": {
               "type": ["boolean"]
@@ -1892,6 +1913,9 @@
                               "is_basic": {
                                 "type": ["boolean"]
                               },
+                              "is_preferred": {
+                                "type": ["boolean"]
+                              },
                               "capacitance": {
                                 "type": ["number"]
                               },
@@ -1913,6 +1937,7 @@
                               "mfr",
                               "package",
                               "is_basic",
+                              "is_preferred",
                               "capacitance"
                             ]
                           }
@@ -1947,6 +1972,9 @@
                   "is_basic": {
                     "type": ["boolean"]
                   },
+                  "is_preferred": {
+                    "type": ["boolean"]
+                  },
                   "capacitance": {
                     "type": ["string"]
                   }
@@ -1972,6 +2000,13 @@
           },
           {
             "name": "is_basic",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "is_preferred",
             "in": "query",
             "schema": {
               "type": ["boolean"]
@@ -2162,6 +2197,13 @@
             "schema": {
               "type": ["boolean"]
             }
+          },
+          {
+            "name": "is_preferred",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
           }
         ],
         "operationId": "componentsList.jsonGet"
@@ -2217,6 +2259,13 @@
           },
           {
             "name": "is_basic",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "is_preferred",
             "in": "query",
             "schema": {
               "type": ["boolean"]
@@ -3016,6 +3065,124 @@
           }
         ],
         "operationId": "fpcConnectorsListPost"
+      }
+    },
+    "/fpgas/list.json": {
+      "get": {
+        "summary": "/fpgas/list.json",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "logic_elements_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "logic_array_blocks_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "embedded_ram_min_bits",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          }
+        ],
+        "operationId": "fpgasList.jsonGet"
+      }
+    },
+    "/fpgas/list": {
+      "get": {
+        "summary": "/fpgas/list",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "package",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "type": ["string"]
+            }
+          },
+          {
+            "name": "logic_elements_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "logic_array_blocks_min",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          },
+          {
+            "name": "embedded_ram_min_bits",
+            "in": "query",
+            "schema": {
+              "type": ["number"]
+            }
+          }
+        ],
+        "operationId": "fpgasListGet"
       }
     },
     "/fuses/list.json": {
@@ -10601,6 +10768,9 @@
                               "is_basic": {
                                 "type": ["boolean"]
                               },
+                              "is_preferred": {
+                                "type": ["boolean"]
+                              },
                               "resistance": {
                                 "type": ["number"]
                               },
@@ -10622,6 +10792,7 @@
                               "mfr",
                               "package",
                               "is_basic",
+                              "is_preferred",
                               "resistance"
                             ]
                           }
@@ -10656,6 +10827,9 @@
                   "is_basic": {
                     "type": ["boolean"]
                   },
+                  "is_preferred": {
+                    "type": ["boolean"]
+                  },
                   "resistance": {
                     "type": ["string"]
                   }
@@ -10681,6 +10855,13 @@
           },
           {
             "name": "is_basic",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "is_preferred",
             "in": "query",
             "schema": {
               "type": ["boolean"]
@@ -10728,6 +10909,9 @@
                               "is_basic": {
                                 "type": ["boolean"]
                               },
+                              "is_preferred": {
+                                "type": ["boolean"]
+                              },
                               "resistance": {
                                 "type": ["number"]
                               },
@@ -10749,6 +10933,7 @@
                               "mfr",
                               "package",
                               "is_basic",
+                              "is_preferred",
                               "resistance"
                             ]
                           }
@@ -10783,6 +10968,9 @@
                   "is_basic": {
                     "type": ["boolean"]
                   },
+                  "is_preferred": {
+                    "type": ["boolean"]
+                  },
                   "resistance": {
                     "type": ["string"]
                   }
@@ -10808,6 +10996,13 @@
           },
           {
             "name": "is_basic",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "is_preferred",
             "in": "query",
             "schema": {
               "type": ["boolean"]
@@ -10857,6 +11052,9 @@
                               "is_basic": {
                                 "type": ["boolean"]
                               },
+                              "is_preferred": {
+                                "type": ["boolean"]
+                              },
                               "resistance": {
                                 "type": ["number"]
                               },
@@ -10878,6 +11076,7 @@
                               "mfr",
                               "package",
                               "is_basic",
+                              "is_preferred",
                               "resistance"
                             ]
                           }
@@ -10912,6 +11111,9 @@
                   "is_basic": {
                     "type": ["boolean"]
                   },
+                  "is_preferred": {
+                    "type": ["boolean"]
+                  },
                   "resistance": {
                     "type": ["string"]
                   }
@@ -10937,6 +11139,13 @@
           },
           {
             "name": "is_basic",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "is_preferred",
             "in": "query",
             "schema": {
               "type": ["boolean"]
@@ -10984,6 +11193,9 @@
                               "is_basic": {
                                 "type": ["boolean"]
                               },
+                              "is_preferred": {
+                                "type": ["boolean"]
+                              },
                               "resistance": {
                                 "type": ["number"]
                               },
@@ -11005,6 +11217,7 @@
                               "mfr",
                               "package",
                               "is_basic",
+                              "is_preferred",
                               "resistance"
                             ]
                           }
@@ -11039,6 +11252,9 @@
                   "is_basic": {
                     "type": ["boolean"]
                   },
+                  "is_preferred": {
+                    "type": ["boolean"]
+                  },
                   "resistance": {
                     "type": ["string"]
                   }
@@ -11064,6 +11280,13 @@
           },
           {
             "name": "is_basic",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "is_preferred",
             "in": "query",
             "schema": {
               "type": ["boolean"]

--- a/lib/db/derivedtables/fpga.ts
+++ b/lib/db/derivedtables/fpga.ts
@@ -1,0 +1,119 @@
+import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import type { DerivedTableSpec } from "./types"
+import { BaseComponent } from "./component-base"
+
+export interface FPGA extends BaseComponent {
+  package: string
+  type: string | null
+  logic_array_blocks: number | null
+  logic_elements: number | null
+  embedded_ram_bits: number | null
+  supply_voltage_min: number | null
+  supply_voltage_max: number | null
+  operating_temp_min: number | null
+  operating_temp_max: number | null
+  max_delay_ns: number | null
+  logic_gates: number | null
+}
+
+const SUBCATEGORY_MATCHES = [
+  "Programmable Logic Device (CPLDs/FPGAs)",
+  "CPLD/FPGA",
+  "CPLD & FPGA",
+]
+
+const parseNumericValue = (value?: string | null): number | null => {
+  if (!value) return null
+  const cleaned = value.replace(/[,\s]/g, "")
+  const match = cleaned.match(/(-?[\d.]+)([kKmMgG]?)/)
+  if (!match) return null
+  let numeric = parseFloat(match[1]!)
+  const suffix = match[2]?.toLowerCase()
+  if (suffix === "k") numeric *= 1e3
+  else if (suffix === "m") numeric *= 1e6
+  else if (suffix === "g") numeric *= 1e9
+  if (Number.isNaN(numeric)) return null
+  return numeric
+}
+
+const parseRange = (
+  value?: string | null,
+): { min: number | null; max: number | null } => {
+  if (!value) return { min: null, max: null }
+  const matches = value.match(/-?[\d.]+/g)
+  if (!matches || matches.length === 0) return { min: null, max: null }
+  const numbers = matches
+    .map((m) => parseFloat(m))
+    .filter((n) => !Number.isNaN(n))
+  if (numbers.length === 0) return { min: null, max: null }
+  return {
+    min: Math.min(...numbers),
+    max: Math.max(...numbers),
+  }
+}
+
+export const fpgaTableSpec: DerivedTableSpec<FPGA> = {
+  tableName: "fpga",
+  extraColumns: [
+    { name: "package", type: "text" },
+    { name: "type", type: "text" },
+    { name: "logic_array_blocks", type: "real" },
+    { name: "logic_elements", type: "real" },
+    { name: "embedded_ram_bits", type: "real" },
+    { name: "supply_voltage_min", type: "real" },
+    { name: "supply_voltage_max", type: "real" },
+    { name: "operating_temp_min", type: "real" },
+    { name: "operating_temp_max", type: "real" },
+    { name: "max_delay_ns", type: "real" },
+    { name: "logic_gates", type: "real" },
+    { name: "is_basic", type: "boolean" },
+    { name: "is_preferred", type: "boolean" },
+  ],
+  listCandidateComponents: (db) =>
+    db
+      .selectFrom("components")
+      .innerJoin("categories", "components.category_id", "categories.id")
+      .selectAll()
+      .where((eb) =>
+        eb.or(
+          SUBCATEGORY_MATCHES.map((subcategory) =>
+            eb("categories.subcategory", "=", subcategory),
+          ),
+        ),
+      ),
+  mapToTable: (components) =>
+    components.map((c) => {
+      try {
+        const extra = c.extra ? JSON.parse(c.extra) : null
+        const attrs: Record<string, string> = extra?.attributes ?? {}
+
+        const supplyRange = parseRange(attrs["Supply Voltage Range - VCCIO"])
+        const tempRange = parseRange(attrs["Operating Temperature Range"])
+
+        return {
+          lcsc: Number(c.lcsc),
+          mfr: String(c.mfr ?? ""),
+          description: String(c.description ?? ""),
+          stock: Number(c.stock ?? 0),
+          price1: extractMinQPrice(c.price),
+          in_stock: Boolean((c.stock ?? 0) > 0),
+          is_basic: Boolean(c.basic),
+          is_preferred: Boolean(c.preferred),
+          package: extra?.package ?? c.package ?? "",
+          type: attrs["Type"] ?? null,
+          logic_array_blocks: parseNumericValue(attrs["Logic Array Blocks"]),
+          logic_elements: parseNumericValue(attrs["Logic Elements / Cells"]),
+          embedded_ram_bits: parseNumericValue(attrs["Embedded Block RAM"]),
+          supply_voltage_min: supplyRange.min,
+          supply_voltage_max: supplyRange.max,
+          operating_temp_min: tempRange.min,
+          operating_temp_max: tempRange.max,
+          max_delay_ns: parseNumericValue(attrs["Maximum Delay Time Tpd"]),
+          logic_gates: parseNumericValue(attrs["Number of Logic Gates"]),
+          attributes: attrs,
+        }
+      } catch (err) {
+        return null
+      }
+    }),
+}

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -39,8 +39,6 @@ export interface Adc {
   has_spi: number | null;
   has_uart: number | null;
   in_stock: number | null;
-  is_basic: number | null;
-  is_preferred: number | null;
   is_differential: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
@@ -65,8 +63,6 @@ export interface AnalogMultiplexer {
   has_parallel_interface: number | null;
   has_spi: number | null;
   in_stock: number | null;
-  is_basic: number | null;
-  is_preferred: number | null;
   lcsc: Generated<number | null>;
   leakage_current_na: number | null;
   mfr: string | null;
@@ -89,8 +85,6 @@ export interface BjtTransistor {
   current_gain: number | null;
   description: string | null;
   in_stock: number | null;
-  is_basic: number | null;
-is_preferred: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   package: string | null;
@@ -108,7 +102,7 @@ export interface BoostConverter {
   input_voltage_max: number | null;
   input_voltage_min: number | null;
   is_basic: number | null;
-is_preferred: number | null;
+  is_preferred: number | null;
   is_synchronous: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
@@ -130,7 +124,7 @@ export interface BuckBoostConverter {
   input_voltage_max: number | null;
   input_voltage_min: number | null;
   is_basic: number | null;
-is_preferred: number | null;
+  is_preferred: number | null;
   is_synchronous: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
@@ -153,8 +147,8 @@ export interface Capacitor {
   esr_ohms: number | null;
   in_stock: number | null;
   is_basic: number | null;
-is_preferred: number | null;
   is_polarized: number | null;
+  is_preferred: number | null;
   is_surface_mount: number | null;
   lcsc: Generated<number | null>;
   lifetime_hours: number | null;
@@ -236,8 +230,6 @@ export interface Dac {
   has_parallel_interface: number | null;
   has_spi: number | null;
   in_stock: number | null;
-  is_basic: number | null;
-is_preferred: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   nonlinearity_lsb: number | null;
@@ -262,8 +254,6 @@ export interface Diode {
   forward_current: number | null;
   forward_voltage: number | null;
   in_stock: number | null;
-  is_basic: number | null;
-is_preferred: number | null;
   is_schottky: number | null;
   is_tvs: number | null;
   is_zener: number | null;
@@ -286,7 +276,7 @@ export interface FpcConnector {
   description: string | null;
   in_stock: number | null;
   is_basic: number | null;
-is_preferred: number | null;
+  is_preferred: number | null;
   lcsc: Generated<number | null>;
   locking_feature: string | null;
   mfr: string | null;
@@ -296,13 +286,34 @@ is_preferred: number | null;
   stock: number | null;
 }
 
+export interface Fpga {
+  attributes: string | null;
+  description: string | null;
+  embedded_ram_bits: number | null;
+  in_stock: number | null;
+  is_basic: number | null;
+  is_preferred: number | null;
+  lcsc: Generated<number | null>;
+  logic_array_blocks: number | null;
+  logic_elements: number | null;
+  logic_gates: number | null;
+  max_delay_ns: number | null;
+  mfr: string | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  package: string | null;
+  price1: number | null;
+  stock: number | null;
+  supply_voltage_max: number | null;
+  supply_voltage_min: number | null;
+  type: string | null;
+}
+
 export interface Fuse {
   attributes: string | null;
   current_rating: number | null;
   description: string | null;
   in_stock: number | null;
-  is_basic: number | null;
-is_preferred: number | null;
   is_glass_encased: number | null;
   is_resettable: number | null;
   is_surface_mount: number | null;
@@ -320,7 +331,7 @@ export interface GasSensor {
   description: string | null;
   in_stock: number | null;
   is_basic: number | null;
-is_preferred: number | null;
+  is_preferred: number | null;
   lcsc: Generated<number | null>;
   measures_air_quality: number | null;
   measures_carbon_monoxide: number | null;
@@ -349,7 +360,7 @@ export interface Gyroscope {
   has_uart: number | null;
   in_stock: number | null;
   is_basic: number | null;
-is_preferred: number | null;
+  is_preferred: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
@@ -370,8 +381,6 @@ export interface Header {
   gender: string | null;
   in_stock: number | null;
   insulation_height_mm: number | null;
-  is_basic: number | null;
-is_preferred: number | null;
   is_right_angle: number | null;
   is_shrouded: number | null;
   lcsc: Generated<number | null>;
@@ -400,8 +409,6 @@ export interface IoExpander {
   has_smbus: number | null;
   has_spi: number | null;
   in_stock: number | null;
-  is_basic: number | null;
-is_preferred: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   num_gpios: number | null;
@@ -422,7 +429,7 @@ export interface JstConnector {
   description: string | null;
   in_stock: number | null;
   is_basic: number | null;
-is_preferred: number | null;
+  is_preferred: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   num_pins: number | null;
@@ -440,8 +447,6 @@ export interface LcdDisplay {
   display_size: string | null;
   display_type: string | null;
   in_stock: number | null;
-  is_basic: number | null;
-is_preferred: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   package: string | null;
@@ -458,8 +463,8 @@ export interface Ldo {
   input_voltage_max: number | null;
   input_voltage_min: number | null;
   is_basic: number | null;
-is_preferred: number | null;
   is_positive: number | null;
+  is_preferred: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
@@ -484,8 +489,6 @@ export interface Led {
   forward_current: number | null;
   forward_voltage: number | null;
   in_stock: number | null;
-  is_basic: number | null;
-is_preferred: number | null;
   is_rgb: number | null;
   lcsc: Generated<number | null>;
   lens_color: string | null;
@@ -507,8 +510,6 @@ export interface LedDotMatrixDisplay {
   color: string | null;
   description: string | null;
   in_stock: number | null;
-  is_basic: number | null;
-is_preferred: number | null;
   lcsc: Generated<number | null>;
   matrix_size: string | null;
   mfr: string | null;
@@ -524,8 +525,6 @@ export interface LedDriver {
   dimming_method: string | null;
   efficiency_percent: number | null;
   in_stock: number | null;
-  is_basic: number | null;
-is_preferred: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   mounting_style: string | null;
@@ -545,8 +544,6 @@ export interface LedSegmentDisplay {
   color: string | null;
   description: string | null;
   in_stock: number | null;
-  is_basic: number | null;
-is_preferred: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   package: string | null;
@@ -564,8 +561,6 @@ export interface LedWithIc {
   forward_current: number | null;
   forward_voltage: number | null;
   in_stock: number | null;
-  is_basic: number | null;
-is_preferred: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   mounting_style: string | null;
@@ -603,8 +598,6 @@ export interface Microcontroller {
   has_usb: number | null;
   has_watchdog: number | null;
   in_stock: number | null;
-  is_basic: number | null;
-is_preferred: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
@@ -624,8 +617,6 @@ export interface Mosfet {
   drain_source_voltage: number | null;
   gate_threshold_voltage: number | null;
   in_stock: number | null;
-  is_basic: number | null;
-is_preferred: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   mounting_style: string | null;
@@ -642,8 +633,6 @@ export interface OledDisplay {
   description: string | null;
   display_width: string | null;
   in_stock: number | null;
-  is_basic: number | null;
-is_preferred: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   package: string | null;
@@ -658,7 +647,7 @@ export interface PcieM2Connector {
   description: string | null;
   in_stock: number | null;
   is_basic: number | null;
-is_preferred: number | null;
+  is_preferred: number | null;
   is_right_angle: number | null;
   key: string | null;
   lcsc: Generated<number | null>;
@@ -671,8 +660,6 @@ export interface Potentiometer {
   attributes: string | null;
   description: string | null;
   in_stock: number | null;
-  is_basic: number | null;
-is_preferred: number | null;
   is_surface_mount: number | null;
   lcsc: Generated<number | null>;
   max_resistance: number | null;
@@ -691,7 +678,7 @@ export interface Relay {
   description: string | null;
   in_stock: number | null;
   is_basic: number | null;
-is_preferred: number | null;
+  is_preferred: number | null;
   lcsc: Generated<number | null>;
   max_switching_current: number | null;
   max_switching_voltage: number | null;
@@ -708,9 +695,9 @@ export interface Resistor {
   description: string | null;
   in_stock: number | null;
   is_basic: number | null;
-is_preferred: number | null;
   is_multi_resistor_chip: number | null;
   is_potentiometer: number | null;
+  is_preferred: number | null;
   is_surface_mount: number | null;
   lcsc: Generated<number | null>;
   max_overload_voltage: number | null;
@@ -732,8 +719,8 @@ export interface Switch {
   description: string | null;
   in_stock: number | null;
   is_basic: number | null;
-is_preferred: number | null;
   is_latching: number | null;
+  is_preferred: number | null;
   lcsc: Generated<number | null>;
   length_mm: number | null;
   mfr: string | null;
@@ -757,7 +744,7 @@ export interface UsbCConnector {
   gender: string | null;
   in_stock: number | null;
   is_basic: number | null;
-is_preferred: number | null;
+  is_preferred: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   mounting_style: string | null;
@@ -796,8 +783,6 @@ export interface VoltageRegulator {
   in_stock: number | null;
   input_voltage_max: number | null;
   input_voltage_min: number | null;
-  is_basic: number | null;
-is_preferred: number | null;
   is_low_dropout: number | null;
   is_positive: number | null;
   lcsc: Generated<number | null>;
@@ -830,8 +815,6 @@ export interface WifiModule {
   has_spi: number | null;
   has_uart: number | null;
   in_stock: number | null;
-  is_basic: number | null;
-is_preferred: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
@@ -865,6 +848,7 @@ export interface DB {
   dac: Dac;
   diode: Diode;
   fpc_connector: FpcConnector;
+  fpga: Fpga;
   fuse: Fuse;
   gas_sensor: GasSensor;
   gyroscope: Gyroscope;

--- a/routes/fpgas/list.json.tsx
+++ b/routes/fpgas/list.json.tsx
@@ -1,0 +1,2 @@
+import list from "./list"
+export default list

--- a/routes/fpgas/list.tsx
+++ b/routes/fpgas/list.tsx
@@ -1,0 +1,216 @@
+import { Table } from "lib/ui/Table"
+import { withWinterSpec } from "lib/with-winter-spec"
+import { z } from "zod"
+import { formatPrice } from "lib/util/format-price"
+import { formatSiUnit } from "lib/util/format-si-unit"
+
+const formatNumber = (value: number) =>
+  Number.isInteger(value)
+    ? value.toString()
+    : value
+        .toFixed(2)
+        .replace(/\.0+$/, "")
+        .replace(/(\.\d*[1-9])0+$/, "$1")
+
+const formatRange = (
+  min: number | null | undefined,
+  max: number | null | undefined,
+  unit: string,
+) => {
+  if (min == null && max == null) return ""
+  if (min != null && max != null)
+    return `${formatNumber(min)}${unit} - ${formatNumber(max)}${unit}`
+  const value = min ?? max
+  if (value == null) return ""
+  return `${formatNumber(value)}${unit}`
+}
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET"],
+  queryParams: z.object({
+    package: z.string().optional(),
+    type: z.string().optional(),
+    logic_elements_min: z.coerce.number().optional(),
+    logic_array_blocks_min: z.coerce.number().optional(),
+    embedded_ram_min_bits: z.coerce.number().optional(),
+  }),
+  jsonResponse: z.any(),
+} as const)(async (req, ctx) => {
+  let query = ctx.db
+    .selectFrom("fpga")
+    .selectAll()
+    .limit(100)
+    .orderBy("stock", "desc")
+
+  if (req.query.package) {
+    query = query.where("package", "=", req.query.package)
+  }
+
+  if (req.query.type) {
+    query = query.where("type", "=", req.query.type)
+  }
+
+  if (req.query.logic_elements_min) {
+    query = query.where("logic_elements", ">=", req.query.logic_elements_min)
+  }
+
+  if (req.query.logic_array_blocks_min) {
+    query = query.where(
+      "logic_array_blocks",
+      ">=",
+      req.query.logic_array_blocks_min,
+    )
+  }
+
+  if (req.query.embedded_ram_min_bits) {
+    query = query.where(
+      "embedded_ram_bits",
+      ">=",
+      req.query.embedded_ram_min_bits,
+    )
+  }
+
+  const packages = await ctx.db
+    .selectFrom("fpga")
+    .select("package")
+    .distinct()
+    .where("package", "is not", null)
+    .orderBy("package")
+    .execute()
+
+  const types = await ctx.db
+    .selectFrom("fpga")
+    .select("type")
+    .distinct()
+    .where("type", "is not", null)
+    .orderBy("type")
+    .execute()
+
+  const fpgas = await query.execute()
+
+  if (ctx.isApiRequest) {
+    return ctx.json({
+      fpgas: fpgas.map((f) => ({
+        lcsc: f.lcsc ?? 0,
+        mfr: f.mfr ?? "",
+        package: f.package ?? "",
+        type: f.type ?? null,
+        logic_array_blocks: f.logic_array_blocks ?? null,
+        logic_elements: f.logic_elements ?? null,
+        embedded_ram_bits: f.embedded_ram_bits ?? null,
+        supply_voltage_min: f.supply_voltage_min ?? null,
+        supply_voltage_max: f.supply_voltage_max ?? null,
+        operating_temp_min: f.operating_temp_min ?? null,
+        operating_temp_max: f.operating_temp_max ?? null,
+        max_delay_ns: f.max_delay_ns ?? null,
+        logic_gates: f.logic_gates ?? null,
+        stock: f.stock ?? null,
+        price1: f.price1 ?? null,
+      })),
+    })
+  }
+
+  return ctx.react(
+    <div>
+      <h2>FPGAs &amp; CPLDs</h2>
+
+      <form method="GET" className="flex flex-row flex-wrap gap-4">
+        <div>
+          <label>Package:</label>
+          <select name="package">
+            <option value="">All</option>
+            {packages.map((p) => (
+              <option
+                key={p.package}
+                value={p.package ?? ""}
+                selected={p.package === req.query.package}
+              >
+                {p.package}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label>Type:</label>
+          <select name="type">
+            <option value="">All</option>
+            {types.map((t) => (
+              <option
+                key={t.type}
+                value={t.type ?? ""}
+                selected={t.type === req.query.type}
+              >
+                {t.type}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label>Min Logic Elements:</label>
+          <input
+            type="number"
+            name="logic_elements_min"
+            placeholder="Count"
+            defaultValue={req.query.logic_elements_min}
+          />
+        </div>
+
+        <div>
+          <label>Min Logic Array Blocks:</label>
+          <input
+            type="number"
+            name="logic_array_blocks_min"
+            placeholder="Count"
+            defaultValue={req.query.logic_array_blocks_min}
+          />
+        </div>
+
+        <div>
+          <label>Min Embedded RAM (bits):</label>
+          <input
+            type="number"
+            name="embedded_ram_min_bits"
+            placeholder="Bits"
+            defaultValue={req.query.embedded_ram_min_bits}
+          />
+        </div>
+
+        <button type="submit">Filter</button>
+      </form>
+
+      <Table
+        rows={fpgas.map((f) => ({
+          lcsc: f.lcsc,
+          mfr: f.mfr,
+          package: f.package,
+          type: f.type ?? "",
+          "logic blocks": f.logic_array_blocks ?? "",
+          "logic elements": f.logic_elements
+            ? formatSiUnit(f.logic_elements)
+            : "",
+          "embedded ram": f.embedded_ram_bits
+            ? `${formatSiUnit(f.embedded_ram_bits)}b`
+            : "",
+          "supply voltage": formatRange(
+            f.supply_voltage_min,
+            f.supply_voltage_max,
+            "V",
+          ),
+          "operating temp": formatRange(
+            f.operating_temp_min,
+            f.operating_temp_max,
+            "°C",
+          ),
+          "max delay":
+            f.max_delay_ns != null ? `${formatSiUnit(f.max_delay_ns)}ns` : "",
+          "logic gates": f.logic_gates ? formatSiUnit(f.logic_gates) : "",
+          stock: f.stock,
+          price: formatPrice(f.price1 ?? null),
+        }))}
+      />
+    </div>,
+  )
+})

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -37,6 +37,7 @@ export default withWinterSpec({
         <a href="/microcontrollers/list">Microcontrollers</a>
         <a href="/arm_processors/list">ARM Processors</a>
         <a href="/risc_v_processors/list">RISC-V Processors</a>
+        <a href="/fpgas/list">FPGAs &amp; CPLDs</a>
         <a href="/voltage_regulators/list">Voltage Regulators</a>
         <a href="/ldos/list">LDO Regulators</a>
         <a href="/boost_converters/list">Boost DC-DC Converters</a>

--- a/scripts/setup-derived-tables.ts
+++ b/scripts/setup-derived-tables.ts
@@ -36,6 +36,7 @@ import { usbCConnectorTableSpec } from "lib/db/derivedtables/usb_c_connector"
 import { pcieM2ConnectorTableSpec } from "lib/db/derivedtables/pcie_m2_connector"
 import { fpcConnectorTableSpec } from "lib/db/derivedtables/fpc_connector"
 import { jstConnectorTableSpec } from "lib/db/derivedtables/jst_connector"
+import { fpgaTableSpec } from "lib/db/derivedtables/fpga"
 
 const resetArg = process.argv.indexOf("--reset")
 const resetTable = resetArg !== -1 ? process.argv[resetArg + 1] : null
@@ -76,6 +77,7 @@ const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   usbCConnectorTableSpec,
   pcieM2ConnectorTableSpec,
   jstConnectorTableSpec,
+  fpgaTableSpec,
 ]
 
 function jsonParseOrNull(strObject: string) {

--- a/tests/routes/fpgas/list.test.ts
+++ b/tests/routes/fpgas/list.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("GET /fpgas/list with json param returns fpga data", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/fpgas/list?json=true")
+
+  expect(res.data).toHaveProperty("fpgas")
+  expect(Array.isArray(res.data.fpgas)).toBe(true)
+
+  if (res.data.fpgas.length > 0) {
+    const fpga = res.data.fpgas[0]
+    expect(fpga).toHaveProperty("lcsc")
+    expect(fpga).toHaveProperty("mfr")
+    expect(fpga).toHaveProperty("package")
+    expect(fpga).toHaveProperty("logic_elements")
+  }
+})


### PR DESCRIPTION
## Summary
- add an FPGA derived table specification and include it in the derived table setup script
- expose a /fpgas listing route with filters, JSON responses, navigation entry, and update OpenAPI and generated DB types
- cover the new API with a regression test

## Testing
- `bun test tests/routes/fpgas`
- `bunx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_69063009e09c832ea32cb186bdc65267