### PR TITLE
feat: add is_extended_promotional column to components

### DIFF
--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -192,6 +192,7 @@ export interface Component {
   description: string;
   extra: string | null;
   flag: Generated<number>;
+  is_extended_promotional: number | null;
   joints: number;
   last_on_stock: Generated<number>;
   last_update: number;

--- a/lib/db/optimizations/component-is-extended-promotional-column.ts
+++ b/lib/db/optimizations/component-is-extended-promotional-column.ts
@@ -1,0 +1,35 @@
+import { sql } from "kysely"
+import type { DbOptimizationSpec } from "./types"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+
+export const componentIsExtendedPromotionalColumn: DbOptimizationSpec = {
+  name: "add_components_is_extended_promotional_column",
+  description:
+    "Adds is_extended_promotional boolean column to components table derived from extra JSON field",
+
+  async checkIfAdded(db: KyselyDatabaseInstance) {
+    const {
+      rows: [ex],
+    } = await sql<any>`
+      SELECT * FROM components LIMIT 1
+    `.execute(db)
+
+    return ex && "is_extended_promotional" in ex
+  },
+
+  async execute(db: KyselyDatabaseInstance) {
+    // Add the column
+    await sql`
+      ALTER TABLE components 
+      ADD COLUMN is_extended_promotional boolean 
+      GENERATED ALWAYS AS (json_extract(extra, '$.is_extended_promotional'))
+    `.execute(db)
+
+    // Create an index on the new column
+    await db.schema
+      .createIndex("idx_components_is_extended_promotional")
+      .on("components")
+      .column("is_extended_promotional")
+      .execute()
+  },
+}

--- a/scripts/setup-db-optimizations.ts
+++ b/scripts/setup-db-optimizations.ts
@@ -9,6 +9,7 @@ import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
 import { componentPackageIndex } from "lib/db/optimizations/component-indexes"
 import { componentBasicIndex } from "lib/db/optimizations/component-basic-index"
 import { componentPreferredIndex } from "lib/db/optimizations/component-preferred-index"
+import { componentIsExtendedPromotionalColumn } from "lib/db/optimizations/component-is-extended-promotional-column"
 
 const OPTIMIZATIONS: DbOptimizationSpec[] = [
   componentSearchFTS,
@@ -20,6 +21,7 @@ const OPTIMIZATIONS: DbOptimizationSpec[] = [
   componentInStockColumn,
   componentCategoryIndex,
   componentInStockCategoryIndex,
+  componentIsExtendedPromotionalColumn,
 ]
 
 async function main() {


### PR DESCRIPTION
This PR adds the `is_extended_promotional` column to the `components` table.\n\n### Changes\n- Added `component-is-extended-promotional-column.ts` optimization script.\n- Integrated the new column into `setup-db-optimizations.ts`.\n- Manually updated Kysely types in `lib/db/generated/kysely.ts` to include the new field.\n\nFixes #92