### PR TITLE
fix: add is_extended_promotional column and fix missing preferred in SELECT

### DIFF
--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -35,6 +35,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -51,6 +52,7 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -69,6 +71,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   if (req.query.search) {
@@ -111,6 +116,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.preferred && !c.basic),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +158,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>


### PR DESCRIPTION
**Changes:**

1. Add `is_extended_promotional` query parameter to filter components
2. Add `"preferred"` to SELECT array (fixes bug where `is_preferred` in response was always false)
3. Add filter logic: `preferred = 1 AND basic = 0` for extended promotional parts
4. Add `is_extended_promotional: Boolean(c.preferred && !c.basic)` to response mapping
5. Add UI checkbox for "Extended Promotional" filter

**Bug Fixed:** The original code was missing `preferred` in the SELECT array, causing `is_preferred` in the API response to always be `false` (undefined → Boolean(undefined) = false).

**Testing:** 
- Filter by `?is_extended_promotional=true` returns preferred parts that are not basic
- API response now correctly includes `is_extended_promotional` field
- UI checkbox allows filtering extended promotional parts

/claim #92