### PR TITLE
Add barrel jack query support

### DIFF
--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely"
+import type { Kysely, RawBuilder } from "kysely"
 import { sql } from "kysely"
 import type { DB } from "./db/types"
 import { buildSearchTokenGroups } from "./search-query"
@@ -9,6 +9,19 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+}
+
+const buildSearchTextWhereClause = (
+  tokenGroups: string[][],
+): RawBuilder<unknown> => {
+  const groupConditions = tokenGroups.map((group) => {
+    const tokenConditions = group.map(
+      (token) => sql`search_text LIKE ${`%${token}%`}`,
+    )
+    return sql`(${sql.join(tokenConditions, sql` OR `)})`
+  })
+
+  return sql.join(groupConditions, sql` AND `)
 }
 
 export async function queryComponentCatalog(
@@ -63,20 +76,13 @@ export async function queryComponentCatalog(
     const likeTokenGroups =
       filteredTokenGroups.length > 0 ? filteredTokenGroups : searchTokenGroups
 
-    for (const group of likeTokenGroups) {
-      const groupConditions = group.map((token) => {
-        const pattern = `%${token}%`
-        return sql<boolean>`(
-          LOWER(COALESCE(description, '')) LIKE ${pattern}
-          OR LOWER(COALESCE(mfr, '')) LIKE ${pattern}
-          OR LOWER(COALESCE(package, '')) LIKE ${pattern}
-          OR LOWER(COALESCE(extra, '')) LIKE ${pattern}
-        )`
-      })
-      query = query.where(
-        sql<boolean>`(${sql.join(groupConditions, sql` OR `)})`,
-      )
-    }
+    query = query.where(
+      sql`lcsc`,
+      "in",
+      sql`(SELECT lcsc FROM search_index WHERE ${buildSearchTextWhereClause(
+        likeTokenGroups,
+      )})`,
+    )
   }
 
   return await query.execute()

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -1,5 +1,7 @@
 import type { Kysely } from "kysely"
+import { sql } from "kysely"
 import type { DB } from "./db/types"
+import { buildSearchTokenGroups } from "./search-query"
 
 export interface ComponentCatalogQueryParams {
   subcategory_name?: string
@@ -52,13 +54,29 @@ export async function queryComponentCatalog(
 
   if (params.search) {
     const raw = params.search.trim()
-    const pattern = `%${raw.toLowerCase()}%`
+    const tokenGroups = buildSearchTokenGroups(raw)
+    const searchTokenGroups =
+      tokenGroups.length > 0 ? tokenGroups : [[raw.toLowerCase()]]
+    const filteredTokenGroups = searchTokenGroups
+      .map((group) => group.filter((token) => token.length > 1))
+      .filter((group) => group.length > 0)
+    const likeTokenGroups =
+      filteredTokenGroups.length > 0 ? filteredTokenGroups : searchTokenGroups
 
-    query = query.where((eb) =>
-      eb("description", "like", pattern)
-        .or("mfr", "like", pattern)
-        .or("package", "like", pattern),
-    )
+    for (const group of likeTokenGroups) {
+      const groupConditions = group.map((token) => {
+        const pattern = `%${token}%`
+        return sql<boolean>`(
+          LOWER(COALESCE(description, '')) LIKE ${pattern}
+          OR LOWER(COALESCE(mfr, '')) LIKE ${pattern}
+          OR LOWER(COALESCE(package, '')) LIKE ${pattern}
+          OR LOWER(COALESCE(extra, '')) LIKE ${pattern}
+        )`
+      })
+      query = query.where(
+        sql<boolean>`(${sql.join(groupConditions, sql` OR `)})`,
+      )
+    }
   }
 
   return await query.execute()

--- a/cf-proxy/src/search-query.ts
+++ b/cf-proxy/src/search-query.ts
@@ -58,6 +58,6 @@ export const buildSearchTokenGroups = (term: string): SearchTokenGroup[] => {
     ...remainingTokens.map((token) => [token]),
     ["dc"],
     ["power"],
-    ["receptacle", "connector"],
+    ["receptacle"],
   ])
 }

--- a/cf-proxy/src/search-query.ts
+++ b/cf-proxy/src/search-query.ts
@@ -1,0 +1,63 @@
+export type SearchTokenGroup = string[]
+
+export const tokenizeSearchTerm = (term: string): string[] =>
+  term.toLowerCase().match(/[a-z0-9]+/g) ?? []
+
+const barrelJackWords = new Set([
+  "jack",
+  "jacks",
+  "connector",
+  "connectors",
+  "socket",
+  "sockets",
+  "receptacle",
+  "receptacles",
+  "plug",
+  "plugs",
+])
+
+const isVoltageToken = (token: string): boolean =>
+  /^\d+(?:\.\d+)?v(?:olts?)?$/.test(token)
+
+const uniqueGroups = (groups: SearchTokenGroup[]): SearchTokenGroup[] => {
+  const seen = new Set<string>()
+  const result: SearchTokenGroup[] = []
+
+  for (const group of groups) {
+    const uniqueTokens = Array.from(new Set(group)).filter(Boolean)
+    if (uniqueTokens.length === 0) continue
+
+    const key = uniqueTokens.join("\0")
+    if (seen.has(key)) continue
+
+    seen.add(key)
+    result.push(uniqueTokens)
+  }
+
+  return result
+}
+
+export const buildSearchTokenGroups = (term: string): SearchTokenGroup[] => {
+  const tokens = tokenizeSearchTerm(term)
+  const hasBarrelJack =
+    tokens.includes("barrel") &&
+    tokens.some((token) => barrelJackWords.has(token))
+
+  if (!hasBarrelJack) {
+    return tokens.map((token) => [token])
+  }
+
+  const remainingTokens = tokens.filter(
+    (token) =>
+      token !== "barrel" &&
+      !barrelJackWords.has(token) &&
+      !isVoltageToken(token),
+  )
+
+  return uniqueGroups([
+    ...remainingTokens.map((token) => [token]),
+    ["dc"],
+    ["power"],
+    ["receptacle", "connector"],
+  ])
+}

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -1,5 +1,6 @@
 import { sql, type Kysely, type RawBuilder } from "kysely"
 import type { DB } from "./db/types"
+import { buildSearchTokenGroups } from "./search-query"
 
 export interface SearchQueryParams {
   q?: string
@@ -20,9 +21,6 @@ interface SearchRow {
   basic: number | null
   preferred: number | null
 }
-
-const tokenizeSearchTerm = (term: string): string[] =>
-  term.toLowerCase().match(/[a-z0-9]+/g) ?? []
 
 const buildWhereClause = (conditions: RawBuilder<unknown>[]) =>
   conditions.length > 0 ? sql.join(conditions, sql` AND `) : sql`1 = 1`
@@ -56,18 +54,23 @@ export async function searchIndex(
         conditions.push(sql`lcsc = ${lcsc}`)
       }
     } else {
-      const tokens = tokenizeSearchTerm(raw)
-      const searchTokens = tokens.length > 0 ? tokens : [raw.toLowerCase()]
-      const filteredTokens = searchTokens.filter((token) => token.length > 1)
-      const likeTokens =
-        filteredTokens.length > 0 ? filteredTokens : searchTokens
+      const tokenGroups = buildSearchTokenGroups(raw)
+      const searchTokenGroups =
+        tokenGroups.length > 0 ? tokenGroups : [[raw.toLowerCase()]]
+      const filteredTokenGroups = searchTokenGroups
+        .map((group) => group.filter((token) => token.length > 1))
+        .filter((group) => group.length > 0)
+      const likeTokenGroups =
+        filteredTokenGroups.length > 0 ? filteredTokenGroups : searchTokenGroups
 
-      for (const token of likeTokens) {
+      for (const group of likeTokenGroups) {
         const alternatives = Array.from(
           new Set(
-            token.endsWith("mhz")
-              ? [token, token.replace(/mhz$/, "m")]
-              : [token],
+            group.flatMap((token) =>
+              token.endsWith("mhz")
+                ? [token, token.replace(/mhz$/, "m")]
+                : [token],
+            ),
           ),
         )
 

--- a/cf-proxy/test/search-query.test.ts
+++ b/cf-proxy/test/search-query.test.ts
@@ -6,7 +6,7 @@ describe("buildSearchTokenGroups", () => {
     expect(buildSearchTokenGroups("barrel jack")).toEqual([
       ["dc"],
       ["power"],
-      ["receptacle", "connector"],
+      ["receptacle"],
     ])
   })
 
@@ -14,7 +14,7 @@ describe("buildSearchTokenGroups", () => {
     expect(buildSearchTokenGroups("5v barrel jack")).toEqual([
       ["dc"],
       ["power"],
-      ["receptacle", "connector"],
+      ["receptacle"],
     ])
   })
 
@@ -24,7 +24,7 @@ describe("buildSearchTokenGroups", () => {
       ["1mm"],
       ["dc"],
       ["power"],
-      ["receptacle", "connector"],
+      ["receptacle"],
     ])
   })
 })

--- a/cf-proxy/test/search-query.test.ts
+++ b/cf-proxy/test/search-query.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+import { buildSearchTokenGroups } from "../src/search-query"
+
+describe("buildSearchTokenGroups", () => {
+  it("maps barrel jack wording to DC power connector catalog terms", () => {
+    expect(buildSearchTokenGroups("barrel jack")).toEqual([
+      ["dc"],
+      ["power"],
+      ["receptacle", "connector"],
+    ])
+  })
+
+  it("drops nominal voltage tokens for barrel jack searches", () => {
+    expect(buildSearchTokenGroups("5v barrel jack")).toEqual([
+      ["dc"],
+      ["power"],
+      ["receptacle", "connector"],
+    ])
+  })
+
+  it("preserves non-barrel-jack terms", () => {
+    expect(buildSearchTokenGroups("2.1mm barrel jack")).toEqual([
+      ["2"],
+      ["1mm"],
+      ["dc"],
+      ["power"],
+      ["receptacle", "connector"],
+    ])
+  })
+})

--- a/lib/util/search-token-groups.ts
+++ b/lib/util/search-token-groups.ts
@@ -58,6 +58,6 @@ export const buildSearchTokenGroups = (term: string): SearchTokenGroup[] => {
     ...remainingTokens.map((token) => [token]),
     ["dc"],
     ["power"],
-    ["receptacle", "connector"],
+    ["receptacle"],
   ])
 }

--- a/lib/util/search-token-groups.ts
+++ b/lib/util/search-token-groups.ts
@@ -1,0 +1,63 @@
+export type SearchTokenGroup = string[]
+
+export const tokenizeSearchTerm = (term: string): string[] =>
+  term.toLowerCase().match(/[a-z0-9]+/g) ?? []
+
+const barrelJackWords = new Set([
+  "jack",
+  "jacks",
+  "connector",
+  "connectors",
+  "socket",
+  "sockets",
+  "receptacle",
+  "receptacles",
+  "plug",
+  "plugs",
+])
+
+const isVoltageToken = (token: string): boolean =>
+  /^\d+(?:\.\d+)?v(?:olts?)?$/.test(token)
+
+const uniqueGroups = (groups: SearchTokenGroup[]): SearchTokenGroup[] => {
+  const seen = new Set<string>()
+  const result: SearchTokenGroup[] = []
+
+  for (const group of groups) {
+    const uniqueTokens = Array.from(new Set(group)).filter(Boolean)
+    if (uniqueTokens.length === 0) continue
+
+    const key = uniqueTokens.join("\0")
+    if (seen.has(key)) continue
+
+    seen.add(key)
+    result.push(uniqueTokens)
+  }
+
+  return result
+}
+
+export const buildSearchTokenGroups = (term: string): SearchTokenGroup[] => {
+  const tokens = tokenizeSearchTerm(term)
+  const hasBarrelJack =
+    tokens.includes("barrel") &&
+    tokens.some((token) => barrelJackWords.has(token))
+
+  if (!hasBarrelJack) {
+    return tokens.map((token) => [token])
+  }
+
+  const remainingTokens = tokens.filter(
+    (token) =>
+      token !== "barrel" &&
+      !barrelJackWords.has(token) &&
+      !isVoltageToken(token),
+  )
+
+  return uniqueGroups([
+    ...remainingTokens.map((token) => [token]),
+    ["dc"],
+    ["power"],
+    ["receptacle", "connector"],
+  ])
+}

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -1,4 +1,9 @@
 import { sql } from "kysely"
+import {
+  buildSearchTokenGroups,
+  type SearchTokenGroup,
+  tokenizeSearchTerm,
+} from "lib/util/search-token-groups"
 import { withWinterSpec } from "lib/with-winter-spec"
 import { z } from "zod"
 
@@ -16,10 +21,6 @@ const escapeFts5SearchTerm = (term: string): string => {
   return `"${term.replace(/"/g, '""')}"`
 }
 
-const tokenizeSearchTerm = (term: string): string[] => {
-  return term.toLowerCase().match(/[a-z0-9]+/g) ?? []
-}
-
 const broadSearchTokens = new Set([
   "usb",
   "type",
@@ -31,6 +32,13 @@ const broadSearchTokens = new Set([
   "mount",
   "chip",
 ])
+
+const ftsGroupQuery = (group: SearchTokenGroup): string => {
+  const tokenQueries = group.map((token) => `${escapeFts5SearchTerm(token)}*`)
+  return tokenQueries.length === 1
+    ? tokenQueries[0]
+    : `(${tokenQueries.join(" OR ")})`
+}
 
 export default withWinterSpec({
   auth: "none",
@@ -81,55 +89,47 @@ export default withWinterSpec({
       }
     } else {
       const searchTokens = tokenizeSearchTerm(searchTerm)
-      const tokensForFtsRaw =
-        searchTokens.length > 0 ? searchTokens : [searchTerm]
-      const filteredFtsTokens = tokensForFtsRaw.filter(
-        (token) => token.length > 1,
+      const searchTokenGroups = buildSearchTokenGroups(searchTerm)
+      const tokenGroupsForFtsRaw =
+        searchTokenGroups.length > 0 ? searchTokenGroups : [[searchTerm]]
+      const filteredFtsGroups = tokenGroupsForFtsRaw
+        .map((group) => group.filter((token) => token.length > 1))
+        .filter((group) => group.length > 0)
+      const focusedFtsGroups = filteredFtsGroups.filter(
+        (group) => !group.every((token) => broadSearchTokens.has(token)),
       )
-      const focusedFtsTokens = filteredFtsTokens.filter(
-        (token) => !broadSearchTokens.has(token),
-      )
-      const qualifierFtsTokens = filteredFtsTokens.filter((token) =>
-        broadSearchTokens.has(token),
+      const qualifierFtsGroups = filteredFtsGroups.filter((group) =>
+        group.every((token) => broadSearchTokens.has(token)),
       )
       const tokenQueries: string[] = []
 
-      if (focusedFtsTokens.length > 0) {
-        tokenQueries.push(
-          ...focusedFtsTokens.map((token) => {
-            const quotedToken = escapeFts5SearchTerm(token)
-            return `${quotedToken}*`
-          }),
-        )
+      if (focusedFtsGroups.length > 0) {
+        tokenQueries.push(...focusedFtsGroups.map(ftsGroupQuery))
 
-        if (qualifierFtsTokens.length > 0) {
+        if (qualifierFtsGroups.length > 0) {
           tokenQueries.push(
-            `(${qualifierFtsTokens
-              .map((token) => `${escapeFts5SearchTerm(token)}*`)
-              .join(" OR ")})`,
+            `(${qualifierFtsGroups.map(ftsGroupQuery).join(" OR ")})`,
           )
         }
       } else {
         tokenQueries.push(
-          ...(filteredFtsTokens.length > 0
-            ? filteredFtsTokens
-            : tokensForFtsRaw
-          ).map((token) => {
-            const quotedToken = escapeFts5SearchTerm(token)
-            return `${quotedToken}*`
-          }),
+          ...(filteredFtsGroups.length > 0
+            ? filteredFtsGroups
+            : tokenGroupsForFtsRaw
+          ).map(ftsGroupQuery),
         )
       }
 
       const combinedFtsQuery = tokenQueries.join(" AND ")
 
-      const tokensForLike =
-        searchTokens.length > 0 ? searchTokens : [searchTerm]
-      const filteredLikeTokens = tokensForLike.filter(
-        (token) => token.length > 1,
-      )
-      fallbackLikeTokens =
-        filteredLikeTokens.length > 0 ? filteredLikeTokens : tokensForLike
+      const tokenGroupsForLike =
+        searchTokenGroups.length > 0 ? searchTokenGroups : [[searchTerm]]
+      const filteredLikeGroups = tokenGroupsForLike
+        .map((group) => group.filter((token) => token.length > 1))
+        .filter((group) => group.length > 0)
+      fallbackLikeTokens = (
+        filteredLikeGroups.length > 0 ? filteredLikeGroups : tokenGroupsForLike
+      ).map((group) => group.join("\0"))
 
       query = query.where(
         sql`lcsc`,
@@ -160,15 +160,19 @@ export default withWinterSpec({
       )
     }
 
-    for (const token of fallbackLikeTokens) {
-      const pattern = `%${token}%`
-      fallbackQuery = fallbackQuery.where(
-        sql<boolean>`(
+    for (const groupValue of fallbackLikeTokens) {
+      const group = groupValue.split("\0")
+      const groupConditions = group.map((token) => {
+        const pattern = `%${token}%`
+        return sql<boolean>`(
           LOWER(COALESCE(mfr, '')) LIKE ${pattern}
           OR LOWER(COALESCE(description, '')) LIKE ${pattern}
           OR LOWER(COALESCE(extra, '')) LIKE ${pattern}
           OR LOWER(COALESCE(package, '')) LIKE ${pattern}
-        )`,
+        )`
+      })
+      fallbackQuery = fallbackQuery.where(
+        sql<boolean>`(${sql.join(groupConditions, sql` OR `)})`,
       )
     }
 

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -14,6 +14,17 @@ const extractSmallQuantityPrice = (price: string | null) => {
   }
 }
 
+const escapeFts5SearchTerm = (term: string): string => {
+  return `"${term.replace(/"/g, '""')}"`
+}
+
+const ftsGroupQuery = (group: string[]): string => {
+  const tokenQueries = group.map((token) => `${escapeFts5SearchTerm(token)}*`)
+  return tokenQueries.length === 1
+    ? tokenQueries[0]
+    : `(${tokenQueries.join(" OR ")})`
+}
+
 export default withWinterSpec({
   auth: "none",
   methods: ["GET"],
@@ -75,19 +86,19 @@ export default withWinterSpec({
       const likeTokenGroups =
         filteredTokenGroups.length > 0 ? filteredTokenGroups : searchTokenGroups
 
-      for (const group of likeTokenGroups) {
-        const groupConditions = group.map((token) => {
-          const pattern = `%${token}%`
-          return sql<boolean>`(
-            LOWER(COALESCE(description, '')) LIKE ${pattern}
-            OR LOWER(COALESCE(mfr, '')) LIKE ${pattern}
-            OR LOWER(COALESCE(extra, '')) LIKE ${pattern}
-            OR LOWER(COALESCE(package, '')) LIKE ${pattern}
-          )`
-        })
-        query = query.where(
-          sql<boolean>`(${sql.join(groupConditions, sql` OR `)})`,
-        )
+      query = query.where(
+        sql`lcsc`,
+        "in",
+        sql`(SELECT CAST(lcsc AS INTEGER) FROM components_fts WHERE components_fts MATCH ${likeTokenGroups
+          .map(ftsGroupQuery)
+          .join(" AND ")})`,
+      )
+
+      const packageTokens = buildSearchTokenGroups(search)
+        .flat()
+        .filter((token) => /^\d{4}$/.test(token))
+      if (packageTokens.length > 0) {
+        query = query.where("package", "in", packageTokens)
       }
     }
   }

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -1,6 +1,7 @@
 import { sql } from "kysely"
 import { Table } from "lib/ui/Table"
 import { ExpressionBuilder } from "kysely"
+import { buildSearchTokenGroups } from "lib/util/search-token-groups"
 import { withWinterSpec } from "lib/with-winter-spec"
 import { z } from "zod"
 
@@ -60,18 +61,35 @@ export default withWinterSpec({
   }
 
   if (req.query.search) {
-    const search = req.query.search // TypeScript now knows this is defined within this block
-    const searchPattern = `%${search}%`
-    query = query.where((eb) =>
-      eb("description", "like", searchPattern)
-        .or("mfr", "like", searchPattern)
-        // For lcsc, we'll search it as a number if it's numeric, otherwise skip it
-        .or(
-          search.match(/^\d+$/)
-            ? eb("lcsc", "=", parseInt(search))
-            : eb("description", "like", searchPattern), // Fallback to description if not numeric
-        ),
-    )
+    const search = req.query.search
+
+    if (search.match(/^\d+$/)) {
+      query = query.where("lcsc", "=", parseInt(search))
+    } else {
+      const tokenGroups = buildSearchTokenGroups(search)
+      const searchTokenGroups =
+        tokenGroups.length > 0 ? tokenGroups : [[search.toLowerCase()]]
+      const filteredTokenGroups = searchTokenGroups
+        .map((group) => group.filter((token) => token.length > 1))
+        .filter((group) => group.length > 0)
+      const likeTokenGroups =
+        filteredTokenGroups.length > 0 ? filteredTokenGroups : searchTokenGroups
+
+      for (const group of likeTokenGroups) {
+        const groupConditions = group.map((token) => {
+          const pattern = `%${token}%`
+          return sql<boolean>`(
+            LOWER(COALESCE(description, '')) LIKE ${pattern}
+            OR LOWER(COALESCE(mfr, '')) LIKE ${pattern}
+            OR LOWER(COALESCE(extra, '')) LIKE ${pattern}
+            OR LOWER(COALESCE(package, '')) LIKE ${pattern}
+          )`
+        })
+        query = query.where(
+          sql<boolean>`(${sql.join(groupConditions, sql` OR `)})`,
+        )
+      }
+    }
   }
 
   const fullComponents = await query.execute()

--- a/tests/lib/search-token-groups.test.ts
+++ b/tests/lib/search-token-groups.test.ts
@@ -5,7 +5,7 @@ test("search token groups map barrel jack wording to DC power connector terms", 
   expect(buildSearchTokenGroups("barrel jack")).toEqual([
     ["dc"],
     ["power"],
-    ["receptacle", "connector"],
+    ["receptacle"],
   ])
 })
 
@@ -13,7 +13,7 @@ test("search token groups drop nominal voltage tokens for barrel jack searches",
   expect(buildSearchTokenGroups("5v barrel jack")).toEqual([
     ["dc"],
     ["power"],
-    ["receptacle", "connector"],
+    ["receptacle"],
   ])
 })
 
@@ -23,6 +23,6 @@ test("search token groups preserve non-barrel-jack terms", () => {
     ["1mm"],
     ["dc"],
     ["power"],
-    ["receptacle", "connector"],
+    ["receptacle"],
   ])
 })

--- a/tests/lib/search-token-groups.test.ts
+++ b/tests/lib/search-token-groups.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test"
+import { buildSearchTokenGroups } from "lib/util/search-token-groups"
+
+test("search token groups map barrel jack wording to DC power connector terms", () => {
+  expect(buildSearchTokenGroups("barrel jack")).toEqual([
+    ["dc"],
+    ["power"],
+    ["receptacle", "connector"],
+  ])
+})
+
+test("search token groups drop nominal voltage tokens for barrel jack searches", () => {
+  expect(buildSearchTokenGroups("5v barrel jack")).toEqual([
+    ["dc"],
+    ["power"],
+    ["receptacle", "connector"],
+  ])
+})
+
+test("search token groups preserve non-barrel-jack terms", () => {
+  expect(buildSearchTokenGroups("2.1mm barrel jack")).toEqual([
+    ["2"],
+    ["1mm"],
+    ["dc"],
+    ["power"],
+    ["receptacle", "connector"],
+  ])
+})


### PR DESCRIPTION
## Summary
- Normalize barrel jack queries to the connector wording used in the catalog
- Ignore nominal voltage tokens like `5v` when the query is clearly about a barrel jack
- Apply the same search behavior across the API route, component listings, and proxy search paths
- Add unit coverage for the new token grouping behavior

## Testing
- Unit tests added for search token grouping in the root app and cf-proxy
- Local typecheck and formatting passed in both workspaces