### PR TITLE
feat: add is_extended_promotional column to components (#92)

### DIFF
--- a/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
+++ b/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
@@ -14,6 +14,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -51,3 +52,4 @@ CREATE INDEX IF NOT EXISTS idx_search_index_lcsc ON search_index(lcsc);
 CREATE INDEX IF NOT EXISTS idx_search_index_package ON search_index(package);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
+CREATE INDEX IF NOT EXISTS idx_search_index_is_extended_promotional ON search_index(is_extended_promotional);

--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -260,6 +260,7 @@ SELECT
   package,
   basic,
   preferred,
+  is_extended_promotional,
   description,
   stock,
   price,
@@ -270,6 +271,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_is_extended_promotional ON component_catalog(is_extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA
 
@@ -283,6 +285,7 @@ CREATE TABLE component_catalog (
   package TEXT,
   basic INTEGER,
   preferred INTEGER,
+  is_extended_promotional INTEGER,
   description TEXT,
   stock INTEGER,
   price TEXT,
@@ -292,6 +295,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_is_extended_promotional ON component_catalog(is_extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA_EXPORT
 }
@@ -314,6 +318,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -351,6 +356,7 @@ CREATE INDEX IF NOT EXISTS idx_search_index_lcsc ON search_index(lcsc);
 CREATE INDEX IF NOT EXISTS idx_search_index_package ON search_index(package);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
+CREATE INDEX IF NOT EXISTS idx_search_index_is_extended_promotional ON search_index(is_extended_promotional);
 SEARCH_INDEX_SCHEMA
 
   cat > search_index_schema.sql <<'SEARCH_INDEX_SCHEMA_EXPORT'
@@ -365,6 +371,7 @@ CREATE TABLE search_index (
   price1 REAL,
   basic INTEGER,
   preferred INTEGER,
+  is_extended_promotional INTEGER,
   category TEXT,
   subcategory TEXT,
   manufacturer_name TEXT,
@@ -378,6 +385,7 @@ CREATE INDEX IF NOT EXISTS idx_search_index_lcsc ON search_index(lcsc);
 CREATE INDEX IF NOT EXISTS idx_search_index_package ON search_index(package);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
+CREATE INDEX IF NOT EXISTS idx_search_index_is_extended_promotional ON search_index(is_extended_promotional);
 SEARCH_INDEX_SCHEMA_EXPORT
 }
 

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -7,6 +7,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -21,6 +22,7 @@ export async function queryComponentCatalog(
     package: string | null
     basic: number | null
     preferred: number | null
+    is_extended_promotional: number | null
     description: string | null
     stock: number | null
     price: string | null
@@ -48,6 +50,10 @@ export async function queryComponentCatalog(
 
   if (params.is_preferred === "true") {
     query = query.where("preferred", "=", 1)
+  }
+
+  if (params.is_extended_promotional === "true") {
+    query = query.where("is_extended_promotional", "=", 1)
   }
 
   if (params.search) {

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -161,6 +161,7 @@ export interface ComponentCatalog {
   category: string | null
   description: string | null
   extra: string | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   package: string | null
@@ -660,6 +661,7 @@ export interface SearchIndex {
   basic: number | null
   category: string | null
   description: string | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   manufacturer_name: string | null

--- a/lib/db/derivedtables/accelerometer.ts
+++ b/lib/db/derivedtables/accelerometer.ts
@@ -28,6 +28,7 @@ export const accelerometerTableSpec: DerivedTableSpec<Accelerometer> = {
     { name: "has_uart", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -102,6 +103,7 @@ export const accelerometerTableSpec: DerivedTableSpec<Accelerometer> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         supply_voltage_min: voltageMin,
         supply_voltage_max: voltageMax,

--- a/lib/db/derivedtables/adc.ts
+++ b/lib/db/derivedtables/adc.ts
@@ -40,6 +40,7 @@ export const adcTableSpec: DerivedTableSpec<Adc> = {
     { name: "operating_temp_max", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -115,6 +116,7 @@ export const adcTableSpec: DerivedTableSpec<Adc> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         resolution_bits: resolution,
         sampling_rate_hz: samplingRate,

--- a/lib/db/derivedtables/analog_multiplexer.ts
+++ b/lib/db/derivedtables/analog_multiplexer.ts
@@ -40,6 +40,7 @@ export const analogMultiplexerTableSpec: DerivedTableSpec<AnalogMultiplexer> = {
     { name: "channel_type", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -144,6 +145,7 @@ export const analogMultiplexerTableSpec: DerivedTableSpec<AnalogMultiplexer> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         num_channels: numChannels,
         num_bits: numBits,

--- a/lib/db/derivedtables/battery_holder.ts
+++ b/lib/db/derivedtables/battery_holder.ts
@@ -32,6 +32,7 @@ export const batteryHolderTableSpec: DerivedTableSpec<BatteryHolder> = {
     { name: "operating_temp_max", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -74,6 +75,7 @@ export const batteryHolderTableSpec: DerivedTableSpec<BatteryHolder> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: String(c.package || ""),
           connector_type: attrs["Connector Type"] || null,
           battery_type: attrs["Battery Type"] || null,

--- a/lib/db/derivedtables/bjt_transistor.ts
+++ b/lib/db/derivedtables/bjt_transistor.ts
@@ -26,6 +26,7 @@ export const bjtTransistorTableSpec: DerivedTableSpec<BJTTransistor> = {
     { name: "temperature_range", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -74,6 +75,7 @@ export const bjtTransistorTableSpec: DerivedTableSpec<BJTTransistor> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: c.package || "",
           current_gain: current_gain,
           collector_current: collector_current,

--- a/lib/db/derivedtables/boost_converter.ts
+++ b/lib/db/derivedtables/boost_converter.ts
@@ -31,6 +31,7 @@ export const boostConverterTableSpec: DerivedTableSpec<BoostConverter> = {
     { name: "number_of_outputs", type: "integer" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -117,6 +118,7 @@ export const boostConverterTableSpec: DerivedTableSpec<BoostConverter> = {
           in_stock: c.stock > 0,
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: c.package || "",
           input_voltage_min: inputMin,
           input_voltage_max: inputMax,

--- a/lib/db/derivedtables/buck_boost_converter.ts
+++ b/lib/db/derivedtables/buck_boost_converter.ts
@@ -32,6 +32,7 @@ export const buckBoostConverterTableSpec: DerivedTableSpec<BuckBoostConverter> =
       { name: "number_of_outputs", type: "integer" },
       { name: "is_basic", type: "boolean" },
       { name: "is_preferred", type: "boolean" },
+      { name: "is_extended_promotional", type: "boolean" },
     ],
     listCandidateComponents: (db) =>
       db
@@ -121,6 +122,7 @@ export const buckBoostConverterTableSpec: DerivedTableSpec<BuckBoostConverter> =
             in_stock: c.stock > 0,
             is_basic: Boolean(c.basic),
             is_preferred: Boolean(c.preferred),
+            is_extended_promotional: Boolean(c.is_extended_promotional),
             package: c.package || "",
             input_voltage_min: inputMin,
             input_voltage_max: inputMax,

--- a/lib/db/derivedtables/capacitor.ts
+++ b/lib/db/derivedtables/capacitor.ts
@@ -34,6 +34,7 @@ export const capacitorTableSpec: DerivedTableSpec<Capacitor> = {
     { name: "capacitor_type", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -115,6 +116,7 @@ export const capacitorTableSpec: DerivedTableSpec<Capacitor> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         capacitance_farads: capacitance,
         tolerance_fraction: tolerance,
         voltage_rating: voltage,

--- a/lib/db/derivedtables/component-base.ts
+++ b/lib/db/derivedtables/component-base.ts
@@ -7,5 +7,6 @@ export interface BaseComponent {
   in_stock: boolean
   is_basic: boolean
   is_preferred: boolean
+  is_extended_promotional: boolean
   attributes: Record<string, string>
 }

--- a/lib/db/derivedtables/dac.ts
+++ b/lib/db/derivedtables/dac.ts
@@ -38,6 +38,7 @@ export const dacTableSpec: DerivedTableSpec<Dac> = {
     { name: "nonlinearity_lsb", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -129,6 +130,7 @@ export const dacTableSpec: DerivedTableSpec<Dac> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         resolution_bits: resolution,
         num_channels: numChannels,

--- a/lib/db/derivedtables/diode.ts
+++ b/lib/db/derivedtables/diode.ts
@@ -40,6 +40,7 @@ export const diodeTableSpec: DerivedTableSpec<Diode> = {
     { name: "configuration", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -159,6 +160,7 @@ export const diodeTableSpec: DerivedTableSpec<Diode> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         forward_voltage: forwardVoltage,
         reverse_voltage: reverseVoltage,

--- a/lib/db/derivedtables/fpc_connector.ts
+++ b/lib/db/derivedtables/fpc_connector.ts
@@ -20,6 +20,7 @@ export const fpcConnectorTableSpec: DerivedTableSpec<FpcConnector> = {
     { name: "locking_feature", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -55,6 +56,7 @@ export const fpcConnectorTableSpec: DerivedTableSpec<FpcConnector> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           pitch_mm: parseNum(attrs["Pitch"]),
           number_of_contacts: isNaN(contacts) ? null : contacts,
           contact_type: attrs["Contact Type"] || null,

--- a/lib/db/derivedtables/fpga.ts
+++ b/lib/db/derivedtables/fpga.ts
@@ -68,6 +68,7 @@ export const fpgaTableSpec: DerivedTableSpec<FPGA> = {
     { name: "logic_gates", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -99,6 +100,7 @@ export const fpgaTableSpec: DerivedTableSpec<FPGA> = {
           in_stock: Boolean((c.stock ?? 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: extra?.package ?? c.package ?? "",
           type: attrs["Type"] ?? null,
           logic_array_blocks: parseNumericValue(attrs["Logic Array Blocks"]),

--- a/lib/db/derivedtables/fuse.ts
+++ b/lib/db/derivedtables/fuse.ts
@@ -37,6 +37,7 @@ export const fuseTableSpec: DerivedTableSpec<Fuse> = {
     { name: "is_resettable", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -129,6 +130,7 @@ export const fuseTableSpec: DerivedTableSpec<Fuse> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           current_rating: current_rating as number,
           voltage_rating: voltage_rating as number,
           response_time,

--- a/lib/db/derivedtables/gas_sensor.ts
+++ b/lib/db/derivedtables/gas_sensor.ts
@@ -36,6 +36,7 @@ export const gasSensorTableSpec: DerivedTableSpec<GasSensor> = {
     { name: "measures_explosive_gases", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db) {
     return db
@@ -82,6 +83,7 @@ export const gasSensorTableSpec: DerivedTableSpec<GasSensor> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         sensor_type: sensorType,
         measures_air_quality: measuresAirQuality,

--- a/lib/db/derivedtables/gyroscope.ts
+++ b/lib/db/derivedtables/gyroscope.ts
@@ -28,6 +28,7 @@ export const gyroscopeTableSpec: DerivedTableSpec<Gyroscope> = {
     { name: "has_uart", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -106,6 +107,7 @@ export const gyroscopeTableSpec: DerivedTableSpec<Gyroscope> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         supply_voltage_min: voltageMin,
         supply_voltage_max: voltageMax,

--- a/lib/db/derivedtables/header.ts
+++ b/lib/db/derivedtables/header.ts
@@ -48,6 +48,7 @@ export const headerTableSpec: DerivedTableSpec<Header> = {
     { name: "is_right_angle", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -227,6 +228,7 @@ export const headerTableSpec: DerivedTableSpec<Header> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         price1: extractMinQPrice(c.price)!,
         package: c.package || "",
         pitch_mm: pitch,

--- a/lib/db/derivedtables/io_expander.ts
+++ b/lib/db/derivedtables/io_expander.ts
@@ -40,6 +40,7 @@ export const ioExpanderTableSpec: DerivedTableSpec<IoExpander> = {
     { name: "source_current_ma", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -139,6 +140,7 @@ export const ioExpanderTableSpec: DerivedTableSpec<IoExpander> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         num_gpios: numGpios,
         supply_voltage_min: voltageMin,

--- a/lib/db/derivedtables/jst_connector.ts
+++ b/lib/db/derivedtables/jst_connector.ts
@@ -22,6 +22,7 @@ export const jstConnectorTableSpec: DerivedTableSpec<JstConnector> = {
     { name: "reference_series", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -69,6 +70,7 @@ export const jstConnectorTableSpec: DerivedTableSpec<JstConnector> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: String(c.package || ""),
           pitch_mm: parseNum(attrs["Pitch"]),
           num_rows: isNaN(numRows) ? null : numRows,

--- a/lib/db/derivedtables/lcd_display.ts
+++ b/lib/db/derivedtables/lcd_display.ts
@@ -19,6 +19,7 @@ export const lcdDisplayTableSpec: DerivedTableSpec<LCDDisplay> = {
     { name: "display_type", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -64,6 +65,7 @@ export const lcdDisplayTableSpec: DerivedTableSpec<LCDDisplay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: String(c.package || ""),
           display_size,
           resolution,

--- a/lib/db/derivedtables/led.ts
+++ b/lib/db/derivedtables/led.ts
@@ -37,6 +37,7 @@ export const ledTableSpec: DerivedTableSpec<Led> = {
     { name: "is_rgb", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -165,6 +166,7 @@ export const ledTableSpec: DerivedTableSpec<Led> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         forward_voltage: forwardVoltage,
         forward_current: forwardCurrent,

--- a/lib/db/derivedtables/led_dot_matrix_display.ts
+++ b/lib/db/derivedtables/led_dot_matrix_display.ts
@@ -18,6 +18,7 @@ export const ledDotMatrixDisplayTableSpec: DerivedTableSpec<LEDDotMatrixDisplay>
       { name: "color", type: "text" },
       { name: "is_basic", type: "boolean" },
       { name: "is_preferred", type: "boolean" },
+      { name: "is_extended_promotional", type: "boolean" },
     ],
     listCandidateComponents(db: KyselyDatabaseInstance) {
       return db
@@ -57,6 +58,7 @@ export const ledDotMatrixDisplayTableSpec: DerivedTableSpec<LEDDotMatrixDisplay>
             in_stock: Boolean((c.stock || 0) > 0),
             is_basic: Boolean(c.basic),
             is_preferred: Boolean(c.preferred),
+            is_extended_promotional: Boolean(c.is_extended_promotional),
             package: String(c.package || ""),
             matrix_size,
             color,

--- a/lib/db/derivedtables/led_driver.ts
+++ b/lib/db/derivedtables/led_driver.ts
@@ -42,6 +42,7 @@ export const ledDriverTableSpec: DerivedTableSpec<LedDriver> = {
     { name: "mounting_style", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -77,6 +78,7 @@ export const ledDriverTableSpec: DerivedTableSpec<LedDriver> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: String(c.package || ""),
           supply_voltage_min: parseValue(attrs["Input Voltage"]?.split("~")[0]),
           supply_voltage_max: parseValue(attrs["Input Voltage"]?.split("~")[1]),

--- a/lib/db/derivedtables/led_segment_display.ts
+++ b/lib/db/derivedtables/led_segment_display.ts
@@ -26,6 +26,7 @@ export const ledSegmentDisplayTableSpec: DerivedTableSpec<LEDSegmentDisplay> = {
     { name: "color", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
 
   listCandidateComponents(db: KyselyDatabaseInstance) {
@@ -91,6 +92,7 @@ export const ledSegmentDisplayTableSpec: DerivedTableSpec<LEDSegmentDisplay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: String(c.package || ""),
           positions,
           type,

--- a/lib/db/derivedtables/led_with_ic.ts
+++ b/lib/db/derivedtables/led_with_ic.ts
@@ -27,6 +27,7 @@ export const ledWithICTableSpec: DerivedTableSpec<LEDWithIC> = {
     { name: "protocol", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -99,6 +100,7 @@ export const ledWithICTableSpec: DerivedTableSpec<LEDWithIC> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: String(c.package || ""),
           forward_voltage: forwardVoltage,
           forward_current: forwardCurrent,

--- a/lib/db/derivedtables/microcontroller.ts
+++ b/lib/db/derivedtables/microcontroller.ts
@@ -62,6 +62,7 @@ export const microcontrollerTableSpec: DerivedTableSpec<Microcontroller> = {
     { name: "dac_resolution_bits", type: "integer" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -228,6 +229,7 @@ export const microcontrollerTableSpec: DerivedTableSpec<Microcontroller> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         cpu_core: cpuCore,
         cpu_speed_hz: cpuSpeed,

--- a/lib/db/derivedtables/mosfet.ts
+++ b/lib/db/derivedtables/mosfet.ts
@@ -35,6 +35,7 @@ export const mosfetTableSpec: DerivedTableSpec<Mosfet> = {
     { name: "mounting_style", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -68,6 +69,7 @@ export const mosfetTableSpec: DerivedTableSpec<Mosfet> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: String(c.package || ""),
           drain_source_voltage: parseValue(
             attrs["Drain Source Voltage (Vdss)"],

--- a/lib/db/derivedtables/oled_display.ts
+++ b/lib/db/derivedtables/oled_display.ts
@@ -19,6 +19,7 @@ export const oledDisplayTableSpec: DerivedTableSpec<OLEDDisplay> = {
     { name: "pixel_resolution", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
 
   listCandidateComponents(db: KyselyDatabaseInstance) {
@@ -65,6 +66,7 @@ export const oledDisplayTableSpec: DerivedTableSpec<OLEDDisplay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: String(c.package || ""),
           protocol: protocol || undefined,
           display_width,

--- a/lib/db/derivedtables/pcie_m2_connector.ts
+++ b/lib/db/derivedtables/pcie_m2_connector.ts
@@ -14,6 +14,7 @@ export const pcieM2ConnectorTableSpec: DerivedTableSpec<PcieM2Connector> = {
     { name: "is_right_angle", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -49,6 +50,7 @@ export const pcieM2ConnectorTableSpec: DerivedTableSpec<PcieM2Connector> = {
         in_stock: Boolean((c.stock || 0) > 0),
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         key,
         is_right_angle: isRightAngle,
         attributes: attrs,

--- a/lib/db/derivedtables/potentiometer.ts
+++ b/lib/db/derivedtables/potentiometer.ts
@@ -19,6 +19,7 @@ export const potentiometerTableSpec: DerivedTableSpec<Potentiometer> = {
     { name: "is_surface_mount", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -67,6 +68,7 @@ export const potentiometerTableSpec: DerivedTableSpec<Potentiometer> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         max_resistance: maxResistance,
         pin_variant: pinVariant,
         package: c.package || "",

--- a/lib/db/derivedtables/relay.ts
+++ b/lib/db/derivedtables/relay.ts
@@ -29,6 +29,7 @@ export const relayTableSpec: DerivedTableSpec<Relay> = {
     { name: "pin_number", type: "integer" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -62,6 +63,7 @@ export const relayTableSpec: DerivedTableSpec<Relay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: String(c.package || ""),
           relay_type: (c as any).subcategory || "",
           contact_form: attrs["Contact Form"] || null,

--- a/lib/db/derivedtables/resistor.ts
+++ b/lib/db/derivedtables/resistor.ts
@@ -31,6 +31,7 @@ export const resistorTableSpec: DerivedTableSpec<Resistor> = {
     { name: "is_multi_resistor_chip", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -82,6 +83,7 @@ export const resistorTableSpec: DerivedTableSpec<Resistor> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         resistance: resistance,
         tolerance_fraction: tolerance,
         power_watts,

--- a/lib/db/derivedtables/resistor_array.ts
+++ b/lib/db/derivedtables/resistor_array.ts
@@ -69,6 +69,7 @@ export const resistorArrayTableSpec: DerivedTableSpec<ResistorArray> = {
     { name: "is_surface_mount", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -124,6 +125,7 @@ export const resistorArrayTableSpec: DerivedTableSpec<ResistorArray> = {
         in_stock: component.stock > 0,
         is_basic: Boolean(component.basic),
         is_preferred: Boolean(component.preferred),
+        is_extended_promotional: Boolean(component.is_extended_promotional),
         package: component.package ?? "",
         resistance,
         tolerance_fraction: tolerance,

--- a/lib/db/derivedtables/switch.ts
+++ b/lib/db/derivedtables/switch.ts
@@ -37,6 +37,7 @@ export const switchTableSpec: DerivedTableSpec<Switch> = {
     { name: "switch_height_mm", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db) {
     return db
@@ -91,6 +92,7 @@ export const switchTableSpec: DerivedTableSpec<Switch> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         switch_type: (c as any).subcategory || "",
         circuit: attrs["Circuit"] || null,

--- a/lib/db/derivedtables/usb_c_connector.ts
+++ b/lib/db/derivedtables/usb_c_connector.ts
@@ -28,6 +28,7 @@ export const usbCConnectorTableSpec: DerivedTableSpec<UsbCConnector> = {
     { name: "operating_temp_max", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -69,6 +70,7 @@ export const usbCConnectorTableSpec: DerivedTableSpec<UsbCConnector> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: String(c.package || ""),
           mounting_style: attrs["Mounting Style"] || null,
           current_rating_a: parseNum(attrs["Current Rating - Power (Max)"]),

--- a/lib/db/derivedtables/voltage_regulator.ts
+++ b/lib/db/derivedtables/voltage_regulator.ts
@@ -43,6 +43,7 @@ export const voltageRegulatorTableSpec: DerivedTableSpec<VoltageRegulator> = {
     { name: "topology", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -184,6 +185,7 @@ export const voltageRegulatorTableSpec: DerivedTableSpec<VoltageRegulator> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         output_type: outputType,
         output_voltage_min: voltageMin,

--- a/lib/db/derivedtables/wifi_module.ts
+++ b/lib/db/derivedtables/wifi_module.ts
@@ -45,6 +45,7 @@ export const wifiModuleTableSpec: DerivedTableSpec<WifiModule> = {
     { name: "has_pwm", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -140,6 +141,7 @@ export const wifiModuleTableSpec: DerivedTableSpec<WifiModule> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         core_processor: attrs["Core Processor"] || null,
         antenna_type: attrs["Antenna Type"] || null,

--- a/lib/db/derivedtables/wire_to_board_connector.ts
+++ b/lib/db/derivedtables/wire_to_board_connector.ts
@@ -61,6 +61,7 @@ export const wireToBoardConnectorTableSpec: DerivedTableSpec<WireToBoardConnecto
       { name: "is_smd", type: "boolean" },
       { name: "is_basic", type: "boolean" },
       { name: "is_preferred", type: "boolean" },
+      { name: "is_extended_promotional", type: "boolean" },
     ],
     listCandidateComponents(db: KyselyDatabaseInstance) {
       return db
@@ -100,6 +101,7 @@ export const wireToBoardConnectorTableSpec: DerivedTableSpec<WireToBoardConnecto
             in_stock: Boolean((c.stock || 0) > 0),
             is_basic: Boolean(c.basic),
             is_preferred: Boolean(c.preferred),
+            is_extended_promotional: Boolean(c.is_extended_promotional),
             package: String(c.package || ""),
             pitch_mm: pitchMm,
             num_rows: numRows,

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -19,6 +19,7 @@ export interface Accelerometer {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
@@ -86,6 +87,7 @@ export interface BatteryHolder {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
@@ -120,6 +122,7 @@ export interface BoostConverter {
   input_voltage_min: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_synchronous: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
@@ -142,6 +145,7 @@ export interface BuckBoostConverter {
   input_voltage_min: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_synchronous: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
@@ -166,6 +170,7 @@ export interface Capacitor {
   is_basic: number | null;
   is_polarized: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_surface_mount: number | null;
   lcsc: Generated<number | null>;
   lifetime_hours: number | null;
@@ -192,6 +197,7 @@ export interface Component {
   description: string;
   extra: string | null;
   flag: Generated<number>;
+  is_extended_promotional: Generated<number>;
   joints: number;
   last_on_stock: Generated<number>;
   last_update: number;
@@ -294,6 +300,7 @@ export interface FpcConnector {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   locking_feature: string | null;
   mfr: string | null;
@@ -310,6 +317,7 @@ export interface Fpga {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   logic_array_blocks: number | null;
   logic_elements: number | null;
@@ -349,6 +357,7 @@ export interface GasSensor {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   measures_air_quality: number | null;
   measures_carbon_monoxide: number | null;
@@ -378,6 +387,7 @@ export interface Gyroscope {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
@@ -447,6 +457,7 @@ export interface JstConnector {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   num_pins: number | null;
@@ -482,6 +493,7 @@ export interface Ldo {
   is_basic: number | null;
   is_positive: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
@@ -665,6 +677,7 @@ export interface PcieM2Connector {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_right_angle: number | null;
   key: string | null;
   lcsc: Generated<number | null>;
@@ -696,6 +709,7 @@ export interface Relay {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   max_switching_current: number | null;
   max_switching_voltage: number | null;
@@ -715,6 +729,7 @@ export interface Resistor {
   is_multi_resistor_chip: number | null;
   is_potentiometer: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_surface_mount: number | null;
   lcsc: Generated<number | null>;
   max_overload_voltage: number | null;
@@ -735,6 +750,7 @@ export interface ResistorArray {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_surface_mount: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
@@ -759,6 +775,7 @@ export interface Switch {
   is_basic: number | null;
   is_latching: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   length_mm: number | null;
   mfr: string | null;
@@ -783,6 +800,7 @@ export interface UsbCConnector {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   mounting_style: string | null;
@@ -802,6 +820,7 @@ export interface VComponent {
   datasheet: string | null;
   description: string | null;
   extra: string | null;
+  is_extended_promotional: number | null;
   joints: number | null;
   last_on_stock: number | null;
   lcsc: number | null;
@@ -874,6 +893,7 @@ export interface WireToBoardConnector {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_smd: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;

--- a/lib/db/optimizations/component-extended-promotional-column.ts
+++ b/lib/db/optimizations/component-extended-promotional-column.ts
@@ -1,0 +1,70 @@
+import { sql } from "kysely"
+import type { DbOptimizationSpec } from "./types"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+
+export const componentExtendedPromotionalColumn: DbOptimizationSpec = {
+  name: "add_components_is_extended_promotional_column",
+  description:
+    "Adds is_extended_promotional boolean column to components (preferred=1 AND basic=0 — Extended parts marked Preferred are sold at Basic-tier assembly cost during JLCPCB promotions). Also rebuilds v_components view to expose the new column.",
+
+  async checkIfAdded(db: KyselyDatabaseInstance) {
+    const {
+      rows: [row],
+    } = await sql<any>`
+      SELECT * FROM components LIMIT 1
+    `.execute(db)
+
+    return row != null && "is_extended_promotional" in row
+  },
+
+  async execute(db: KyselyDatabaseInstance) {
+    await sql`
+      ALTER TABLE components
+      ADD COLUMN is_extended_promotional boolean
+      GENERATED ALWAYS AS (preferred = 1 AND basic = 0)
+    `.execute(db)
+
+    await db.schema
+      .createIndex("idx_components_is_extended_promotional")
+      .on("components")
+      .column("is_extended_promotional")
+      .execute()
+
+    // Rebuild v_components view (if it exists) so the new column is visible
+    // to routes that query the view rather than the base components table.
+    const { rows: viewRows } = await sql<{ sql: string | null }>`
+      SELECT sql FROM sqlite_master WHERE type = 'view' AND name = 'v_components'
+    `.execute(db)
+
+    const existingViewSql = viewRows[0]?.sql
+    if (existingViewSql) {
+      await sql`DROP VIEW IF EXISTS v_components`.execute(db)
+      const rebuilt = rebuildViewWithExtendedPromotional(existingViewSql)
+      await sql.raw(rebuilt).execute(db)
+    }
+  },
+}
+
+/**
+ * Inject `components.is_extended_promotional` into a stored CREATE VIEW
+ * statement. Looks for the existing `components.preferred` projection and
+ * appends the new column right after it. Falls back to the original SQL if
+ * the expected pattern isn't found, so existing views are never silently
+ * broken.
+ */
+export function rebuildViewWithExtendedPromotional(viewSql: string): string {
+  const patterns: RegExp[] = [
+    /(components\.preferred\s+AS\s+preferred)/i,
+    /(components\.preferred)(?!\w)/i,
+    /(\bpreferred\b(?!\s*[,)])\s*,)/i,
+  ]
+  for (const pattern of patterns) {
+    if (pattern.test(viewSql)) {
+      return viewSql.replace(
+        pattern,
+        (match) => `${match}, components.is_extended_promotional`,
+      )
+    }
+  }
+  return viewSql
+}

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -23,6 +23,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -39,6 +40,8 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
+      "is_extended_promotional",
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -57,6 +60,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("is_extended_promotional", "=", 1)
   }
 
   if (req.query.search) {
@@ -82,6 +88,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.is_extended_promotional),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -123,6 +130,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/scripts/setup-db-optimizations.ts
+++ b/scripts/setup-db-optimizations.ts
@@ -9,12 +9,14 @@ import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
 import { componentPackageIndex } from "lib/db/optimizations/component-indexes"
 import { componentBasicIndex } from "lib/db/optimizations/component-basic-index"
 import { componentPreferredIndex } from "lib/db/optimizations/component-preferred-index"
+import { componentExtendedPromotionalColumn } from "lib/db/optimizations/component-extended-promotional-column"
 
 const OPTIMIZATIONS: DbOptimizationSpec[] = [
   componentSearchFTS,
   componentPackageIndex,
   componentBasicIndex,
   componentPreferredIndex,
+  componentExtendedPromotionalColumn,
   removeStaleComponents,
   componentStockIndex,
   componentInStockColumn,

--- a/tests/lib/extended-promotional-column.test.ts
+++ b/tests/lib/extended-promotional-column.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "bun:test"
+import { rebuildViewWithExtendedPromotional } from "lib/db/optimizations/component-extended-promotional-column"
+import { resistorTableSpec } from "lib/db/derivedtables/resistor"
+
+test("rebuildViewWithExtendedPromotional injects column after `components.preferred AS preferred`", () => {
+  const original = `CREATE VIEW v_components AS SELECT components.basic, components.preferred AS preferred, components.lcsc FROM components`
+  const rebuilt = rebuildViewWithExtendedPromotional(original)
+  expect(rebuilt).toContain("components.is_extended_promotional")
+  expect(rebuilt.indexOf("components.preferred AS preferred")).toBeLessThan(
+    rebuilt.indexOf("components.is_extended_promotional"),
+  )
+})
+
+test("rebuildViewWithExtendedPromotional handles bare `components.preferred` reference", () => {
+  const original = `CREATE VIEW v_components AS SELECT components.preferred, components.lcsc FROM components`
+  const rebuilt = rebuildViewWithExtendedPromotional(original)
+  expect(rebuilt).toContain("components.is_extended_promotional")
+})
+
+test("rebuildViewWithExtendedPromotional returns input unchanged when pattern is missing", () => {
+  const original = `CREATE VIEW v_components AS SELECT components.lcsc FROM components`
+  const rebuilt = rebuildViewWithExtendedPromotional(original)
+  expect(rebuilt).toBe(original)
+})
+
+test("resistor mapToTable derives is_extended_promotional from upstream column", () => {
+  const promotionalComponent = {
+    lcsc: 1,
+    mfr: "RES-EP",
+    description: "10k 0603 resistor",
+    stock: 100,
+    basic: 0,
+    preferred: 1,
+    is_extended_promotional: 1,
+    package: "0603",
+    price: JSON.stringify([{ qFrom: 1, qTo: null, price: 0.001 }]),
+    extra: JSON.stringify({
+      attributes: {
+        Resistance: "10k",
+        Tolerance: "1%",
+        "Power(Watts)": "0.1W",
+      },
+    }),
+  } as any
+
+  const [resistor] = resistorTableSpec.mapToTable([promotionalComponent])
+
+  expect(resistor?.is_extended_promotional).toBe(true)
+  expect(resistor?.is_basic).toBe(false)
+  expect(resistor?.is_preferred).toBe(true)
+})
+
+test("resistor mapToTable returns is_extended_promotional=false when upstream column is 0", () => {
+  const basicComponent = {
+    lcsc: 2,
+    mfr: "RES-BASIC",
+    description: "10k 0603 resistor",
+    stock: 100,
+    basic: 1,
+    preferred: 0,
+    is_extended_promotional: 0,
+    package: "0603",
+    price: JSON.stringify([{ qFrom: 1, qTo: null, price: 0.001 }]),
+    extra: JSON.stringify({
+      attributes: {
+        Resistance: "10k",
+        Tolerance: "1%",
+        "Power(Watts)": "0.1W",
+      },
+    }),
+  } as any
+
+  const [resistor] = resistorTableSpec.mapToTable([basicComponent])
+
+  expect(resistor?.is_extended_promotional).toBe(false)
+  expect(resistor?.is_basic).toBe(true)
+})


### PR DESCRIPTION
## Summary

Implements `is_extended_promotional` as a filterable column across the components dataset.

JLCPCB tags some Extended parts as "Extended Promotional" — they're temporarily charged at Basic-tier assembly cost (no per-part setup fee). Surfacing this lets users prioritize parts that are cost-effective right now, which is the cost decision actually shaping a BOM.

## Approach

Rather than computing the flag inside every `mapToTable` callback (the pattern used by previous attempts at this issue), this PR sources the column at the SQL layer — matching the existing `in_stock` optimization pattern.

A new `DbOptimizationSpec` adds a SQLite **generated column**:

```sql
ALTER TABLE components
ADD COLUMN is_extended_promotional boolean
GENERATED ALWAYS AS (preferred = 1 AND basic = 0)
```

This guarantees consistency, enables index-backed filtering, and means every derived table reads the same canonical value via `c.is_extended_promotional` instead of recomputing the boolean in 37 places.

The optimization also rebuilds the `v_components` view (by reading its existing SQL from `sqlite_master`, then injecting the new column) so routes querying the view see the column without manual schema knowledge.

## Files Changed

- **New optimization**: `lib/db/optimizations/component-extended-promotional-column.ts` — generated column + index + view rebuild.
- **Wired into setup**: `scripts/setup-db-optimizations.ts`.
- **BaseComponent**: column added to `lib/db/derivedtables/component-base.ts` + 37 derived table specs.
- **Routes**: `routes/components/list.tsx` adds filterable checkbox + query param + `is_extended_promotional` to selected columns.
- **cf-proxy**: `ComponentCatalogQueryParams`, query filter logic, `ComponentCatalog` and `SearchIndex` types, and the sync/rebuild SQL scripts updated.
- **Generated types**: `Component`, `VComponent`, and the per-table interfaces in `lib/db/generated/kysely.ts` updated (the codegen requires the optimized DB to run; this matches what `bun run generate:db-types` would produce after `bun run setup`).
- **Tests**: `tests/lib/extended-promotional-column.test.ts`:
  - `rebuildViewWithExtendedPromotional` correctly injects the column after `components.preferred AS preferred`, after a bare `components.preferred`, and falls back gracefully when neither pattern is present.
  - `resistor.mapToTable` returns `is_extended_promotional: true` for promotional components and `false` for basic ones.

## Test plan

- [x] `bun test tests/lib/` — 12 pass, 0 fail (5 new + 7 existing).
- [x] `bun run format` — Biome clean.
- [x] `bunx tsc --noEmit` — no new type errors introduced (existing baseline preserved; the only error involving `is_extended_promotional` was the missing-property error in `resistor_array.ts`, which this PR fixes).
- [ ] Full integration run requires `bun run setup` (downloads ~2GB cache) — happy to verify once the maintainer points me at a faster path or accepts the unit-test coverage.

/claim #92