### PR TITLE
Add wire to board connector search page

### DIFF
--- a/lib/db/derivedtables/wire_to_board_connector.ts
+++ b/lib/db/derivedtables/wire_to_board_connector.ts
@@ -1,0 +1,119 @@
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import type { BaseComponent } from "./component-base"
+import type { DerivedTableSpec } from "./types"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+
+export interface WireToBoardConnector extends BaseComponent {
+  package: string
+  pitch_mm: number | null
+  num_rows: number | null
+  num_pins_per_row: number | null
+  num_pins: number | null
+  reference_series: string | null
+  mounting_style: string | null
+  gender: string | null
+  is_smd: boolean
+}
+
+const parseNumber = (value?: string | null) => {
+  const parsed = value ? parseFloat(value) : NaN
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+const parsePinsStructure = (structure?: string | null) => {
+  if (!structure)
+    return { rows: null as number | null, pinsPerRow: null as number | null }
+  const match = structure.match(/(\d+)x(\d+)/)
+  if (!match)
+    return { rows: null as number | null, pinsPerRow: null as number | null }
+  return {
+    rows: parseNumber(match[1]),
+    pinsPerRow: parseNumber(match[2]),
+  }
+}
+
+const parsePitch = (pitch?: string | null) => {
+  if (!pitch || pitch === "-") return null
+  return parseAndConvertSiUnit(pitch).value as number
+}
+
+const deriveIsSmd = (mountingStyle: string | null, pkg: string | null) => {
+  const mounting = mountingStyle?.toLowerCase() ?? ""
+  const packageStr = pkg?.toLowerCase() ?? ""
+  if (mounting.includes("surface")) return true
+  if (packageStr.includes("smd") || packageStr.includes("smt")) return true
+  return false
+}
+
+export const wireToBoardConnectorTableSpec: DerivedTableSpec<WireToBoardConnector> =
+  {
+    tableName: "wire_to_board_connector",
+    extraColumns: [
+      { name: "package", type: "text" },
+      { name: "pitch_mm", type: "real" },
+      { name: "num_rows", type: "integer" },
+      { name: "num_pins_per_row", type: "integer" },
+      { name: "num_pins", type: "integer" },
+      { name: "reference_series", type: "text" },
+      { name: "mounting_style", type: "text" },
+      { name: "gender", type: "text" },
+      { name: "is_smd", type: "boolean" },
+      { name: "is_basic", type: "boolean" },
+      { name: "is_preferred", type: "boolean" },
+    ],
+    listCandidateComponents(db: KyselyDatabaseInstance) {
+      return db
+        .selectFrom("components")
+        .innerJoin("categories", "components.category_id", "categories.id")
+        .selectAll()
+        .where("categories.category", "like", "Connectors%")
+        .where("categories.subcategory", "like", "Wire To Board%")
+    },
+    mapToTable(components) {
+      return components.map((c) => {
+        try {
+          const extra = c.extra ? JSON.parse(c.extra) : {}
+          const attrs: Record<string, string> = extra.attributes || {}
+
+          const structure = parsePinsStructure(attrs["Pins Structure"])
+          const numRows = parseNumber(attrs["Number of Rows"]) ?? structure.rows
+          const pinsPerRow =
+            parseNumber(attrs["Number of PINs Per Row"]) ?? structure.pinsPerRow
+
+          const explicitPins = parseNumber(attrs["Number of Pins"])
+          const computedPins =
+            pinsPerRow && numRows ? pinsPerRow * numRows : (pinsPerRow ?? null)
+          const numPins = explicitPins ?? computedPins
+
+          const pitchMm = parsePitch(attrs["Pitch"])
+          const mountingStyle = attrs["Mounting Style"] || null
+          const gender = attrs["Gender"] || null
+          const isSmd = deriveIsSmd(mountingStyle, c.package)
+
+          return {
+            lcsc: Number(c.lcsc),
+            mfr: String(c.mfr || ""),
+            description: String(c.description || ""),
+            stock: Number(c.stock || 0),
+            price1: extractMinQPrice(c.price),
+            in_stock: Boolean((c.stock || 0) > 0),
+            is_basic: Boolean(c.basic),
+            is_preferred: Boolean(c.preferred),
+            package: String(c.package || ""),
+            pitch_mm: pitchMm,
+            num_rows: numRows,
+            num_pins_per_row: pinsPerRow,
+            num_pins: numPins,
+            reference_series: attrs["Reference Series"] || null,
+            mounting_style: mountingStyle,
+            gender,
+            is_smd: isSmd,
+            attributes: attrs,
+          }
+        } catch (err) {
+          return null
+        }
+      })
+    },
+  }

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -850,6 +850,27 @@ export interface WifiModule {
   tx_current_ma: number | null;
 }
 
+export interface WireToBoardConnector {
+  attributes: string | null;
+  description: string | null;
+  gender: string | null;
+  in_stock: number | null;
+  is_basic: number | null;
+  is_preferred: number | null;
+  is_smd: number | null;
+  lcsc: Generated<number | null>;
+  mfr: string | null;
+  mounting_style: string | null;
+  num_pins: number | null;
+  num_pins_per_row: number | null;
+  num_rows: number | null;
+  package: string | null;
+  pitch_mm: number | null;
+  price1: number | null;
+  reference_series: string | null;
+  stock: number | null;
+}
+
 export interface DB {
   accelerometer: Accelerometer;
   adc: Adc;
@@ -897,4 +918,5 @@ export interface DB {
   v_components: VComponent;
   voltage_regulator: VoltageRegulator;
   wifi_module: WifiModule;
+  wire_to_board_connector: WireToBoardConnector;
 }

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -24,6 +24,7 @@ export default withWinterSpec({
         <a href="/pcie_m2_connectors/list">PCIe M.2 Connectors</a>
         <a href="/fpc_connectors/list">FPC Connectors</a>
         <a href="/jst_connectors/list">JST Connectors</a>
+        <a href="/wire_to_board_connectors/list">Wire to Board Connectors</a>
         <a href="/leds/list">LEDs</a>
         <a href="/adcs/list">ADCs</a>
         <a href="/analog_multiplexers/list">Analog Muxes</a>

--- a/routes/wire_to_board_connectors/list.json.tsx
+++ b/routes/wire_to_board_connectors/list.json.tsx
@@ -1,0 +1,2 @@
+import list from "./list"
+export default list

--- a/routes/wire_to_board_connectors/list.tsx
+++ b/routes/wire_to_board_connectors/list.tsx
@@ -1,0 +1,190 @@
+import { Table } from "lib/ui/Table"
+import { formatPrice } from "lib/util/format-price"
+import { withWinterSpec } from "lib/with-winter-spec"
+import { boolish } from "lib/zod"
+import { z } from "zod"
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET", "POST"],
+  commonParams: z.object({
+    json: z.boolean().optional(),
+    pitch: z.string().optional(),
+    series: z.string().optional(),
+    is_smd: z
+      .union([z.literal(""), boolish])
+      .transform((value) => (value === "" ? undefined : value))
+      .optional(),
+  }),
+  jsonResponse: z.string().or(
+    z.object({
+      wire_to_board_connectors: z.array(
+        z.object({
+          lcsc: z.number().int(),
+          mfr: z.string(),
+          package: z.string(),
+          pitch_mm: z.number().optional(),
+          num_rows: z.number().optional(),
+          num_pins_per_row: z.number().optional(),
+          num_pins: z.number().optional(),
+          reference_series: z.string().optional(),
+          mounting_style: z.string().optional(),
+          gender: z.string().optional(),
+          is_smd: z.coerce.boolean().optional(),
+          stock: z.number().optional(),
+          price1: z.number().optional(),
+        }),
+      ),
+    }),
+  ),
+} as const)(async (req, ctx) => {
+  let query = ctx.db
+    .selectFrom("wire_to_board_connector")
+    .selectAll()
+    .limit(100)
+    .orderBy("stock", "desc")
+
+  const params = req.commonParams
+
+  if (params.pitch) {
+    const p = Number(params.pitch)
+    if (!Number.isNaN(p)) {
+      query = query.where("pitch_mm", "=", p)
+    }
+  }
+
+  if (params.series) {
+    query = query.where("reference_series", "=", params.series)
+  }
+
+  if (params.is_smd !== undefined) {
+    query = query.where("is_smd", "=", params.is_smd ? 1 : 0)
+  }
+
+  const pitches = await ctx.db
+    .selectFrom("wire_to_board_connector")
+    .select("pitch_mm")
+    .distinct()
+    .where("pitch_mm", "is not", null)
+    .orderBy("pitch_mm")
+    .execute()
+
+  const seriesList = await ctx.db
+    .selectFrom("wire_to_board_connector")
+    .select("reference_series")
+    .distinct()
+    .where("reference_series", "is not", null)
+    .orderBy("reference_series")
+    .execute()
+
+  const connectors = await query.execute()
+
+  if (ctx.isApiRequest) {
+    return ctx.json({
+      wire_to_board_connectors: connectors
+        .map((c) => ({
+          lcsc: c.lcsc ?? 0,
+          mfr: c.mfr ?? "",
+          package: c.package ?? "",
+          pitch_mm: c.pitch_mm ?? undefined,
+          num_rows: c.num_rows ?? undefined,
+          num_pins_per_row: c.num_pins_per_row ?? undefined,
+          num_pins: c.num_pins ?? undefined,
+          reference_series: c.reference_series ?? undefined,
+          mounting_style: c.mounting_style ?? undefined,
+          gender: c.gender ?? undefined,
+          is_smd: Boolean(c.is_smd ?? undefined),
+          stock: c.stock ?? undefined,
+          price1: c.price1 ?? undefined,
+        }))
+        .filter((c) => c.lcsc !== 0 && c.package !== ""),
+    })
+  }
+
+  return ctx.react(
+    <div>
+      <h2>Wire to Board Connectors</h2>
+
+      <form method="GET" className="flex flex-row gap-4">
+        <div>
+          <label>Pitch:</label>
+          <select name="pitch">
+            <option value="">All</option>
+            {pitches.map((p) => (
+              <option
+                key={p.pitch_mm}
+                value={p.pitch_mm ?? ""}
+                selected={String(p.pitch_mm) === params.pitch}
+              >
+                {p.pitch_mm}mm
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label>Series:</label>
+          <select name="series">
+            <option value="">All</option>
+            {seriesList.map((s) => (
+              <option
+                key={s.reference_series}
+                value={s.reference_series ?? ""}
+                selected={s.reference_series === params.series}
+              >
+                {s.reference_series}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label>Mounting:</label>
+          <select name="is_smd">
+            <option value="">All</option>
+            <option
+              value="true"
+              selected={params.is_smd?.toString() === "true"}
+            >
+              SMD
+            </option>
+            <option
+              value="false"
+              selected={params.is_smd?.toString() === "false"}
+            >
+              Through-Hole
+            </option>
+          </select>
+        </div>
+
+        <button type="submit">Filter</button>
+      </form>
+
+      <Table
+        rows={connectors.map((c) => ({
+          lcsc: c.lcsc,
+          mfr: c.mfr,
+          package: c.package,
+          pitch: c.pitch_mm && (
+            <span className="tabular-nums">{c.pitch_mm}mm</span>
+          ),
+          pins_wires: (
+            <span className="tabular-nums">
+              {c.num_rows && c.num_pins_per_row
+                ? `${c.num_rows}×${c.num_pins_per_row}`
+                : (c.num_pins_per_row ?? c.num_pins)}
+              {c.num_pins ? ` (${c.num_pins})` : ""}
+            </span>
+          ),
+          series: c.reference_series,
+          gender: c.gender,
+          mounting: c.mounting_style,
+          is_smd: c.is_smd ? "Yes" : "No",
+          stock: <span className="tabular-nums">{c.stock}</span>,
+          price: <span className="tabular-nums">{formatPrice(c.price1)}</span>,
+        }))}
+      />
+    </div>,
+    "JLCPCB Wire to Board Connector Search",
+  )
+})

--- a/scripts/setup-derived-tables.ts
+++ b/scripts/setup-derived-tables.ts
@@ -38,6 +38,7 @@ import { pcieM2ConnectorTableSpec } from "lib/db/derivedtables/pcie_m2_connector
 import { fpcConnectorTableSpec } from "lib/db/derivedtables/fpc_connector"
 import { jstConnectorTableSpec } from "lib/db/derivedtables/jst_connector"
 import { fpgaTableSpec } from "lib/db/derivedtables/fpga"
+import { wireToBoardConnectorTableSpec } from "lib/db/derivedtables/wire_to_board_connector"
 
 const resetArg = process.argv.indexOf("--reset")
 const resetTable = resetArg !== -1 ? process.argv[resetArg + 1] : null
@@ -79,6 +80,7 @@ const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   usbCConnectorTableSpec,
   pcieM2ConnectorTableSpec,
   jstConnectorTableSpec,
+  wireToBoardConnectorTableSpec,
   fpgaTableSpec,
 ]
 


### PR DESCRIPTION
## Summary
- add derived table for wire-to-board connectors with pin counts and smd detection
- expose a new UI/API list page with filters and pins/wires and is_smd columns
- link the connector page from the homepage navigation and update generated DB types

## Testing
- bunx tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69239b6a117c832ea1d0162c603d1b66)