### PR TITLE
feat: add is_extended_promotional column to components and all derived tables

### DIFF
--- a/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
+++ b/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
@@ -13,6 +13,7 @@ SELECT
     ELSE NULL
   END AS price1,
   basic,
+  extended_promotional,
   preferred,
   category,
   subcategory,
@@ -50,4 +51,5 @@ CREATE INDEX IF NOT EXISTS idx_search_index_stock ON search_index(stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_lcsc ON search_index(lcsc);
 CREATE INDEX IF NOT EXISTS idx_search_index_package ON search_index(package);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -6,6 +6,7 @@ export interface ComponentCatalogQueryParams {
   package?: string
   search?: string
   is_basic?: string
+  is_extended_promotional?: string
   is_preferred?: string
 }
 
@@ -44,6 +45,10 @@ export async function queryComponentCatalog(
 
   if (params.is_basic === "true") {
     query = query.where("basic", "=", 1)
+  }
+
+  if (params.is_extended_promotional === "true") {
+    query = query.where("extended_promotional", "=", 1)
   }
 
   if (params.is_preferred === "true") {

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -18,6 +18,7 @@ export interface Accelerometer {
   has_uart: number | null
   in_stock: number | null
   is_basic: number | null
+  is_extended_promotional: number | null
   is_preferred: number | null
   lcsc: Generated<number | null>
   mfr: string | null
@@ -85,6 +86,7 @@ export interface BatteryHolder {
   description: string | null
   in_stock: number | null
   is_basic: number | null
+  is_extended_promotional: number | null
   is_preferred: number | null
   lcsc: Generated<number | null>
   mfr: string | null
@@ -119,6 +121,7 @@ export interface BoostConverter {
   input_voltage_max: number | null
   input_voltage_min: number | null
   is_basic: number | null
+  is_extended_promotional: number | null
   is_preferred: number | null
   is_synchronous: number | null
   lcsc: Generated<number | null>
@@ -141,6 +144,7 @@ export interface BuckBoostConverter {
   input_voltage_max: number | null
   input_voltage_min: number | null
   is_basic: number | null
+  is_extended_promotional: number | null
   is_preferred: number | null
   is_synchronous: number | null
   lcsc: Generated<number | null>
@@ -158,6 +162,7 @@ export interface BuckBoostConverter {
 
 export interface ComponentCatalog {
   basic: number | null
+  extended_promotional: number | null
   category: string | null
   description: string | null
   extra: string | null
@@ -178,6 +183,7 @@ export interface Capacitor {
   esr_ohms: number | null
   in_stock: number | null
   is_basic: number | null
+  is_extended_promotional: number | null
   is_polarized: number | null
   is_preferred: number | null
   is_surface_mount: number | null
@@ -246,6 +252,7 @@ export interface FpcConnector {
   description: string | null
   in_stock: number | null
   is_basic: number | null
+  is_extended_promotional: number | null
   is_preferred: number | null
   lcsc: Generated<number | null>
   locking_feature: string | null
@@ -262,6 +269,7 @@ export interface Fpga {
   embedded_ram_bits: number | null
   in_stock: number | null
   is_basic: number | null
+  is_extended_promotional: number | null
   is_preferred: number | null
   lcsc: Generated<number | null>
   logic_array_blocks: number | null
@@ -301,6 +309,7 @@ export interface GasSensor {
   description: string | null
   in_stock: number | null
   is_basic: number | null
+  is_extended_promotional: number | null
   is_preferred: number | null
   lcsc: Generated<number | null>
   measures_air_quality: number | null
@@ -330,6 +339,7 @@ export interface Gyroscope {
   has_uart: number | null
   in_stock: number | null
   is_basic: number | null
+  is_extended_promotional: number | null
   is_preferred: number | null
   lcsc: Generated<number | null>
   mfr: string | null
@@ -399,6 +409,7 @@ export interface JstConnector {
   description: string | null
   in_stock: number | null
   is_basic: number | null
+  is_extended_promotional: number | null
   is_preferred: number | null
   lcsc: Generated<number | null>
   mfr: string | null
@@ -433,6 +444,7 @@ export interface Ldo {
   input_voltage_max: number | null
   input_voltage_min: number | null
   is_basic: number | null
+  is_extended_promotional: number | null
   is_positive: number | null
   is_preferred: number | null
   lcsc: Generated<number | null>
@@ -612,6 +624,7 @@ export interface PcieM2Connector {
   description: string | null
   in_stock: number | null
   is_basic: number | null
+  is_extended_promotional: number | null
   is_preferred: number | null
   is_right_angle: number | null
   key: string | null
@@ -643,6 +656,7 @@ export interface Relay {
   description: string | null
   in_stock: number | null
   is_basic: number | null
+  is_extended_promotional: number | null
   is_preferred: number | null
   lcsc: Generated<number | null>
   max_switching_current: number | null
@@ -658,6 +672,7 @@ export interface Relay {
 export interface SearchIndex {
   attributes: string | null
   basic: number | null
+  extended_promotional: number | null
   category: string | null
   description: string | null
   lcsc: Generated<number | null>
@@ -679,6 +694,7 @@ export interface Resistor {
   description: string | null
   in_stock: number | null
   is_basic: number | null
+  is_extended_promotional: number | null
   is_multi_resistor_chip: number | null
   is_potentiometer: number | null
   is_preferred: number | null
@@ -701,6 +717,7 @@ export interface ResistorArray {
   description: string | null
   in_stock: number | null
   is_basic: number | null
+  is_extended_promotional: number | null
   is_preferred: number | null
   is_surface_mount: number | null
   lcsc: Generated<number | null>
@@ -724,6 +741,7 @@ export interface Switch {
   description: string | null
   in_stock: number | null
   is_basic: number | null
+  is_extended_promotional: number | null
   is_latching: number | null
   is_preferred: number | null
   lcsc: Generated<number | null>
@@ -749,6 +767,7 @@ export interface UsbCConnector {
   gender: string | null
   in_stock: number | null
   is_basic: number | null
+  is_extended_promotional: number | null
   is_preferred: number | null
   lcsc: Generated<number | null>
   mfr: string | null
@@ -821,6 +840,7 @@ export interface WireToBoardConnector {
   gender: string | null
   in_stock: number | null
   is_basic: number | null
+  is_extended_promotional: number | null
   is_preferred: number | null
   is_smd: number | null
   lcsc: Generated<number | null>

--- a/cf-proxy/src/handlers/index.ts
+++ b/cf-proxy/src/handlers/index.ts
@@ -163,6 +163,10 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     filters: {
       package: { field: "package", type: "string" },
       is_basic: { field: "is_basic", type: "boolean" },
+      is_extended_promotional: {
+        field: "is_extended_promotional",
+        type: "boolean",
+      },
       is_preferred: { field: "is_preferred", type: "boolean" },
       resistance: { field: "resistance", type: "number_tolerance" },
     },
@@ -171,6 +175,10 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     filters: {
       package: { field: "package", type: "string" },
       is_basic: { field: "is_basic", type: "boolean" },
+      is_extended_promotional: {
+        field: "is_extended_promotional",
+        type: "boolean",
+      },
       is_preferred: { field: "is_preferred", type: "boolean" },
       capacitance: { field: "capacitance_farads", type: "number_tolerance" },
     },

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -366,6 +366,7 @@ async function handleD1Search(
       mfr: row.mfr ?? "",
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
+      is_extended_promotional: Boolean(row.extended_promotional),
       is_preferred: Boolean(row.preferred),
       description: row.description ?? "",
       stock: row.stock ?? 0,
@@ -490,6 +491,7 @@ async function handleD1ComponentsList(
         category: row.category ?? "",
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
+        is_extended_promotional: Boolean(row.extended_promotional),
         is_preferred: Boolean(row.preferred),
       })),
     }

--- a/lib/db/derivedtables/accelerometer.ts
+++ b/lib/db/derivedtables/accelerometer.ts
@@ -101,6 +101,7 @@ export const accelerometerTableSpec: DerivedTableSpec<Accelerometer> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean((c as any).extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         supply_voltage_min: voltageMin,

--- a/lib/db/derivedtables/adc.ts
+++ b/lib/db/derivedtables/adc.ts
@@ -114,6 +114,7 @@ export const adcTableSpec: DerivedTableSpec<Adc> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean((c as any).extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         resolution_bits: resolution,

--- a/lib/db/derivedtables/analog_multiplexer.ts
+++ b/lib/db/derivedtables/analog_multiplexer.ts
@@ -143,6 +143,7 @@ export const analogMultiplexerTableSpec: DerivedTableSpec<AnalogMultiplexer> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean((c as any).extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         num_channels: numChannels,

--- a/lib/db/derivedtables/battery_holder.ts
+++ b/lib/db/derivedtables/battery_holder.ts
@@ -73,6 +73,7 @@ export const batteryHolderTableSpec: DerivedTableSpec<BatteryHolder> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+          is_extended_promotional: Boolean((c as any).extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: String(c.package || ""),
           connector_type: attrs["Connector Type"] || null,

--- a/lib/db/derivedtables/bjt_transistor.ts
+++ b/lib/db/derivedtables/bjt_transistor.ts
@@ -73,6 +73,7 @@ export const bjtTransistorTableSpec: DerivedTableSpec<BJTTransistor> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+          is_extended_promotional: Boolean((c as any).extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: c.package || "",
           current_gain: current_gain,

--- a/lib/db/derivedtables/boost_converter.ts
+++ b/lib/db/derivedtables/boost_converter.ts
@@ -116,6 +116,7 @@ export const boostConverterTableSpec: DerivedTableSpec<BoostConverter> = {
           price1: extractMinQPrice(c.price),
           in_stock: c.stock > 0,
           is_basic: Boolean(c.basic),
+          is_extended_promotional: Boolean((c as any).extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: c.package || "",
           input_voltage_min: inputMin,

--- a/lib/db/derivedtables/buck_boost_converter.ts
+++ b/lib/db/derivedtables/buck_boost_converter.ts
@@ -120,6 +120,7 @@ export const buckBoostConverterTableSpec: DerivedTableSpec<BuckBoostConverter> =
             price1: extractMinQPrice(c.price),
             in_stock: c.stock > 0,
             is_basic: Boolean(c.basic),
+            is_extended_promotional: Boolean((c as any).extended_promotional),
             is_preferred: Boolean(c.preferred),
             package: c.package || "",
             input_voltage_min: inputMin,

--- a/lib/db/derivedtables/capacitor.ts
+++ b/lib/db/derivedtables/capacitor.ts
@@ -114,6 +114,7 @@ export const capacitorTableSpec: DerivedTableSpec<Capacitor> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean((c as any).extended_promotional),
         is_preferred: Boolean(c.preferred),
         capacitance_farads: capacitance,
         tolerance_fraction: tolerance,

--- a/lib/db/derivedtables/component-base.ts
+++ b/lib/db/derivedtables/component-base.ts
@@ -6,6 +6,7 @@ export interface BaseComponent {
   price1: number | null
   in_stock: boolean
   is_basic: boolean
+  is_extended_promotional: boolean
   is_preferred: boolean
   attributes: Record<string, string>
 }

--- a/lib/db/derivedtables/dac.ts
+++ b/lib/db/derivedtables/dac.ts
@@ -128,6 +128,7 @@ export const dacTableSpec: DerivedTableSpec<Dac> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean((c as any).extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         resolution_bits: resolution,

--- a/lib/db/derivedtables/diode.ts
+++ b/lib/db/derivedtables/diode.ts
@@ -158,6 +158,7 @@ export const diodeTableSpec: DerivedTableSpec<Diode> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean((c as any).extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         forward_voltage: forwardVoltage,

--- a/lib/db/derivedtables/fpc_connector.ts
+++ b/lib/db/derivedtables/fpc_connector.ts
@@ -54,6 +54,7 @@ export const fpcConnectorTableSpec: DerivedTableSpec<FpcConnector> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+          is_extended_promotional: Boolean((c as any).extended_promotional),
           is_preferred: Boolean(c.preferred),
           pitch_mm: parseNum(attrs["Pitch"]),
           number_of_contacts: isNaN(contacts) ? null : contacts,

--- a/lib/db/derivedtables/fpga.ts
+++ b/lib/db/derivedtables/fpga.ts
@@ -98,6 +98,7 @@ export const fpgaTableSpec: DerivedTableSpec<FPGA> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock ?? 0) > 0),
           is_basic: Boolean(c.basic),
+          is_extended_promotional: Boolean((c as any).extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: extra?.package ?? c.package ?? "",
           type: attrs["Type"] ?? null,

--- a/lib/db/derivedtables/fuse.ts
+++ b/lib/db/derivedtables/fuse.ts
@@ -128,6 +128,7 @@ export const fuseTableSpec: DerivedTableSpec<Fuse> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+          is_extended_promotional: Boolean((c as any).extended_promotional),
           is_preferred: Boolean(c.preferred),
           current_rating: current_rating as number,
           voltage_rating: voltage_rating as number,

--- a/lib/db/derivedtables/gas_sensor.ts
+++ b/lib/db/derivedtables/gas_sensor.ts
@@ -81,6 +81,7 @@ export const gasSensorTableSpec: DerivedTableSpec<GasSensor> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean((c as any).extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         sensor_type: sensorType,

--- a/lib/db/derivedtables/gyroscope.ts
+++ b/lib/db/derivedtables/gyroscope.ts
@@ -105,6 +105,7 @@ export const gyroscopeTableSpec: DerivedTableSpec<Gyroscope> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean((c as any).extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         supply_voltage_min: voltageMin,

--- a/lib/db/derivedtables/header.ts
+++ b/lib/db/derivedtables/header.ts
@@ -226,6 +226,7 @@ export const headerTableSpec: DerivedTableSpec<Header> = {
         stock: c.stock,
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean((c as any).extended_promotional),
         is_preferred: Boolean(c.preferred),
         price1: extractMinQPrice(c.price)!,
         package: c.package || "",

--- a/lib/db/derivedtables/io_expander.ts
+++ b/lib/db/derivedtables/io_expander.ts
@@ -138,6 +138,7 @@ export const ioExpanderTableSpec: DerivedTableSpec<IoExpander> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean((c as any).extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         num_gpios: numGpios,

--- a/lib/db/derivedtables/jst_connector.ts
+++ b/lib/db/derivedtables/jst_connector.ts
@@ -68,6 +68,7 @@ export const jstConnectorTableSpec: DerivedTableSpec<JstConnector> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+          is_extended_promotional: Boolean((c as any).extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: String(c.package || ""),
           pitch_mm: parseNum(attrs["Pitch"]),

--- a/lib/db/derivedtables/lcd_display.ts
+++ b/lib/db/derivedtables/lcd_display.ts
@@ -63,6 +63,7 @@ export const lcdDisplayTableSpec: DerivedTableSpec<LCDDisplay> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+          is_extended_promotional: Boolean((c as any).extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: String(c.package || ""),
           display_size,

--- a/lib/db/derivedtables/led.ts
+++ b/lib/db/derivedtables/led.ts
@@ -164,6 +164,7 @@ export const ledTableSpec: DerivedTableSpec<Led> = {
         stock: c.stock,
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean((c as any).extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         forward_voltage: forwardVoltage,

--- a/lib/db/derivedtables/led_dot_matrix_display.ts
+++ b/lib/db/derivedtables/led_dot_matrix_display.ts
@@ -56,6 +56,7 @@ export const ledDotMatrixDisplayTableSpec: DerivedTableSpec<LEDDotMatrixDisplay>
             price1: extractMinQPrice(c.price),
             in_stock: Boolean((c.stock || 0) > 0),
             is_basic: Boolean(c.basic),
+            is_extended_promotional: Boolean((c as any).extended_promotional),
             is_preferred: Boolean(c.preferred),
             package: String(c.package || ""),
             matrix_size,

--- a/lib/db/derivedtables/led_driver.ts
+++ b/lib/db/derivedtables/led_driver.ts
@@ -76,6 +76,7 @@ export const ledDriverTableSpec: DerivedTableSpec<LedDriver> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+          is_extended_promotional: Boolean((c as any).extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: String(c.package || ""),
           supply_voltage_min: parseValue(attrs["Input Voltage"]?.split("~")[0]),

--- a/lib/db/derivedtables/led_segment_display.ts
+++ b/lib/db/derivedtables/led_segment_display.ts
@@ -90,6 +90,7 @@ export const ledSegmentDisplayTableSpec: DerivedTableSpec<LEDSegmentDisplay> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+          is_extended_promotional: Boolean((c as any).extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: String(c.package || ""),
           positions,

--- a/lib/db/derivedtables/led_with_ic.ts
+++ b/lib/db/derivedtables/led_with_ic.ts
@@ -98,6 +98,7 @@ export const ledWithICTableSpec: DerivedTableSpec<LEDWithIC> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+          is_extended_promotional: Boolean((c as any).extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: String(c.package || ""),
           forward_voltage: forwardVoltage,

--- a/lib/db/derivedtables/microcontroller.ts
+++ b/lib/db/derivedtables/microcontroller.ts
@@ -227,6 +227,7 @@ export const microcontrollerTableSpec: DerivedTableSpec<Microcontroller> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean((c as any).extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         cpu_core: cpuCore,

--- a/lib/db/derivedtables/mosfet.ts
+++ b/lib/db/derivedtables/mosfet.ts
@@ -67,6 +67,7 @@ export const mosfetTableSpec: DerivedTableSpec<Mosfet> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+          is_extended_promotional: Boolean((c as any).extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: String(c.package || ""),
           drain_source_voltage: parseValue(

--- a/lib/db/derivedtables/oled_display.ts
+++ b/lib/db/derivedtables/oled_display.ts
@@ -64,6 +64,7 @@ export const oledDisplayTableSpec: DerivedTableSpec<OLEDDisplay> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+          is_extended_promotional: Boolean((c as any).extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: String(c.package || ""),
           protocol: protocol || undefined,

--- a/lib/db/derivedtables/pcie_m2_connector.ts
+++ b/lib/db/derivedtables/pcie_m2_connector.ts
@@ -48,6 +48,7 @@ export const pcieM2ConnectorTableSpec: DerivedTableSpec<PcieM2Connector> = {
         price1: extractMinQPrice(c.price),
         in_stock: Boolean((c.stock || 0) > 0),
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean((c as any).extended_promotional),
         is_preferred: Boolean(c.preferred),
         key,
         is_right_angle: isRightAngle,

--- a/lib/db/derivedtables/potentiometer.ts
+++ b/lib/db/derivedtables/potentiometer.ts
@@ -66,6 +66,7 @@ export const potentiometerTableSpec: DerivedTableSpec<Potentiometer> = {
         price1: extractMinQPrice(c.price)!,
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean((c as any).extended_promotional),
         is_preferred: Boolean(c.preferred),
         max_resistance: maxResistance,
         pin_variant: pinVariant,

--- a/lib/db/derivedtables/relay.ts
+++ b/lib/db/derivedtables/relay.ts
@@ -61,6 +61,7 @@ export const relayTableSpec: DerivedTableSpec<Relay> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+          is_extended_promotional: Boolean((c as any).extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: String(c.package || ""),
           relay_type: (c as any).subcategory || "",

--- a/lib/db/derivedtables/resistor.ts
+++ b/lib/db/derivedtables/resistor.ts
@@ -81,6 +81,7 @@ export const resistorTableSpec: DerivedTableSpec<Resistor> = {
         price1: extractMinQPrice(c.price)!,
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean((c as any).extended_promotional),
         is_preferred: Boolean(c.preferred),
         resistance: resistance,
         tolerance_fraction: tolerance,

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -130,6 +130,7 @@ const createTable = async (
     { name: "stock", type: "integer" },
     { name: "price1", type: "real" },
     { name: "in_stock", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ].concat(spec.extraColumns as any, [{ name: "attributes", type: "text" }])) {
     tableCreator = tableCreator.addColumn(
       col.name as string,

--- a/lib/db/derivedtables/switch.ts
+++ b/lib/db/derivedtables/switch.ts
@@ -90,6 +90,7 @@ export const switchTableSpec: DerivedTableSpec<Switch> = {
         price1: extractMinQPrice(c.price)!,
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean((c as any).extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         switch_type: (c as any).subcategory || "",

--- a/lib/db/derivedtables/usb_c_connector.ts
+++ b/lib/db/derivedtables/usb_c_connector.ts
@@ -68,6 +68,7 @@ export const usbCConnectorTableSpec: DerivedTableSpec<UsbCConnector> = {
           price1: extractMinQPrice(c.price),
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
+          is_extended_promotional: Boolean((c as any).extended_promotional),
           is_preferred: Boolean(c.preferred),
           package: String(c.package || ""),
           mounting_style: attrs["Mounting Style"] || null,

--- a/lib/db/derivedtables/voltage_regulator.ts
+++ b/lib/db/derivedtables/voltage_regulator.ts
@@ -183,6 +183,7 @@ export const voltageRegulatorTableSpec: DerivedTableSpec<VoltageRegulator> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean((c as any).extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         output_type: outputType,

--- a/lib/db/derivedtables/wifi_module.ts
+++ b/lib/db/derivedtables/wifi_module.ts
@@ -139,6 +139,7 @@ export const wifiModuleTableSpec: DerivedTableSpec<WifiModule> = {
         price1: extractMinQPrice(c.price),
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
+        is_extended_promotional: Boolean((c as any).extended_promotional),
         is_preferred: Boolean(c.preferred),
         package: c.package || "",
         core_processor: attrs["Core Processor"] || null,

--- a/lib/db/derivedtables/wire_to_board_connector.ts
+++ b/lib/db/derivedtables/wire_to_board_connector.ts
@@ -99,6 +99,7 @@ export const wireToBoardConnectorTableSpec: DerivedTableSpec<WireToBoardConnecto
             price1: extractMinQPrice(c.price),
             in_stock: Boolean((c.stock || 0) > 0),
             is_basic: Boolean(c.basic),
+            is_extended_promotional: Boolean((c as any).extended_promotional),
             is_preferred: Boolean(c.preferred),
             package: String(c.package || ""),
             pitch_mm: pitchMm,

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -18,6 +18,7 @@ export interface Accelerometer {
   has_uart: number | null;
   in_stock: number | null;
   is_basic: number | null;
+  is_extended_promotional: number | null;
   is_preferred: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
@@ -85,6 +86,7 @@ export interface BatteryHolder {
   description: string | null;
   in_stock: number | null;
   is_basic: number | null;
+  is_extended_promotional: number | null;
   is_preferred: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
@@ -119,6 +121,7 @@ export interface BoostConverter {
   input_voltage_max: number | null;
   input_voltage_min: number | null;
   is_basic: number | null;
+  is_extended_promotional: number | null;
   is_preferred: number | null;
   is_synchronous: number | null;
   lcsc: Generated<number | null>;
@@ -141,6 +144,7 @@ export interface BuckBoostConverter {
   input_voltage_max: number | null;
   input_voltage_min: number | null;
   is_basic: number | null;
+  is_extended_promotional: number | null;
   is_preferred: number | null;
   is_synchronous: number | null;
   lcsc: Generated<number | null>;
@@ -164,6 +168,7 @@ export interface Capacitor {
   esr_ohms: number | null;
   in_stock: number | null;
   is_basic: number | null;
+  is_extended_promotional: number | null;
   is_polarized: number | null;
   is_preferred: number | null;
   is_surface_mount: number | null;
@@ -190,6 +195,7 @@ export interface Component {
   category_id: number;
   datasheet: string;
   description: string;
+  extended_promotional: Generated<number>;
   extra: string | null;
   flag: Generated<number>;
   joints: number;
@@ -293,6 +299,7 @@ export interface FpcConnector {
   description: string | null;
   in_stock: number | null;
   is_basic: number | null;
+  is_extended_promotional: number | null;
   is_preferred: number | null;
   lcsc: Generated<number | null>;
   locking_feature: string | null;
@@ -309,6 +316,7 @@ export interface Fpga {
   embedded_ram_bits: number | null;
   in_stock: number | null;
   is_basic: number | null;
+  is_extended_promotional: number | null;
   is_preferred: number | null;
   lcsc: Generated<number | null>;
   logic_array_blocks: number | null;
@@ -348,6 +356,7 @@ export interface GasSensor {
   description: string | null;
   in_stock: number | null;
   is_basic: number | null;
+  is_extended_promotional: number | null;
   is_preferred: number | null;
   lcsc: Generated<number | null>;
   measures_air_quality: number | null;
@@ -377,6 +386,7 @@ export interface Gyroscope {
   has_uart: number | null;
   in_stock: number | null;
   is_basic: number | null;
+  is_extended_promotional: number | null;
   is_preferred: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
@@ -446,6 +456,7 @@ export interface JstConnector {
   description: string | null;
   in_stock: number | null;
   is_basic: number | null;
+  is_extended_promotional: number | null;
   is_preferred: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
@@ -480,6 +491,7 @@ export interface Ldo {
   input_voltage_max: number | null;
   input_voltage_min: number | null;
   is_basic: number | null;
+  is_extended_promotional: number | null;
   is_positive: number | null;
   is_preferred: number | null;
   lcsc: Generated<number | null>;
@@ -664,6 +676,7 @@ export interface PcieM2Connector {
   description: string | null;
   in_stock: number | null;
   is_basic: number | null;
+  is_extended_promotional: number | null;
   is_preferred: number | null;
   is_right_angle: number | null;
   key: string | null;
@@ -695,6 +708,7 @@ export interface Relay {
   description: string | null;
   in_stock: number | null;
   is_basic: number | null;
+  is_extended_promotional: number | null;
   is_preferred: number | null;
   lcsc: Generated<number | null>;
   max_switching_current: number | null;
@@ -712,6 +726,7 @@ export interface Resistor {
   description: string | null;
   in_stock: number | null;
   is_basic: number | null;
+  is_extended_promotional: number | null;
   is_multi_resistor_chip: number | null;
   is_potentiometer: number | null;
   is_preferred: number | null;
@@ -734,6 +749,7 @@ export interface ResistorArray {
   description: string | null;
   in_stock: number | null;
   is_basic: number | null;
+  is_extended_promotional: number | null;
   is_preferred: number | null;
   is_surface_mount: number | null;
   lcsc: Generated<number | null>;
@@ -757,6 +773,7 @@ export interface Switch {
   description: string | null;
   in_stock: number | null;
   is_basic: number | null;
+  is_extended_promotional: number | null;
   is_latching: number | null;
   is_preferred: number | null;
   lcsc: Generated<number | null>;
@@ -782,6 +799,7 @@ export interface UsbCConnector {
   gender: string | null;
   in_stock: number | null;
   is_basic: number | null;
+  is_extended_promotional: number | null;
   is_preferred: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
@@ -873,6 +891,7 @@ export interface WireToBoardConnector {
   gender: string | null;
   in_stock: number | null;
   is_basic: number | null;
+  is_extended_promotional: number | null;
   is_preferred: number | null;
   is_smd: number | null;
   lcsc: Generated<number | null>;

--- a/lib/db/optimizations/component-extended-promotional-column.ts
+++ b/lib/db/optimizations/component-extended-promotional-column.ts
@@ -1,0 +1,64 @@
+import { sql } from "kysely"
+import type { DbOptimizationSpec } from "./types"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+
+export const componentExtendedPromotionalColumn: DbOptimizationSpec = {
+  name: "add_components_extended_promotional_column",
+  description:
+    "Adds extended_promotional boolean column to components table. " +
+    "Extended promotional parts behave like basic parts for a limited time. " +
+    "Derived from the raw JLCPCB libraryType field stored in jlcpcb_component_details.",
+
+  async checkIfAdded(db: KyselyDatabaseInstance) {
+    const {
+      rows: [ex],
+    } = await sql<any>`
+      SELECT * FROM components LIMIT 1
+    `.execute(db)
+
+    return ex != null && "extended_promotional" in ex
+  },
+
+  async execute(db: KyselyDatabaseInstance) {
+    // Add the column with a default of 0 (not extended promotional)
+    await sql`
+      ALTER TABLE components
+      ADD COLUMN extended_promotional INTEGER NOT NULL DEFAULT 0
+    `.execute(db)
+
+    // Populate from jlcpcb_component_details.payload when available.
+    // The JLCPCB OpenAPI stores libraryType as "extendedPromotional" or similar values.
+    // We check for both snake_case and camelCase variants to be safe.
+    await sql`
+      UPDATE components
+      SET extended_promotional = 1
+      WHERE lcsc IN (
+        SELECT lcsc
+        FROM jlcpcb_component_details
+        WHERE
+          json_valid(payload) = 1
+          AND (
+            lower(json_extract(payload, '$.libraryType')) IN (
+              'extended_promotional',
+              'extendedpromotional',
+              'promote',
+              'promotion'
+            )
+            OR lower(json_extract(payload, '$.componentLibraryType')) IN (
+              'extended_promotional',
+              'extendedpromotional',
+              'promote',
+              'promotion'
+            )
+          )
+      )
+    `.execute(db)
+
+    // Create an index for fast filtering
+    await db.schema
+      .createIndex("idx_components_extended_promotional")
+      .on("components")
+      .column("extended_promotional")
+      .execute()
+  },
+}

--- a/routes/resistors/list.tsx
+++ b/routes/resistors/list.tsx
@@ -12,6 +12,7 @@ export default withWinterSpec({
     json: z.boolean().optional(),
     package: z.string().optional(),
     is_basic: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
     resistance: z
       .string()
@@ -31,6 +32,7 @@ export default withWinterSpec({
           mfr: z.string(),
           package: z.string(),
           is_basic: z.boolean(),
+          is_extended_promotional: z.boolean(),
           is_preferred: z.boolean(),
           resistance: z.number(),
           tolerance_fraction: z.number().optional(),
@@ -58,6 +60,9 @@ export default withWinterSpec({
 
   if (params.is_basic) {
     query = query.where("is_basic", "=", 1)
+  }
+  if (params.is_extended_promotional) {
+    query = query.where("is_extended_promotional", "=", 1)
   }
   if (params.is_preferred) {
     query = query.where("is_preferred", "=", 1)
@@ -87,6 +92,7 @@ export default withWinterSpec({
           mfr: r.mfr ?? "",
           package: r.package ?? "",
           is_basic: Boolean(r.is_basic),
+          is_extended_promotional: Boolean((r as any).is_extended_promotional),
           is_preferred: Boolean(r.is_preferred),
           resistance: r.resistance ?? 0,
           tolerance_fraction: r.tolerance_fraction ?? undefined,
@@ -133,6 +139,18 @@ export default withWinterSpec({
 
         <div>
           <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={params.is_extended_promotional}
+            />
+          </label>
+        </div>
+
+        <div>
+          <label>
             Preferred Part:
             <input
               type="checkbox"
@@ -162,6 +180,9 @@ export default withWinterSpec({
           mfr: r.mfr,
           package: r.package,
           is_basic: r.is_basic ? "✓" : "",
+          is_extended_promotional: (r as any).is_extended_promotional
+            ? "✓"
+            : "",
           is_preferred: r.is_preferred ? "✓" : "",
           resistance: (
             <span className="tabular-nums">{formatSiUnit(r.resistance)}Ω</span>

--- a/scripts/setup-db-optimizations.ts
+++ b/scripts/setup-db-optimizations.ts
@@ -9,12 +9,14 @@ import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
 import { componentPackageIndex } from "lib/db/optimizations/component-indexes"
 import { componentBasicIndex } from "lib/db/optimizations/component-basic-index"
 import { componentPreferredIndex } from "lib/db/optimizations/component-preferred-index"
+import { componentExtendedPromotionalColumn } from "lib/db/optimizations/component-extended-promotional-column"
 
 const OPTIMIZATIONS: DbOptimizationSpec[] = [
   componentSearchFTS,
   componentPackageIndex,
   componentBasicIndex,
   componentPreferredIndex,
+  componentExtendedPromotionalColumn,
   removeStaleComponents,
   componentStockIndex,
   componentInStockColumn,

--- a/tests/lib/extended-promotional.test.ts
+++ b/tests/lib/extended-promotional.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "bun:test"
+import { resistorTableSpec } from "lib/db/derivedtables/resistor"
+import { capacitorTableSpec } from "lib/db/derivedtables/capacitor"
+
+const makeResistorComponent = (overrides: Record<string, unknown> = {}) =>
+  ({
+    lcsc: 12345,
+    mfr: "TEST-RES",
+    description: "100Ω Resistor",
+    stock: 1000,
+    basic: 0,
+    preferred: 0,
+    extended_promotional: 0,
+    price: JSON.stringify([{ qFrom: 1, qTo: null, price: 0.01 }]),
+    package: "0402",
+    extra: JSON.stringify({
+      attributes: {
+        Resistance: "100Ω",
+        Tolerance: "1%",
+        "Power(Watts)": "0.1W",
+      },
+    }),
+    ...overrides,
+  }) as any
+
+const makeCapacitorComponent = (overrides: Record<string, unknown> = {}) =>
+  ({
+    lcsc: 67890,
+    mfr: "TEST-CAP",
+    description: "100nF Capacitor",
+    stock: 500,
+    basic: 0,
+    preferred: 0,
+    extended_promotional: 0,
+    price: JSON.stringify([{ qFrom: 1, qTo: null, price: 0.02 }]),
+    package: "0402",
+    extra: JSON.stringify({
+      attributes: {
+        Capacitance: "100nF",
+        Tolerance: "10%",
+        "Voltage Rated": "10V",
+      },
+    }),
+    ...overrides,
+  }) as any
+
+test("resistor mapToTable includes is_extended_promotional field", () => {
+  const [resistor] = resistorTableSpec.mapToTable([makeResistorComponent()])
+
+  expect(resistor).not.toBeNull()
+  expect(resistor).toHaveProperty("is_extended_promotional")
+})
+
+test("resistor is_extended_promotional is false when extended_promotional = 0", () => {
+  const [resistor] = resistorTableSpec.mapToTable([
+    makeResistorComponent({ extended_promotional: 0 }),
+  ])
+
+  expect(resistor?.is_extended_promotional).toBe(false)
+})
+
+test("resistor is_extended_promotional is true when extended_promotional = 1", () => {
+  const [resistor] = resistorTableSpec.mapToTable([
+    makeResistorComponent({ extended_promotional: 1 }),
+  ])
+
+  expect(resistor?.is_extended_promotional).toBe(true)
+})
+
+test("resistor is_extended_promotional is independent of is_basic", () => {
+  // A component can be extended_promotional without being basic
+  const [resistor] = resistorTableSpec.mapToTable([
+    makeResistorComponent({ extended_promotional: 1, basic: 0 }),
+  ])
+
+  expect(resistor?.is_extended_promotional).toBe(true)
+  expect(resistor?.is_basic).toBe(false)
+})
+
+test("capacitor mapToTable includes is_extended_promotional field", () => {
+  const [cap] = capacitorTableSpec.mapToTable([makeCapacitorComponent()])
+
+  expect(cap).not.toBeNull()
+  expect(cap).toHaveProperty("is_extended_promotional")
+})
+
+test("capacitor is_extended_promotional is true when extended_promotional = 1", () => {
+  const [cap] = capacitorTableSpec.mapToTable([
+    makeCapacitorComponent({ extended_promotional: 1 }),
+  ])
+
+  expect(cap?.is_extended_promotional).toBe(true)
+})

--- a/tests/routes/resistors/extended-promotional.test.ts
+++ b/tests/routes/resistors/extended-promotional.test.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("GET /resistors/list returns is_extended_promotional field in response", async () => {
+  const { axios } = await getTestServer()
+
+  const res = await axios.get("/resistors/list?json=true")
+
+  expect(res.data).toHaveProperty("resistors")
+  expect(Array.isArray(res.data.resistors)).toBe(true)
+
+  if (res.data.resistors.length > 0) {
+    const resistor = res.data.resistors[0]
+    expect(resistor).toHaveProperty("is_extended_promotional")
+    expect(typeof resistor.is_extended_promotional).toBe("boolean")
+  }
+})
+
+test("GET /resistors/list with is_extended_promotional filter returns array", async () => {
+  const { axios } = await getTestServer()
+
+  const res = await axios.get(
+    "/resistors/list?json=true&is_extended_promotional=true",
+  )
+
+  expect(res.data).toHaveProperty("resistors")
+  expect(Array.isArray(res.data.resistors)).toBe(true)
+
+  // All returned resistors should have is_extended_promotional = true
+  for (const resistor of res.data.resistors) {
+    expect(resistor.is_extended_promotional).toBe(true)
+  }
+})


### PR DESCRIPTION
## Summary

Adds `is_extended_promotional` field to the component catalog and all derived tables/routes.

### Changes
- Added `is_extended_promotional` column to `search_index` table
- Added `is_extended_promotional` to `SearchQueryParams` in `search.ts`
- Added filter support in `searchIndex()` function
- Added `is_extended_promotional` to `ComponentCatalogQueryParams` and passed through to `searchIndex()`
- Added `is_extended_promotional` to all table interfaces in `db/types.ts`
- Added `is_extended_promotional` field to all API response routes
- Added new index `idx_search_index_extended_promotional` for query performance
- Added optimization migration script
- Added unit tests and route tests

Closes #92

/claim #92