### PR TITLE
Add resistor array category and route

### DIFF
--- a/lib/db/derivedtables/resistor_array.ts
+++ b/lib/db/derivedtables/resistor_array.ts
@@ -1,0 +1,139 @@
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import type { DerivedTableSpec } from "./types"
+import { BaseComponent } from "./component-base"
+
+export interface ResistorArray extends BaseComponent {
+  package: string
+  resistance: number | null
+  tolerance_fraction: number | null
+  power_watts: number | null
+  temperature_coefficient_ppm: number | null
+  number_of_resistors: number | null
+  number_of_pins: number | null
+  topology: string | null
+  is_surface_mount: boolean
+  is_basic: boolean
+  is_preferred: boolean
+}
+
+const computeTopology = (
+  numberOfResistors: number | null,
+  numberOfPins: number | null,
+): string | null => {
+  if (!numberOfResistors || !numberOfPins) return null
+
+  if (numberOfPins === numberOfResistors * 2) {
+    return "isolated"
+  }
+
+  if (numberOfPins === numberOfResistors + 1) {
+    return "bussed"
+  }
+
+  if (numberOfPins === numberOfResistors + 2) {
+    return "dual_terminated"
+  }
+
+  return "unknown"
+}
+
+const looksLikeArray = (
+  description: string,
+  packageName: string | null,
+  numberOfResistors: number | null,
+): boolean => {
+  if (numberOfResistors && numberOfResistors > 1) return true
+
+  const normalizedDescription = description.toLowerCase()
+  const normalizedPackage = packageName?.toLowerCase() ?? ""
+
+  return (
+    normalizedDescription.includes("array") ||
+    normalizedDescription.includes("network") ||
+    /x\d+/.test(normalizedPackage)
+  )
+}
+
+export const resistorArrayTableSpec: DerivedTableSpec<ResistorArray> = {
+  tableName: "resistor_array",
+  extraColumns: [
+    { name: "package", type: "text" },
+    { name: "resistance", type: "real" },
+    { name: "tolerance_fraction", type: "real" },
+    { name: "power_watts", type: "real" },
+    { name: "temperature_coefficient_ppm", type: "real" },
+    { name: "number_of_resistors", type: "integer" },
+    { name: "number_of_pins", type: "integer" },
+    { name: "topology", type: "text" },
+    { name: "is_surface_mount", type: "boolean" },
+    { name: "is_basic", type: "boolean" },
+    { name: "is_preferred", type: "boolean" },
+  ],
+  listCandidateComponents: (db) =>
+    db
+      .selectFrom("components")
+      .innerJoin("categories", "components.category_id", "categories.id")
+      .selectAll()
+      .where("categories.category", "=", "Resistors"),
+  mapToTable: (components) =>
+    components.map((component) => {
+      if (!component.extra) return null
+      const extra = JSON.parse(component.extra ?? "{}")
+      const attributes = extra.attributes ?? {}
+
+      const numberOfResistors =
+        Number.parseInt(attributes["Number of Resistors"] ?? "") || null
+      const numberOfPins =
+        Number.parseInt(attributes["Number of Pins"] ?? "") || null
+
+      if (
+        !looksLikeArray(
+          component.description,
+          component.package,
+          numberOfResistors,
+        )
+      ) {
+        return null
+      }
+
+      const resistance = parseAndConvertSiUnit(attributes["Resistance"])
+        .value as number | null
+      const tolerance = parseAndConvertSiUnit(attributes["Tolerance"]).value as
+        | number
+        | null
+      const power = parseAndConvertSiUnit(attributes["Power(Watts)"]).value as
+        | number
+        | null
+      const temperatureCoefficient = parseAndConvertSiUnit(
+        attributes["Temperature Coefficient"],
+      ).value as number | null
+
+      const topology = computeTopology(numberOfResistors, numberOfPins)
+
+      const isSurfaceMount =
+        component.package?.toLowerCase().includes("smd") ||
+        !component.package?.toLowerCase().includes("plugin")
+
+      return {
+        lcsc: component.lcsc,
+        mfr: component.mfr,
+        description: component.description,
+        stock: component.stock,
+        price1: extractMinQPrice(component.price)!,
+        in_stock: component.stock > 0,
+        is_basic: Boolean(component.basic),
+        is_preferred: Boolean(component.preferred),
+        package: component.package ?? "",
+        resistance,
+        tolerance_fraction: tolerance,
+        power_watts: power,
+        temperature_coefficient_ppm: temperatureCoefficient,
+        number_of_resistors: numberOfResistors,
+        number_of_pins: numberOfPins,
+        topology,
+        is_surface_mount: Boolean(isSurfaceMount),
+        attributes,
+      }
+    }),
+}

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -712,6 +712,27 @@ export interface Resistor {
   tolerance_fraction: number | null;
 }
 
+export interface ResistorArray {
+  attributes: string | null;
+  description: string | null;
+  in_stock: number | null;
+  is_basic: number | null;
+  is_preferred: number | null;
+  is_surface_mount: number | null;
+  lcsc: Generated<number | null>;
+  mfr: string | null;
+  number_of_pins: number | null;
+  number_of_resistors: number | null;
+  package: string | null;
+  power_watts: number | null;
+  price1: number | null;
+  resistance: number | null;
+  stock: number | null;
+  temperature_coefficient_ppm: number | null;
+  tolerance_fraction: number | null;
+  topology: string | null;
+}
+
 export interface Switch {
   attributes: string | null;
   circuit: string | null;
@@ -870,6 +891,7 @@ export interface DB {
   potentiometer: Potentiometer;
   relay: Relay;
   resistor: Resistor;
+  resistor_array: ResistorArray;
   switch: Switch;
   usb_c_connector: UsbCConnector;
   v_components: VComponent;

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -16,6 +16,7 @@ export default withWinterSpec({
         <a href="/categories/list">Categories</a>
         <a href="/footprint_index/list">Footprint Index</a>
         <a href="/resistors/list">Resistors</a>
+        <a href="/resistor_arrays/list">Resistor Arrays</a>
         <a href="/capacitors/list">Capacitors</a>
         <a href="/potentiometers/list">Potentiometers</a>
         <a href="/headers/list">Headers</a>

--- a/routes/resistor_arrays/list.json.tsx
+++ b/routes/resistor_arrays/list.json.tsx
@@ -1,0 +1,2 @@
+import list from "./list"
+export default list

--- a/routes/resistor_arrays/list.tsx
+++ b/routes/resistor_arrays/list.tsx
@@ -1,0 +1,296 @@
+import { Table } from "lib/ui/Table"
+import { withWinterSpec } from "lib/with-winter-spec"
+import { z } from "zod"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { formatSiUnit } from "lib/util/format-si-unit"
+import { formatPrice } from "lib/util/format-price"
+
+const TOPOLOGY_LABELS: Record<string, string> = {
+  isolated: "Isolated",
+  bussed: "Bussed",
+  dual_terminated: "Dual Terminated",
+  unknown: "Unknown",
+}
+
+const formatTemperatureCoefficient = (value?: number | null) => {
+  if (value == null) return ""
+  return `${value} ppm/°C`
+}
+
+const normalizeTopologyParam = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined
+  return value ? value : undefined
+}
+
+const parseNumberParam = (value: unknown): number | undefined => {
+  if (typeof value === "number") return value
+  if (typeof value !== "string") return undefined
+  if (!value) return undefined
+  const parsed = Number.parseInt(value, 10)
+  return Number.isNaN(parsed) ? undefined : parsed
+}
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET", "POST"],
+  commonParams: z.object({
+    json: z.boolean().optional(),
+    package: z.string().optional(),
+    number_of_resistors: z
+      .unknown()
+      .optional()
+      .transform((val) => parseNumberParam(val)),
+    topology: z
+      .unknown()
+      .optional()
+      .transform((val) => normalizeTopologyParam(val)),
+    is_basic: z.boolean().optional(),
+    is_preferred: z.boolean().optional(),
+    resistance: z
+      .string()
+      .optional()
+      .transform((val) => {
+        if (!val) return undefined
+        const valWithUnit = `${val}Ω`
+        const parsed = parseAndConvertSiUnit(valWithUnit)
+        return parsed.value
+      }),
+  }),
+  jsonResponse: z.string().or(
+    z.object({
+      resistor_arrays: z.array(
+        z.object({
+          lcsc: z.number().int(),
+          mfr: z.string(),
+          package: z.string(),
+          is_basic: z.boolean(),
+          is_preferred: z.boolean(),
+          number_of_resistors: z.number().nullable(),
+          number_of_pins: z.number().nullable(),
+          topology: z.string().nullable(),
+          resistance: z.number().nullable(),
+          tolerance_fraction: z.number().nullable(),
+          power_watts: z.number().nullable(),
+          temperature_coefficient_ppm: z.number().nullable(),
+          stock: z.number().nullable(),
+          price1: z.number().nullable(),
+        }),
+      ),
+    }),
+  ),
+} as const)(async (req, ctx) => {
+  let query = ctx.db
+    .selectFrom("resistor_array")
+    .selectAll()
+    .limit(100)
+    .orderBy("stock", "desc")
+
+  const params = req.commonParams
+
+  if (params.package) {
+    query = query.where("package", "=", params.package)
+  }
+
+  if (params.is_basic) {
+    query = query.where("is_basic", "=", 1)
+  }
+  if (params.is_preferred) {
+    query = query.where("is_preferred", "=", 1)
+  }
+
+  if (params.number_of_resistors != null) {
+    query = query.where("number_of_resistors", "=", params.number_of_resistors)
+  }
+
+  if (params.topology) {
+    query = query.where("topology", "=", params.topology)
+  }
+
+  if (params.resistance != null) {
+    const delta = params.resistance * 0.0001
+    query = query
+      .where("resistance", ">=", params.resistance - delta)
+      .where("resistance", "<=", params.resistance + delta)
+  }
+
+  const packages = await ctx.db
+    .selectFrom("resistor_array")
+    .select("package")
+    .distinct()
+    .orderBy("package")
+    .execute()
+
+  const resistorCounts = await ctx.db
+    .selectFrom("resistor_array")
+    .select("number_of_resistors")
+    .distinct()
+    .where("number_of_resistors", "is not", null)
+    .orderBy("number_of_resistors")
+    .execute()
+
+  const topologies = await ctx.db
+    .selectFrom("resistor_array")
+    .select("topology")
+    .distinct()
+    .where("topology", "is not", null)
+    .orderBy("topology")
+    .execute()
+
+  const resistorArrays = await query.execute()
+
+  if (ctx.isApiRequest) {
+    return ctx.json({
+      resistor_arrays: resistorArrays.map((array) => ({
+        lcsc: array.lcsc ?? 0,
+        mfr: array.mfr ?? "",
+        package: array.package ?? "",
+        is_basic: Boolean(array.is_basic),
+        is_preferred: Boolean(array.is_preferred),
+        number_of_resistors: array.number_of_resistors ?? null,
+        number_of_pins: array.number_of_pins ?? null,
+        topology: array.topology ?? null,
+        resistance: array.resistance ?? null,
+        tolerance_fraction: array.tolerance_fraction ?? null,
+        power_watts: array.power_watts ?? null,
+        temperature_coefficient_ppm: array.temperature_coefficient_ppm ?? null,
+        stock: array.stock ?? null,
+        price1: array.price1 ?? null,
+      })),
+    })
+  }
+
+  return ctx.react(
+    <div>
+      <h2>Resistor Arrays</h2>
+
+      <form method="GET" className="flex flex-row flex-wrap gap-4">
+        <div>
+          <label>Package:</label>
+          <select name="package">
+            <option value="">All</option>
+            {packages.map((p) => (
+              <option
+                key={p.package ?? "unknown"}
+                value={p.package ?? ""}
+                selected={p.package === params.package}
+              >
+                {p.package}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label>Resistors:</label>
+          <select name="number_of_resistors">
+            <option value="">All</option>
+            {resistorCounts.map((count) => (
+              <option
+                key={count.number_of_resistors ?? "unknown"}
+                value={count.number_of_resistors ?? ""}
+                selected={
+                  count.number_of_resistors === params.number_of_resistors
+                }
+              >
+                {count.number_of_resistors}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label>Topology:</label>
+          <select name="topology">
+            <option value="">All</option>
+            {topologies.map((t) => (
+              <option
+                key={t.topology ?? "unknown"}
+                value={t.topology ?? ""}
+                selected={t.topology === params.topology}
+              >
+                {t.topology ? (TOPOLOGY_LABELS[t.topology] ?? t.topology) : ""}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label>
+            Basic Part:
+            <input
+              type="checkbox"
+              name="is_basic"
+              value="true"
+              checked={params.is_basic}
+            />
+          </label>
+        </div>
+
+        <div>
+          <label>
+            Preferred Part:
+            <input
+              type="checkbox"
+              name="is_preferred"
+              value="true"
+              checked={params.is_preferred}
+            />
+          </label>
+        </div>
+
+        <div>
+          <label>Resistance:</label>
+          <input
+            type="text"
+            name="resistance"
+            placeholder="e.g. 1kΩ"
+            defaultValue={formatSiUnit(params.resistance)}
+          />
+        </div>
+
+        <button type="submit">Filter</button>
+      </form>
+
+      <Table
+        rows={resistorArrays.map((array) => ({
+          lcsc: array.lcsc,
+          mfr: array.mfr,
+          package: array.package,
+          is_basic: array.is_basic ? "✓" : "",
+          is_preferred: array.is_preferred ? "✓" : "",
+          resistors: array.number_of_resistors,
+          pins: array.number_of_pins,
+          topology: array.topology
+            ? (TOPOLOGY_LABELS[array.topology] ?? array.topology)
+            : "",
+          resistance: (
+            <span className="tabular-nums">
+              {formatSiUnit(array.resistance)}Ω
+            </span>
+          ),
+          tolerance: (
+            <span className="tabular-nums">
+              {array.tolerance_fraction
+                ? `±${array.tolerance_fraction * 100}%`
+                : ""}
+            </span>
+          ),
+          power: (
+            <span className="tabular-nums">
+              {formatSiUnit(array.power_watts)}W
+            </span>
+          ),
+          tempco: (
+            <span className="tabular-nums">
+              {formatTemperatureCoefficient(array.temperature_coefficient_ppm)}
+            </span>
+          ),
+          stock: <span className="tabular-nums">{array.stock}</span>,
+          price: (
+            <span className="tabular-nums">{formatPrice(array.price1)}</span>
+          ),
+        }))}
+      />
+    </div>,
+  )
+})

--- a/scripts/setup-derived-tables.ts
+++ b/scripts/setup-derived-tables.ts
@@ -1,6 +1,7 @@
 import { sql } from "kysely"
 import { getBunDatabaseClient, getDbClient } from "lib/db/get-db-client"
 import { resistorTableSpec } from "lib/db/derivedtables/resistor"
+import { resistorArrayTableSpec } from "lib/db/derivedtables/resistor_array"
 import { capacitorTableSpec } from "lib/db/derivedtables/capacitor"
 import { ledTableSpec } from "lib/db/derivedtables/led"
 import { headerTableSpec } from "lib/db/derivedtables/header"
@@ -44,6 +45,7 @@ const resetAll = resetArg !== -1 && !resetTable
 
 const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   resistorTableSpec,
+  resistorArrayTableSpec,
   capacitorTableSpec,
   ledTableSpec,
   headerTableSpec,


### PR DESCRIPTION
## Summary
- add a resistor_array derived table that extracts topology, temperature coefficient, and other helpful fields
- expose a resistor arrays list page and JSON endpoint with filtering for package, topology, and value
- register the new table in the setup script and regenerate Kysely types so the table is available in the database client

## Testing
- bunx tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69100aaec8c4832e8119150389d5b97a)