### PR TITLE
Add boolish schema for header filters

### DIFF
--- a/lib/zod.ts
+++ b/lib/zod.ts
@@ -1,0 +1,37 @@
+import { z } from "zod"
+
+const truthyValues = ["true", "t", "1", "yes", "y", "on"] as const
+const falsyValues = ["false", "f", "0", "no", "n", "off"] as const
+
+const normalizedTruthy = new Set<string>(
+  truthyValues.map((value) => value.toLowerCase()),
+)
+const normalizedFalsy = new Set<string>(
+  falsyValues.map((value) => value.toLowerCase()),
+)
+
+export const boolish = z
+  .union([z.boolean(), z.string()])
+  .transform((value, ctx) => {
+    if (typeof value === "boolean") {
+      return value
+    }
+
+    const normalized = value.trim().toLowerCase()
+
+    if (normalizedTruthy.has(normalized)) {
+      return true
+    }
+
+    if (normalizedFalsy.has(normalized)) {
+      return false
+    }
+
+    ctx.addIssue({
+      code: z.ZodIssueCode.invalid_enum_value,
+      options: [...truthyValues, ...falsyValues],
+      received: value,
+    })
+
+    return z.NEVER
+  })

--- a/routes/headers/list.tsx
+++ b/routes/headers/list.tsx
@@ -2,6 +2,7 @@ import { Table } from "lib/ui/Table"
 import { withWinterSpec } from "lib/with-winter-spec"
 import { z } from "zod"
 import { formatPrice } from "lib/util/format-price"
+import { boolish } from "lib/zod"
 
 export default withWinterSpec({
   auth: "none",
@@ -10,7 +11,10 @@ export default withWinterSpec({
     json: z.boolean().optional(),
     pitch: z.string().optional(),
     num_pins: z.coerce.number().optional(),
-    is_right_angle: z.boolean().optional(),
+    is_right_angle: z
+      .union([z.literal(""), boolish])
+      .transform((value) => (value === "" ? undefined : value))
+      .optional(),
     gender: z.enum(["male", "female", ""]).optional(),
   }),
   jsonResponse: z.string().or(
@@ -151,10 +155,16 @@ export default withWinterSpec({
           <label>Right Angle:</label>
           <select name="is_right_angle">
             <option value="">All</option>
-            <option value="true" selected={params.is_right_angle === true}>
+            <option
+              value="true"
+              selected={params.is_right_angle?.toString() === "true"}
+            >
               Yes
             </option>
-            <option value="false" selected={params.is_right_angle === false}>
+            <option
+              value="false"
+              selected={params.is_right_angle?.toString() === "false"}
+            >
               No
             </option>
           </select>


### PR DESCRIPTION
## Summary
- add a reusable `boolish` schema helper that normalizes boolean-like inputs
- use the helper in the headers list route and keep the UI selection in sync

## Testing
- bunx tsc --noEmit
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69139207be7c832eb68bae0e42070b15)