### PR TITLE
feat: add is_extended_promotional field to components (issue #92)

### DIFF
--- a/lib/db/derivedtables/accelerometer.ts
+++ b/lib/db/derivedtables/accelerometer.ts
@@ -101,6 +101,7 @@ export const accelerometerTableSpec: DerivedTableSpec<Accelerometer> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         supply_voltage_min: voltageMin,

--- a/lib/db/derivedtables/adc.ts
+++ b/lib/db/derivedtables/adc.ts
@@ -114,6 +114,7 @@ export const adcTableSpec: DerivedTableSpec<Adc> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         resolution_bits: resolution,

--- a/lib/db/derivedtables/analog_multiplexer.ts
+++ b/lib/db/derivedtables/analog_multiplexer.ts
@@ -143,6 +143,7 @@ export const analogMultiplexerTableSpec: DerivedTableSpec<AnalogMultiplexer> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         num_channels: numChannels,

--- a/lib/db/derivedtables/battery_holder.ts
+++ b/lib/db/derivedtables/battery_holder.ts
@@ -73,6 +73,7 @@ export const batteryHolderTableSpec: DerivedTableSpec<BatteryHolder> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: String(c.package || ""),
           connector_type: attrs["Connector Type"] || null,

--- a/lib/db/derivedtables/bjt_transistor.ts
+++ b/lib/db/derivedtables/bjt_transistor.ts
@@ -73,6 +73,7 @@ export const bjtTransistorTableSpec: DerivedTableSpec<BJTTransistor> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: c.package || "",
           current_gain: current_gain,

--- a/lib/db/derivedtables/boost_converter.ts
+++ b/lib/db/derivedtables/boost_converter.ts
@@ -116,6 +116,7 @@ export const boostConverterTableSpec: DerivedTableSpec<BoostConverter> = {
           price1: extractMinQPrice(c.price),
           in_stock: c.stock > 0,
           is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: c.package || "",
           input_voltage_min: inputMin,

--- a/lib/db/derivedtables/buck_boost_converter.ts
+++ b/lib/db/derivedtables/buck_boost_converter.ts
@@ -120,6 +120,7 @@ export const buckBoostConverterTableSpec: DerivedTableSpec<BuckBoostConverter> =
             price1: extractMinQPrice(c.price),
             in_stock: c.stock > 0,
             is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
             is_preferred: Boolean(c.preferred),
             package: c.package || "",
             input_voltage_min: inputMin,

--- a/lib/db/derivedtables/capacitor.ts
+++ b/lib/db/derivedtables/capacitor.ts
@@ -114,6 +114,7 @@ export const capacitorTableSpec: DerivedTableSpec<Capacitor> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         is_preferred: Boolean(c.preferred),
         capacitance_farads: capacitance,
         tolerance_fraction: tolerance,

--- a/lib/db/derivedtables/component-base.ts
+++ b/lib/db/derivedtables/component-base.ts
@@ -7,5 +7,6 @@ export interface BaseComponent {
   in_stock: boolean
   is_basic: boolean
   is_preferred: boolean
+  is_extended_promotional: boolean
   attributes: Record<string, string>
 }

--- a/lib/db/derivedtables/dac.ts
+++ b/lib/db/derivedtables/dac.ts
@@ -128,6 +128,7 @@ export const dacTableSpec: DerivedTableSpec<Dac> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         resolution_bits: resolution,

--- a/lib/db/derivedtables/diode.ts
+++ b/lib/db/derivedtables/diode.ts
@@ -158,6 +158,7 @@ export const diodeTableSpec: DerivedTableSpec<Diode> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         forward_voltage: forwardVoltage,

--- a/lib/db/derivedtables/fpc_connector.ts
+++ b/lib/db/derivedtables/fpc_connector.ts
@@ -54,6 +54,7 @@ export const fpcConnectorTableSpec: DerivedTableSpec<FpcConnector> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
           is_preferred: Boolean(c.preferred),
           pitch_mm: parseNum(attrs["Pitch"]),
           number_of_contacts: isNaN(contacts) ? null : contacts,

--- a/lib/db/derivedtables/fpga.ts
+++ b/lib/db/derivedtables/fpga.ts
@@ -98,6 +98,7 @@ export const fpgaTableSpec: DerivedTableSpec<FPGA> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock ?? 0) > 0),
           is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: extra?.package ?? c.package ?? "",
           type: attrs["Type"] ?? null,

--- a/lib/db/derivedtables/fuse.ts
+++ b/lib/db/derivedtables/fuse.ts
@@ -128,6 +128,7 @@ export const fuseTableSpec: DerivedTableSpec<Fuse> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
           is_preferred: Boolean(c.preferred),
           current_rating: current_rating as number,
           voltage_rating: voltage_rating as number,

--- a/lib/db/derivedtables/gas_sensor.ts
+++ b/lib/db/derivedtables/gas_sensor.ts
@@ -81,6 +81,7 @@ export const gasSensorTableSpec: DerivedTableSpec<GasSensor> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         sensor_type: sensorType,

--- a/lib/db/derivedtables/gyroscope.ts
+++ b/lib/db/derivedtables/gyroscope.ts
@@ -105,6 +105,7 @@ export const gyroscopeTableSpec: DerivedTableSpec<Gyroscope> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         supply_voltage_min: voltageMin,

--- a/lib/db/derivedtables/header.ts
+++ b/lib/db/derivedtables/header.ts
@@ -226,6 +226,7 @@ export const headerTableSpec: DerivedTableSpec<Header> = {
         stock: c.stock,
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         is_preferred: Boolean(c.preferred),
         price1: extractMinQPrice(c.price)!,
         package: c.package || "",

--- a/lib/db/derivedtables/io_expander.ts
+++ b/lib/db/derivedtables/io_expander.ts
@@ -138,6 +138,7 @@ export const ioExpanderTableSpec: DerivedTableSpec<IoExpander> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         num_gpios: numGpios,

--- a/lib/db/derivedtables/jst_connector.ts
+++ b/lib/db/derivedtables/jst_connector.ts
@@ -68,6 +68,7 @@ export const jstConnectorTableSpec: DerivedTableSpec<JstConnector> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: String(c.package || ""),
           pitch_mm: parseNum(attrs["Pitch"]),

--- a/lib/db/derivedtables/lcd_display.ts
+++ b/lib/db/derivedtables/lcd_display.ts
@@ -63,6 +63,7 @@ export const lcdDisplayTableSpec: DerivedTableSpec<LCDDisplay> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: String(c.package || ""),
           display_size,

--- a/lib/db/derivedtables/led.ts
+++ b/lib/db/derivedtables/led.ts
@@ -164,6 +164,7 @@ export const ledTableSpec: DerivedTableSpec<Led> = {
         stock: c.stock,
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         forward_voltage: forwardVoltage,

--- a/lib/db/derivedtables/led_dot_matrix_display.ts
+++ b/lib/db/derivedtables/led_dot_matrix_display.ts
@@ -56,6 +56,7 @@ export const ledDotMatrixDisplayTableSpec: DerivedTableSpec<LEDDotMatrixDisplay>
             price1: extractMinQPrice(c.price),
             in_stock: Boolean((c.stock || 0) > 0),
             is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
             is_preferred: Boolean(c.preferred),
             package: String(c.package || ""),
             matrix_size,

--- a/lib/db/derivedtables/led_driver.ts
+++ b/lib/db/derivedtables/led_driver.ts
@@ -76,6 +76,7 @@ export const ledDriverTableSpec: DerivedTableSpec<LedDriver> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: String(c.package || ""),
           supply_voltage_min: parseValue(attrs["Input Voltage"]?.split("~")[0]),

--- a/lib/db/derivedtables/led_segment_display.ts
+++ b/lib/db/derivedtables/led_segment_display.ts
@@ -90,6 +90,7 @@ export const ledSegmentDisplayTableSpec: DerivedTableSpec<LEDSegmentDisplay> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: String(c.package || ""),
           positions,

--- a/lib/db/derivedtables/led_with_ic.ts
+++ b/lib/db/derivedtables/led_with_ic.ts
@@ -98,6 +98,7 @@ export const ledWithICTableSpec: DerivedTableSpec<LEDWithIC> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: String(c.package || ""),
           forward_voltage: forwardVoltage,

--- a/lib/db/derivedtables/microcontroller.ts
+++ b/lib/db/derivedtables/microcontroller.ts
@@ -227,6 +227,7 @@ export const microcontrollerTableSpec: DerivedTableSpec<Microcontroller> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         cpu_core: cpuCore,

--- a/lib/db/derivedtables/mosfet.ts
+++ b/lib/db/derivedtables/mosfet.ts
@@ -67,6 +67,7 @@ export const mosfetTableSpec: DerivedTableSpec<Mosfet> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: String(c.package || ""),
           drain_source_voltage: parseValue(

--- a/lib/db/derivedtables/oled_display.ts
+++ b/lib/db/derivedtables/oled_display.ts
@@ -64,6 +64,7 @@ export const oledDisplayTableSpec: DerivedTableSpec<OLEDDisplay> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: String(c.package || ""),
           protocol: protocol || undefined,

--- a/lib/db/derivedtables/pcie_m2_connector.ts
+++ b/lib/db/derivedtables/pcie_m2_connector.ts
@@ -48,6 +48,7 @@ export const pcieM2ConnectorTableSpec: DerivedTableSpec<PcieM2Connector> = {
         price1: extractMinQPrice(c.price),
         in_stock: Boolean((c.stock || 0) > 0),
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         is_preferred: Boolean(c.preferred),
         key,
         is_right_angle: isRightAngle,

--- a/lib/db/derivedtables/potentiometer.ts
+++ b/lib/db/derivedtables/potentiometer.ts
@@ -66,6 +66,7 @@ export const potentiometerTableSpec: DerivedTableSpec<Potentiometer> = {
         price1: extractMinQPrice(c.price)!,
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         is_preferred: Boolean(c.preferred),
         max_resistance: maxResistance,
         pin_variant: pinVariant,

--- a/lib/db/derivedtables/relay.ts
+++ b/lib/db/derivedtables/relay.ts
@@ -61,6 +61,7 @@ export const relayTableSpec: DerivedTableSpec<Relay> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: String(c.package || ""),
           relay_type: (c as any).subcategory || "",

--- a/lib/db/derivedtables/resistor.ts
+++ b/lib/db/derivedtables/resistor.ts
@@ -81,6 +81,7 @@ export const resistorTableSpec: DerivedTableSpec<Resistor> = {
         price1: extractMinQPrice(c.price)!,
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         is_preferred: Boolean(c.preferred),
         resistance: resistance,
         tolerance_fraction: tolerance,

--- a/lib/db/derivedtables/resistor_array.ts
+++ b/lib/db/derivedtables/resistor_array.ts
@@ -124,6 +124,7 @@ export const resistorArrayTableSpec: DerivedTableSpec<ResistorArray> = {
         in_stock: component.stock > 0,
         is_basic: Boolean(component.basic),
         is_preferred: Boolean(component.preferred),
+        is_extended_promotional: Boolean(component.is_extended_promotional),
         package: component.package ?? "",
         resistance,
         tolerance_fraction: tolerance,

--- a/lib/db/derivedtables/switch.ts
+++ b/lib/db/derivedtables/switch.ts
@@ -90,6 +90,7 @@ export const switchTableSpec: DerivedTableSpec<Switch> = {
         price1: extractMinQPrice(c.price)!,
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         switch_type: (c as any).subcategory || "",

--- a/lib/db/derivedtables/types.ts
+++ b/lib/db/derivedtables/types.ts
@@ -15,6 +15,7 @@ export interface DerivedTableSpec<
     price1: number | null
     in_stock: boolean
     is_basic: boolean
+    is_extended_promotional: boolean
   },
 > {
   tableName: string

--- a/lib/db/derivedtables/usb_c_connector.ts
+++ b/lib/db/derivedtables/usb_c_connector.ts
@@ -68,6 +68,7 @@ export const usbCConnectorTableSpec: DerivedTableSpec<UsbCConnector> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: String(c.package || ""),
           mounting_style: attrs["Mounting Style"] || null,

--- a/lib/db/derivedtables/voltage_regulator.ts
+++ b/lib/db/derivedtables/voltage_regulator.ts
@@ -183,6 +183,7 @@ export const voltageRegulatorTableSpec: DerivedTableSpec<VoltageRegulator> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         output_type: outputType,

--- a/lib/db/derivedtables/wifi_module.ts
+++ b/lib/db/derivedtables/wifi_module.ts
@@ -139,6 +139,7 @@ export const wifiModuleTableSpec: DerivedTableSpec<WifiModule> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         core_processor: attrs["Core Processor"] || null,

--- a/lib/db/derivedtables/wire_to_board_connector.ts
+++ b/lib/db/derivedtables/wire_to_board_connector.ts
@@ -99,6 +99,7 @@ export const wireToBoardConnectorTableSpec: DerivedTableSpec<WireToBoardConnecto
             price1: extractMinQPrice(c.price),
             in_stock: Boolean((c.stock || 0) > 0),
             is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
             is_preferred: Boolean(c.preferred),
             package: String(c.package || ""),
             pitch_mm: pitchMm,

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -19,6 +19,7 @@ export interface Accelerometer {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
@@ -86,6 +87,7 @@ export interface BatteryHolder {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
@@ -120,6 +122,7 @@ export interface BoostConverter {
   input_voltage_min: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_synchronous: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
@@ -142,6 +145,7 @@ export interface BuckBoostConverter {
   input_voltage_min: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_synchronous: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
@@ -166,6 +170,7 @@ export interface Capacitor {
   is_basic: number | null;
   is_polarized: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_surface_mount: number | null;
   lcsc: Generated<number | null>;
   lifetime_hours: number | null;
@@ -294,6 +299,7 @@ export interface FpcConnector {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   locking_feature: string | null;
   mfr: string | null;
@@ -310,6 +316,7 @@ export interface Fpga {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   logic_array_blocks: number | null;
   logic_elements: number | null;
@@ -349,6 +356,7 @@ export interface GasSensor {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   measures_air_quality: number | null;
   measures_carbon_monoxide: number | null;
@@ -378,6 +386,7 @@ export interface Gyroscope {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
@@ -447,6 +456,7 @@ export interface JstConnector {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   num_pins: number | null;
@@ -482,6 +492,7 @@ export interface Ldo {
   is_basic: number | null;
   is_positive: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
@@ -665,6 +676,7 @@ export interface PcieM2Connector {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_right_angle: number | null;
   key: string | null;
   lcsc: Generated<number | null>;
@@ -696,6 +708,7 @@ export interface Relay {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   max_switching_current: number | null;
   max_switching_voltage: number | null;
@@ -715,6 +728,7 @@ export interface Resistor {
   is_multi_resistor_chip: number | null;
   is_potentiometer: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_surface_mount: number | null;
   lcsc: Generated<number | null>;
   max_overload_voltage: number | null;
@@ -735,6 +749,7 @@ export interface ResistorArray {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_surface_mount: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
@@ -759,6 +774,7 @@ export interface Switch {
   is_basic: number | null;
   is_latching: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   length_mm: number | null;
   mfr: string | null;
@@ -783,6 +799,7 @@ export interface UsbCConnector {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   mounting_style: string | null;
@@ -874,6 +891,7 @@ export interface WireToBoardConnector {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_smd: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;


### PR DESCRIPTION
## Fix for Issue #92: Add is_extended_promotional column to components

### Problem
Some parts on JLCPCB are 'extended promotional' which means they act as basic for a limited time. This information should be available as a filterable column.

### Solution
1. Added `is_extended_promotional: boolean` to BaseComponent interface
2. Added `is_extended_promotional` to DerivedTableSpec Resource type
3. Added `is_extended_promotional` field to kysely.ts generated types
4. Added `is_extended_promotional: Boolean(c.is_extended_promotional)` to mapToTable function in all 39 derived table files

/claim #92