### PR TITLE
Add is_extended_promotional column to components

### DIFF
--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -7,6 +7,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -25,6 +26,7 @@ export async function queryComponentCatalog(
     stock: number | null
     price: string | null
     extra: string | null
+    is_extended_promotional: number | null
   }>
 > {
   let query = db
@@ -48,6 +50,10 @@ export async function queryComponentCatalog(
 
   if (params.is_preferred === "true") {
     query = query.where("preferred", "=", 1)
+  }
+
+  if (params.is_extended_promotional === "true") {
+    query = query.where("is_extended_promotional", "=", 1)
   }
 
   if (params.search) {

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -168,6 +168,7 @@ export interface ComponentCatalog {
   price: string | null
   stock: number | null
   subcategory: string | null
+  is_extended_promotional: number | null
 }
 
 export interface Capacitor {
@@ -672,6 +673,7 @@ export interface SearchIndex {
   stock: number | null
   subcategory: string | null
   title: string | null
+  is_extended_promotional: number | null
 }
 
 export interface Resistor {

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -812,6 +812,7 @@ export interface VComponent {
   price: string | null;
   stock: number | null;
   subcategory: string | null;
+  is_extended_promotional: number | null;
 }
 
 export interface VoltageRegulator {

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -23,6 +23,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -39,6 +40,8 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
+      "is_extended_promotional",
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -57,6 +60,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("is_extended_promotional", "=", 1)
   }
 
   if (req.query.search) {
@@ -82,6 +88,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.is_extended_promotional),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -123,6 +130,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>


### PR DESCRIPTION
## Summary
- Add `is_extended_promotional` field to ComponentCatalog type
- Add `is_extended_promotional` column to VComponent type
- Add filter checkbox for extended promotional components
- Update queryComponentCatalog to support filtering

## Test plan
- [ ] Verify column appears in components list
- [ ] Test filter checkbox works correctly

Closes #92