### PR TITLE
feat: add is_extended_promotional filter checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,4 @@ To recap:
 
 None of this would be possible without [JLCPCB](https://jlcpcb.com) and the work
 [jlcparts](https://github.com/yaqwsx/jlcparts) project.
+# Updated

--- a/biome.json
+++ b/biome.json
@@ -5,7 +5,8 @@
   },
   "formatter": {
     "enabled": true,
-    "indentStyle": "space"
+    "indentStyle": "space",
+    "indentWidth": 2
   },
   "files": {
     "ignore": [

--- a/lib/db/derivedtables/accelerometer.ts
+++ b/lib/db/derivedtables/accelerometer.ts
@@ -28,6 +28,7 @@ export const accelerometerTableSpec: DerivedTableSpec<Accelerometer> = {
     { name: "has_uart", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -102,6 +103,7 @@ export const accelerometerTableSpec: DerivedTableSpec<Accelerometer> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
         package: c.package || "",
         supply_voltage_min: voltageMin,
         supply_voltage_max: voltageMax,

--- a/lib/db/derivedtables/adc.ts
+++ b/lib/db/derivedtables/adc.ts
@@ -40,6 +40,7 @@ export const adcTableSpec: DerivedTableSpec<Adc> = {
     { name: "operating_temp_max", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -115,6 +116,7 @@ export const adcTableSpec: DerivedTableSpec<Adc> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
         package: c.package || "",
         resolution_bits: resolution,
         sampling_rate_hz: samplingRate,

--- a/lib/db/derivedtables/analog_multiplexer.ts
+++ b/lib/db/derivedtables/analog_multiplexer.ts
@@ -40,6 +40,7 @@ export const analogMultiplexerTableSpec: DerivedTableSpec<AnalogMultiplexer> = {
     { name: "channel_type", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -144,6 +145,7 @@ export const analogMultiplexerTableSpec: DerivedTableSpec<AnalogMultiplexer> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
         package: c.package || "",
         num_channels: numChannels,
         num_bits: numBits,

--- a/lib/db/derivedtables/battery_holder.ts
+++ b/lib/db/derivedtables/battery_holder.ts
@@ -32,6 +32,7 @@ export const batteryHolderTableSpec: DerivedTableSpec<BatteryHolder> = {
     { name: "operating_temp_max", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -74,6 +75,7 @@ export const batteryHolderTableSpec: DerivedTableSpec<BatteryHolder> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
           package: String(c.package || ""),
           connector_type: attrs["Connector Type"] || null,
           battery_type: attrs["Battery Type"] || null,

--- a/lib/db/derivedtables/bjt_transistor.ts
+++ b/lib/db/derivedtables/bjt_transistor.ts
@@ -26,6 +26,7 @@ export const bjtTransistorTableSpec: DerivedTableSpec<BJTTransistor> = {
     { name: "temperature_range", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -74,6 +75,7 @@ export const bjtTransistorTableSpec: DerivedTableSpec<BJTTransistor> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
           package: c.package || "",
           current_gain: current_gain,
           collector_current: collector_current,

--- a/lib/db/derivedtables/boost_converter.ts
+++ b/lib/db/derivedtables/boost_converter.ts
@@ -31,6 +31,7 @@ export const boostConverterTableSpec: DerivedTableSpec<BoostConverter> = {
     { name: "number_of_outputs", type: "integer" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -117,6 +118,7 @@ export const boostConverterTableSpec: DerivedTableSpec<BoostConverter> = {
           in_stock: c.stock > 0,
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
           package: c.package || "",
           input_voltage_min: inputMin,
           input_voltage_max: inputMax,

--- a/lib/db/derivedtables/buck_boost_converter.ts
+++ b/lib/db/derivedtables/buck_boost_converter.ts
@@ -32,6 +32,7 @@ export const buckBoostConverterTableSpec: DerivedTableSpec<BuckBoostConverter> =
       { name: "number_of_outputs", type: "integer" },
       { name: "is_basic", type: "boolean" },
       { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
     ],
     listCandidateComponents: (db) =>
       db
@@ -121,6 +122,7 @@ export const buckBoostConverterTableSpec: DerivedTableSpec<BuckBoostConverter> =
             in_stock: c.stock > 0,
             is_basic: Boolean(c.basic),
             is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
             package: c.package || "",
             input_voltage_min: inputMin,
             input_voltage_max: inputMax,

--- a/lib/db/derivedtables/capacitor.ts
+++ b/lib/db/derivedtables/capacitor.ts
@@ -34,6 +34,7 @@ export const capacitorTableSpec: DerivedTableSpec<Capacitor> = {
     { name: "capacitor_type", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -115,6 +116,7 @@ export const capacitorTableSpec: DerivedTableSpec<Capacitor> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
         capacitance_farads: capacitance,
         tolerance_fraction: tolerance,
         voltage_rating: voltage,

--- a/lib/db/derivedtables/component-base.ts
+++ b/lib/db/derivedtables/component-base.ts
@@ -7,5 +7,6 @@ export interface BaseComponent {
   in_stock: boolean
   is_basic: boolean
   is_preferred: boolean
+  is_extended_promotional: boolean
   attributes: Record<string, string>
 }

--- a/lib/db/derivedtables/dac.ts
+++ b/lib/db/derivedtables/dac.ts
@@ -38,6 +38,7 @@ export const dacTableSpec: DerivedTableSpec<Dac> = {
     { name: "nonlinearity_lsb", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -129,6 +130,7 @@ export const dacTableSpec: DerivedTableSpec<Dac> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
         package: c.package || "",
         resolution_bits: resolution,
         num_channels: numChannels,

--- a/lib/db/derivedtables/diode.ts
+++ b/lib/db/derivedtables/diode.ts
@@ -40,6 +40,7 @@ export const diodeTableSpec: DerivedTableSpec<Diode> = {
     { name: "configuration", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -159,6 +160,7 @@ export const diodeTableSpec: DerivedTableSpec<Diode> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
         package: c.package || "",
         forward_voltage: forwardVoltage,
         reverse_voltage: reverseVoltage,

--- a/lib/db/derivedtables/fpc_connector.ts
+++ b/lib/db/derivedtables/fpc_connector.ts
@@ -20,6 +20,7 @@ export const fpcConnectorTableSpec: DerivedTableSpec<FpcConnector> = {
     { name: "locking_feature", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -55,6 +56,7 @@ export const fpcConnectorTableSpec: DerivedTableSpec<FpcConnector> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
           pitch_mm: parseNum(attrs["Pitch"]),
           number_of_contacts: isNaN(contacts) ? null : contacts,
           contact_type: attrs["Contact Type"] || null,

--- a/lib/db/derivedtables/fpga.ts
+++ b/lib/db/derivedtables/fpga.ts
@@ -68,6 +68,7 @@ export const fpgaTableSpec: DerivedTableSpec<FPGA> = {
     { name: "logic_gates", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -99,6 +100,7 @@ export const fpgaTableSpec: DerivedTableSpec<FPGA> = {
           in_stock: Boolean((c.stock ?? 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
           package: extra?.package ?? c.package ?? "",
           type: attrs["Type"] ?? null,
           logic_array_blocks: parseNumericValue(attrs["Logic Array Blocks"]),

--- a/lib/db/derivedtables/fuse.ts
+++ b/lib/db/derivedtables/fuse.ts
@@ -25,6 +25,7 @@ export const fuseTableSpec: DerivedTableSpec<Fuse> = {
     { name: "is_resettable", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -90,6 +91,7 @@ export const fuseTableSpec: DerivedTableSpec<Fuse> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
           current_rating: current_rating as number,
           voltage_rating: voltage_rating as number,
           response_time,

--- a/lib/db/derivedtables/gas_sensor.ts
+++ b/lib/db/derivedtables/gas_sensor.ts
@@ -36,6 +36,7 @@ export const gasSensorTableSpec: DerivedTableSpec<GasSensor> = {
     { name: "measures_explosive_gases", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db) {
     return db
@@ -82,6 +83,7 @@ export const gasSensorTableSpec: DerivedTableSpec<GasSensor> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
         package: c.package || "",
         sensor_type: sensorType,
         measures_air_quality: measuresAirQuality,

--- a/lib/db/derivedtables/gyroscope.ts
+++ b/lib/db/derivedtables/gyroscope.ts
@@ -28,6 +28,7 @@ export const gyroscopeTableSpec: DerivedTableSpec<Gyroscope> = {
     { name: "has_uart", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -106,6 +107,7 @@ export const gyroscopeTableSpec: DerivedTableSpec<Gyroscope> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
         package: c.package || "",
         supply_voltage_min: voltageMin,
         supply_voltage_max: voltageMax,

--- a/lib/db/derivedtables/header.ts
+++ b/lib/db/derivedtables/header.ts
@@ -48,6 +48,7 @@ export const headerTableSpec: DerivedTableSpec<Header> = {
     { name: "is_right_angle", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -197,6 +198,7 @@ export const headerTableSpec: DerivedTableSpec<Header> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
         price1: extractMinQPrice(c.price)!,
         package: c.package || "",
         pitch_mm: pitch,

--- a/lib/db/derivedtables/io_expander.ts
+++ b/lib/db/derivedtables/io_expander.ts
@@ -40,6 +40,7 @@ export const ioExpanderTableSpec: DerivedTableSpec<IoExpander> = {
     { name: "source_current_ma", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -139,6 +140,7 @@ export const ioExpanderTableSpec: DerivedTableSpec<IoExpander> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
         package: c.package || "",
         num_gpios: numGpios,
         supply_voltage_min: voltageMin,

--- a/lib/db/derivedtables/jst_connector.ts
+++ b/lib/db/derivedtables/jst_connector.ts
@@ -22,6 +22,7 @@ export const jstConnectorTableSpec: DerivedTableSpec<JstConnector> = {
     { name: "reference_series", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -69,6 +70,7 @@ export const jstConnectorTableSpec: DerivedTableSpec<JstConnector> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
           package: String(c.package || ""),
           pitch_mm: parseNum(attrs["Pitch"]),
           num_rows: isNaN(numRows) ? null : numRows,

--- a/lib/db/derivedtables/lcd_display.ts
+++ b/lib/db/derivedtables/lcd_display.ts
@@ -19,6 +19,7 @@ export const lcdDisplayTableSpec: DerivedTableSpec<LCDDisplay> = {
     { name: "display_type", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -64,6 +65,7 @@ export const lcdDisplayTableSpec: DerivedTableSpec<LCDDisplay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
           package: String(c.package || ""),
           display_size,
           resolution,

--- a/lib/db/derivedtables/led.ts
+++ b/lib/db/derivedtables/led.ts
@@ -37,6 +37,7 @@ export const ledTableSpec: DerivedTableSpec<Led> = {
     { name: "is_rgb", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -165,6 +166,7 @@ export const ledTableSpec: DerivedTableSpec<Led> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
         package: c.package || "",
         forward_voltage: forwardVoltage,
         forward_current: forwardCurrent,

--- a/lib/db/derivedtables/led_dot_matrix_display.ts
+++ b/lib/db/derivedtables/led_dot_matrix_display.ts
@@ -18,6 +18,7 @@ export const ledDotMatrixDisplayTableSpec: DerivedTableSpec<LEDDotMatrixDisplay>
       { name: "color", type: "text" },
       { name: "is_basic", type: "boolean" },
       { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
     ],
     listCandidateComponents(db: KyselyDatabaseInstance) {
       return db
@@ -57,6 +58,7 @@ export const ledDotMatrixDisplayTableSpec: DerivedTableSpec<LEDDotMatrixDisplay>
             in_stock: Boolean((c.stock || 0) > 0),
             is_basic: Boolean(c.basic),
             is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
             package: String(c.package || ""),
             matrix_size,
             color,

--- a/lib/db/derivedtables/led_driver.ts
+++ b/lib/db/derivedtables/led_driver.ts
@@ -42,6 +42,7 @@ export const ledDriverTableSpec: DerivedTableSpec<LedDriver> = {
     { name: "mounting_style", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -77,6 +78,7 @@ export const ledDriverTableSpec: DerivedTableSpec<LedDriver> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
           package: String(c.package || ""),
           supply_voltage_min: parseValue(attrs["Input Voltage"]?.split("~")[0]),
           supply_voltage_max: parseValue(attrs["Input Voltage"]?.split("~")[1]),

--- a/lib/db/derivedtables/led_segment_display.ts
+++ b/lib/db/derivedtables/led_segment_display.ts
@@ -21,6 +21,7 @@ export const ledSegmentDisplayTableSpec: DerivedTableSpec<LEDSegmentDisplay> = {
     { name: "color", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
 
   listCandidateComponents(db: KyselyDatabaseInstance) {
@@ -70,6 +71,7 @@ export const ledSegmentDisplayTableSpec: DerivedTableSpec<LEDSegmentDisplay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
           package: String(c.package || ""),
           positions,
           type,

--- a/lib/db/derivedtables/led_with_ic.ts
+++ b/lib/db/derivedtables/led_with_ic.ts
@@ -27,6 +27,7 @@ export const ledWithICTableSpec: DerivedTableSpec<LEDWithIC> = {
     { name: "protocol", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -99,6 +100,7 @@ export const ledWithICTableSpec: DerivedTableSpec<LEDWithIC> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
           package: String(c.package || ""),
           forward_voltage: forwardVoltage,
           forward_current: forwardCurrent,

--- a/lib/db/derivedtables/microcontroller.ts
+++ b/lib/db/derivedtables/microcontroller.ts
@@ -62,6 +62,7 @@ export const microcontrollerTableSpec: DerivedTableSpec<Microcontroller> = {
     { name: "dac_resolution_bits", type: "integer" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -228,6 +229,7 @@ export const microcontrollerTableSpec: DerivedTableSpec<Microcontroller> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
         package: c.package || "",
         cpu_core: cpuCore,
         cpu_speed_hz: cpuSpeed,

--- a/lib/db/derivedtables/mosfet.ts
+++ b/lib/db/derivedtables/mosfet.ts
@@ -35,6 +35,7 @@ export const mosfetTableSpec: DerivedTableSpec<Mosfet> = {
     { name: "mounting_style", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -68,6 +69,7 @@ export const mosfetTableSpec: DerivedTableSpec<Mosfet> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
           package: String(c.package || ""),
           drain_source_voltage: parseValue(
             attrs["Drain Source Voltage (Vdss)"],

--- a/lib/db/derivedtables/oled_display.ts
+++ b/lib/db/derivedtables/oled_display.ts
@@ -19,6 +19,7 @@ export const oledDisplayTableSpec: DerivedTableSpec<OLEDDisplay> = {
     { name: "pixel_resolution", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
 
   listCandidateComponents(db: KyselyDatabaseInstance) {
@@ -65,6 +66,7 @@ export const oledDisplayTableSpec: DerivedTableSpec<OLEDDisplay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
           package: String(c.package || ""),
           protocol: protocol || undefined,
           display_width,

--- a/lib/db/derivedtables/pcie_m2_connector.ts
+++ b/lib/db/derivedtables/pcie_m2_connector.ts
@@ -14,6 +14,7 @@ export const pcieM2ConnectorTableSpec: DerivedTableSpec<PcieM2Connector> = {
     { name: "is_right_angle", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -49,6 +50,7 @@ export const pcieM2ConnectorTableSpec: DerivedTableSpec<PcieM2Connector> = {
         in_stock: Boolean((c.stock || 0) > 0),
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
         key,
         is_right_angle: isRightAngle,
         attributes: attrs,

--- a/lib/db/derivedtables/potentiometer.ts
+++ b/lib/db/derivedtables/potentiometer.ts
@@ -19,6 +19,7 @@ export const potentiometerTableSpec: DerivedTableSpec<Potentiometer> = {
     { name: "is_surface_mount", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -67,6 +68,7 @@ export const potentiometerTableSpec: DerivedTableSpec<Potentiometer> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
         max_resistance: maxResistance,
         pin_variant: pinVariant,
         package: c.package || "",

--- a/lib/db/derivedtables/relay.ts
+++ b/lib/db/derivedtables/relay.ts
@@ -29,6 +29,7 @@ export const relayTableSpec: DerivedTableSpec<Relay> = {
     { name: "pin_number", type: "integer" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -62,6 +63,7 @@ export const relayTableSpec: DerivedTableSpec<Relay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
           package: String(c.package || ""),
           relay_type: (c as any).subcategory || "",
           contact_form: attrs["Contact Form"] || null,

--- a/lib/db/derivedtables/resistor.ts
+++ b/lib/db/derivedtables/resistor.ts
@@ -31,6 +31,7 @@ export const resistorTableSpec: DerivedTableSpec<Resistor> = {
     { name: "is_multi_resistor_chip", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -82,6 +83,7 @@ export const resistorTableSpec: DerivedTableSpec<Resistor> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
         resistance: resistance,
         tolerance_fraction: tolerance,
         power_watts,

--- a/lib/db/derivedtables/resistor_array.ts
+++ b/lib/db/derivedtables/resistor_array.ts
@@ -69,6 +69,7 @@ export const resistorArrayTableSpec: DerivedTableSpec<ResistorArray> = {
     { name: "is_surface_mount", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db

--- a/lib/db/derivedtables/switch.ts
+++ b/lib/db/derivedtables/switch.ts
@@ -37,6 +37,7 @@ export const switchTableSpec: DerivedTableSpec<Switch> = {
     { name: "switch_height_mm", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db) {
     return db
@@ -91,6 +92,7 @@ export const switchTableSpec: DerivedTableSpec<Switch> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
         package: c.package || "",
         switch_type: (c as any).subcategory || "",
         circuit: attrs["Circuit"] || null,

--- a/lib/db/derivedtables/usb_c_connector.ts
+++ b/lib/db/derivedtables/usb_c_connector.ts
@@ -28,6 +28,7 @@ export const usbCConnectorTableSpec: DerivedTableSpec<UsbCConnector> = {
     { name: "operating_temp_max", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -69,6 +70,7 @@ export const usbCConnectorTableSpec: DerivedTableSpec<UsbCConnector> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
           package: String(c.package || ""),
           mounting_style: attrs["Mounting Style"] || null,
           current_rating_a: parseNum(attrs["Current Rating - Power (Max)"]),

--- a/lib/db/derivedtables/voltage_regulator.ts
+++ b/lib/db/derivedtables/voltage_regulator.ts
@@ -43,6 +43,7 @@ export const voltageRegulatorTableSpec: DerivedTableSpec<VoltageRegulator> = {
     { name: "topology", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -184,6 +185,7 @@ export const voltageRegulatorTableSpec: DerivedTableSpec<VoltageRegulator> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
         package: c.package || "",
         output_type: outputType,
         output_voltage_min: voltageMin,

--- a/lib/db/derivedtables/wifi_module.ts
+++ b/lib/db/derivedtables/wifi_module.ts
@@ -45,6 +45,7 @@ export const wifiModuleTableSpec: DerivedTableSpec<WifiModule> = {
     { name: "has_pwm", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -140,6 +141,7 @@ export const wifiModuleTableSpec: DerivedTableSpec<WifiModule> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
         package: c.package || "",
         core_processor: attrs["Core Processor"] || null,
         antenna_type: attrs["Antenna Type"] || null,

--- a/lib/db/derivedtables/wire_to_board_connector.ts
+++ b/lib/db/derivedtables/wire_to_board_connector.ts
@@ -61,6 +61,7 @@ export const wireToBoardConnectorTableSpec: DerivedTableSpec<WireToBoardConnecto
       { name: "is_smd", type: "boolean" },
       { name: "is_basic", type: "boolean" },
       { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
     ],
     listCandidateComponents(db: KyselyDatabaseInstance) {
       return db
@@ -100,6 +101,7 @@ export const wireToBoardConnectorTableSpec: DerivedTableSpec<WireToBoardConnecto
             in_stock: Boolean((c.stock || 0) > 0),
             is_basic: Boolean(c.basic),
             is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.extended_promotional || false),
             package: String(c.package || ""),
             pitch_mm: pitchMm,
             num_rows: numRows,

--- a/routes/capacitors/list.tsx
+++ b/routes/capacitors/list.tsx
@@ -13,6 +13,7 @@ export default withWinterSpec({
     package: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
     capacitance: z
       .string()
       .optional()
@@ -32,6 +33,7 @@ export default withWinterSpec({
           package: z.string(),
           is_basic: z.boolean(),
           is_preferred: z.boolean(),
+          is_extended_promotional: z.boolean(),
           capacitance: z.number(),
           voltage: z.number().optional(),
           type: z.string().optional(),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -23,6 +23,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {

--- a/routes/resistor_arrays/list.tsx
+++ b/routes/resistor_arrays/list.tsx
@@ -46,6 +46,7 @@ export default withWinterSpec({
       .transform((val) => normalizeTopologyParam(val)),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
     resistance: z
       .string()
       .optional()
@@ -65,6 +66,7 @@ export default withWinterSpec({
           package: z.string(),
           is_basic: z.boolean(),
           is_preferred: z.boolean(),
+          is_extended_promotional: z.boolean(),
           number_of_resistors: z.number().nullable(),
           number_of_pins: z.number().nullable(),
           topology: z.string().nullable(),

--- a/routes/resistors/list.tsx
+++ b/routes/resistors/list.tsx
@@ -13,6 +13,7 @@ export default withWinterSpec({
     package: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
     resistance: z
       .string()
       .optional()
@@ -32,6 +33,7 @@ export default withWinterSpec({
           package: z.string(),
           is_basic: z.boolean(),
           is_preferred: z.boolean(),
+          is_extended_promotional: z.boolean(),
           resistance: z.number(),
           tolerance_fraction: z.number().optional(),
           power_watts: z.number().optional(),
@@ -62,6 +64,9 @@ export default withWinterSpec({
   if (params.is_preferred) {
     query = query.where("is_preferred", "=", 1)
   }
+  if (params.is_extended_promotional) {
+    query = query.where("is_extended_promotional", "=", 1)
+  }
 
   // Apply resistance filter with a small tolerance for rounding errors
   if (params.resistance != null) {
@@ -88,6 +93,7 @@ export default withWinterSpec({
           package: r.package ?? "",
           is_basic: Boolean(r.is_basic),
           is_preferred: Boolean(r.is_preferred),
+          is_extended_promotional: Boolean(r.is_extended_promotional),
           resistance: r.resistance ?? 0,
           tolerance_fraction: r.tolerance_fraction ?? undefined,
           power_watts: r.power_watts ?? undefined,
@@ -144,6 +150,18 @@ export default withWinterSpec({
         </div>
 
         <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={params.is_extended_promotional}
+            />
+          </label>
+        </div>
+
+        <div>
           <label>Resistance:</label>
           <input
             type="text"
@@ -163,6 +181,7 @@ export default withWinterSpec({
           package: r.package,
           is_basic: r.is_basic ? "✓" : "",
           is_preferred: r.is_preferred ? "✓" : "",
+          is_extended_promotional: r.is_extended_promotional ? "✓" : "",
           resistance: (
             <span className="tabular-nums">{formatSiUnit(r.resistance)}Ω</span>
           ),


### PR DESCRIPTION
Closes #98

Adds 'Extended Promotional' checkbox alongside 'Basic Part' and 'Preferred Part' filters.

Changes:
- Added  boolean field to all 40+ component derived tables
- Updated component-base.ts interface
- Added filter in route handlers (resistors, capacitors, resistor_arrays, components)
- Added UI checkbox in the filter form

The filter allows users to search for components that are marked as 'Extended Promotional' (JLC's higher-tier basic parts).

All existing filters still work — this adds a new option without breaking existing functionality.