### PR TITLE
feat: add is_extended_promotional column to components

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 35
 
     steps:
       - name: Checkout code
@@ -30,6 +30,8 @@ jobs:
 
       - name: Run setup if cache miss
         if: steps.cache-setup.outputs.cache-hit != 'true'
+        env:
+          SKIP_DB_VACUUM: "true"
         run: bun run setup
 
       - name: Run tests

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -21,6 +21,10 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Install cf-proxy dependencies
+        run: bun install
+        working-directory: ./cf-proxy
+
       - name: Cache setup artifacts
         id: cache-setup
         uses: actions/cache@v4

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -27,6 +27,7 @@ jobs:
         with:
           path: ./db.sqlite3
           key: db-sqlite3-${{ hashFiles('scripts/setup-*.ts') }}
+          save-always: true
 
       - name: Run setup if cache miss
         if: steps.cache-setup.outputs.cache-hit != 'true'

--- a/lib/db/derivedtables/accelerometer.ts
+++ b/lib/db/derivedtables/accelerometer.ts
@@ -1,6 +1,6 @@
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface Accelerometer extends BaseComponent {
   package: string
@@ -28,6 +28,7 @@ export const accelerometerTableSpec: DerivedTableSpec<Accelerometer> = {
     { name: "has_uart", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -102,6 +103,7 @@ export const accelerometerTableSpec: DerivedTableSpec<Accelerometer> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c.extra),
         package: c.package || "",
         supply_voltage_min: voltageMin,
         supply_voltage_max: voltageMax,

--- a/lib/db/derivedtables/adc.ts
+++ b/lib/db/derivedtables/adc.ts
@@ -1,7 +1,7 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface Adc extends BaseComponent {
   // Extra columns
@@ -40,6 +40,7 @@ export const adcTableSpec: DerivedTableSpec<Adc> = {
     { name: "operating_temp_max", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -115,6 +116,7 @@ export const adcTableSpec: DerivedTableSpec<Adc> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c.extra),
         package: c.package || "",
         resolution_bits: resolution,
         sampling_rate_hz: samplingRate,

--- a/lib/db/derivedtables/analog_multiplexer.ts
+++ b/lib/db/derivedtables/analog_multiplexer.ts
@@ -1,7 +1,7 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface AnalogMultiplexer extends BaseComponent {
   // Extra columns
@@ -40,6 +40,7 @@ export const analogMultiplexerTableSpec: DerivedTableSpec<AnalogMultiplexer> = {
     { name: "channel_type", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -144,6 +145,7 @@ export const analogMultiplexerTableSpec: DerivedTableSpec<AnalogMultiplexer> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c.extra),
         package: c.package || "",
         num_channels: numChannels,
         num_bits: numBits,

--- a/lib/db/derivedtables/battery_holder.ts
+++ b/lib/db/derivedtables/battery_holder.ts
@@ -1,7 +1,7 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 import type { KyselyDatabaseInstance } from "../kysely-types"
 
 export interface BatteryHolder extends BaseComponent {
@@ -32,6 +32,7 @@ export const batteryHolderTableSpec: DerivedTableSpec<BatteryHolder> = {
     { name: "operating_temp_max", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -74,6 +75,7 @@ export const batteryHolderTableSpec: DerivedTableSpec<BatteryHolder> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c.extra),
           package: String(c.package || ""),
           connector_type: attrs["Connector Type"] || null,
           battery_type: attrs["Battery Type"] || null,

--- a/lib/db/derivedtables/bjt_transistor.ts
+++ b/lib/db/derivedtables/bjt_transistor.ts
@@ -1,6 +1,6 @@
 import type { DerivedTableSpec } from "./types"
 import type { KyselyDatabaseInstance } from "../kysely-types"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 
@@ -26,6 +26,7 @@ export const bjtTransistorTableSpec: DerivedTableSpec<BJTTransistor> = {
     { name: "temperature_range", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -74,6 +75,7 @@ export const bjtTransistorTableSpec: DerivedTableSpec<BJTTransistor> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c.extra),
           package: c.package || "",
           current_gain: current_gain,
           collector_current: collector_current,

--- a/lib/db/derivedtables/boost_converter.ts
+++ b/lib/db/derivedtables/boost_converter.ts
@@ -1,6 +1,6 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 import type { DerivedTableSpec } from "./types"
 
 export interface BoostConverter extends BaseComponent {
@@ -31,6 +31,7 @@ export const boostConverterTableSpec: DerivedTableSpec<BoostConverter> = {
     { name: "number_of_outputs", type: "integer" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -117,6 +118,7 @@ export const boostConverterTableSpec: DerivedTableSpec<BoostConverter> = {
           in_stock: c.stock > 0,
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c.extra),
           package: c.package || "",
           input_voltage_min: inputMin,
           input_voltage_max: inputMax,

--- a/lib/db/derivedtables/buck_boost_converter.ts
+++ b/lib/db/derivedtables/buck_boost_converter.ts
@@ -1,6 +1,6 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 import type { DerivedTableSpec } from "./types"
 
 export interface BuckBoostConverter extends BaseComponent {
@@ -32,6 +32,7 @@ export const buckBoostConverterTableSpec: DerivedTableSpec<BuckBoostConverter> =
       { name: "number_of_outputs", type: "integer" },
       { name: "is_basic", type: "boolean" },
       { name: "is_preferred", type: "boolean" },
+      { name: "is_extended_promotional", type: "boolean" },
     ],
     listCandidateComponents: (db) =>
       db
@@ -121,6 +122,7 @@ export const buckBoostConverterTableSpec: DerivedTableSpec<BuckBoostConverter> =
             in_stock: c.stock > 0,
             is_basic: Boolean(c.basic),
             is_preferred: Boolean(c.preferred),
+            is_extended_promotional: isExtendedPromotional(c.extra),
             package: c.package || "",
             input_voltage_min: inputMin,
             input_voltage_max: inputMax,

--- a/lib/db/derivedtables/capacitor.ts
+++ b/lib/db/derivedtables/capacitor.ts
@@ -1,7 +1,7 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface Capacitor extends BaseComponent {
   // Extra columns
@@ -34,6 +34,7 @@ export const capacitorTableSpec: DerivedTableSpec<Capacitor> = {
     { name: "capacitor_type", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -115,6 +116,7 @@ export const capacitorTableSpec: DerivedTableSpec<Capacitor> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c.extra),
         capacitance_farads: capacitance,
         tolerance_fraction: tolerance,
         voltage_rating: voltage,

--- a/lib/db/derivedtables/component-base.ts
+++ b/lib/db/derivedtables/component-base.ts
@@ -7,5 +7,16 @@ export interface BaseComponent {
   in_stock: boolean
   is_basic: boolean
   is_preferred: boolean
+  is_extended_promotional: boolean
   attributes: Record<string, string>
+}
+
+export function isExtendedPromotional(extra: string | null): boolean {
+  try {
+    const parsed = JSON.parse(extra ?? "{}")
+    const libType = parsed?.componentLibraryType
+    return libType === "expand" || libType === "expandPrefer"
+  } catch {
+    return false
+  }
 }

--- a/lib/db/derivedtables/dac.ts
+++ b/lib/db/derivedtables/dac.ts
@@ -1,7 +1,7 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface Dac extends BaseComponent {
   // Extra columns
@@ -38,6 +38,7 @@ export const dacTableSpec: DerivedTableSpec<Dac> = {
     { name: "nonlinearity_lsb", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -129,6 +130,7 @@ export const dacTableSpec: DerivedTableSpec<Dac> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c.extra),
         package: c.package || "",
         resolution_bits: resolution,
         num_channels: numChannels,

--- a/lib/db/derivedtables/diode.ts
+++ b/lib/db/derivedtables/diode.ts
@@ -1,7 +1,7 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface Diode extends BaseComponent {
   // Extra columns
@@ -40,6 +40,7 @@ export const diodeTableSpec: DerivedTableSpec<Diode> = {
     { name: "configuration", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -159,6 +160,7 @@ export const diodeTableSpec: DerivedTableSpec<Diode> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c.extra),
         package: c.package || "",
         forward_voltage: forwardVoltage,
         reverse_voltage: reverseVoltage,

--- a/lib/db/derivedtables/fpc_connector.ts
+++ b/lib/db/derivedtables/fpc_connector.ts
@@ -1,7 +1,7 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 import type { KyselyDatabaseInstance } from "../kysely-types"
 
 export interface FpcConnector extends BaseComponent {
@@ -20,6 +20,7 @@ export const fpcConnectorTableSpec: DerivedTableSpec<FpcConnector> = {
     { name: "locking_feature", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -55,6 +56,7 @@ export const fpcConnectorTableSpec: DerivedTableSpec<FpcConnector> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c.extra),
           pitch_mm: parseNum(attrs["Pitch"]),
           number_of_contacts: isNaN(contacts) ? null : contacts,
           contact_type: attrs["Contact Type"] || null,

--- a/lib/db/derivedtables/fpga.ts
+++ b/lib/db/derivedtables/fpga.ts
@@ -1,6 +1,6 @@
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
 import type { DerivedTableSpec } from "./types"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface FPGA extends BaseComponent {
   package: string
@@ -68,6 +68,7 @@ export const fpgaTableSpec: DerivedTableSpec<FPGA> = {
     { name: "logic_gates", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -99,6 +100,7 @@ export const fpgaTableSpec: DerivedTableSpec<FPGA> = {
           in_stock: Boolean((c.stock ?? 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c.extra),
           package: extra?.package ?? c.package ?? "",
           type: attrs["Type"] ?? null,
           logic_array_blocks: parseNumericValue(attrs["Logic Array Blocks"]),

--- a/lib/db/derivedtables/fuse.ts
+++ b/lib/db/derivedtables/fuse.ts
@@ -1,7 +1,7 @@
 import type { DerivedTableSpec } from "./types"
 import type { KyselyDatabaseInstance } from "../kysely-types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 const FUSE_SUBCATEGORIES = [
   "Fuses",
@@ -37,6 +37,7 @@ export const fuseTableSpec: DerivedTableSpec<Fuse> = {
     { name: "is_resettable", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -129,6 +130,7 @@ export const fuseTableSpec: DerivedTableSpec<Fuse> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c.extra),
           current_rating: current_rating as number,
           voltage_rating: voltage_rating as number,
           response_time,

--- a/lib/db/derivedtables/gas_sensor.ts
+++ b/lib/db/derivedtables/gas_sensor.ts
@@ -1,6 +1,6 @@
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface GasSensor extends BaseComponent {
   package: string
@@ -36,6 +36,7 @@ export const gasSensorTableSpec: DerivedTableSpec<GasSensor> = {
     { name: "measures_explosive_gases", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db) {
     return db
@@ -82,6 +83,7 @@ export const gasSensorTableSpec: DerivedTableSpec<GasSensor> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c.extra),
         package: c.package || "",
         sensor_type: sensorType,
         measures_air_quality: measuresAirQuality,

--- a/lib/db/derivedtables/gyroscope.ts
+++ b/lib/db/derivedtables/gyroscope.ts
@@ -1,6 +1,6 @@
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface Gyroscope extends BaseComponent {
   package: string
@@ -28,6 +28,7 @@ export const gyroscopeTableSpec: DerivedTableSpec<Gyroscope> = {
     { name: "has_uart", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -106,6 +107,7 @@ export const gyroscopeTableSpec: DerivedTableSpec<Gyroscope> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c.extra),
         package: c.package || "",
         supply_voltage_min: voltageMin,
         supply_voltage_max: voltageMax,

--- a/lib/db/derivedtables/header.ts
+++ b/lib/db/derivedtables/header.ts
@@ -1,7 +1,7 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface Header extends BaseComponent {
   // Extra columns
@@ -48,6 +48,7 @@ export const headerTableSpec: DerivedTableSpec<Header> = {
     { name: "is_right_angle", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -227,6 +228,7 @@ export const headerTableSpec: DerivedTableSpec<Header> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c.extra),
         price1: extractMinQPrice(c.price)!,
         package: c.package || "",
         pitch_mm: pitch,

--- a/lib/db/derivedtables/io_expander.ts
+++ b/lib/db/derivedtables/io_expander.ts
@@ -1,7 +1,7 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface IoExpander extends BaseComponent {
   // Extra columns
@@ -40,6 +40,7 @@ export const ioExpanderTableSpec: DerivedTableSpec<IoExpander> = {
     { name: "source_current_ma", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -139,6 +140,7 @@ export const ioExpanderTableSpec: DerivedTableSpec<IoExpander> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c.extra),
         package: c.package || "",
         num_gpios: numGpios,
         supply_voltage_min: voltageMin,

--- a/lib/db/derivedtables/jst_connector.ts
+++ b/lib/db/derivedtables/jst_connector.ts
@@ -1,7 +1,7 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 import type { KyselyDatabaseInstance } from "../kysely-types"
 
 export interface JstConnector extends BaseComponent {
@@ -22,6 +22,7 @@ export const jstConnectorTableSpec: DerivedTableSpec<JstConnector> = {
     { name: "reference_series", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -69,6 +70,7 @@ export const jstConnectorTableSpec: DerivedTableSpec<JstConnector> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c.extra),
           package: String(c.package || ""),
           pitch_mm: parseNum(attrs["Pitch"]),
           num_rows: isNaN(numRows) ? null : numRows,

--- a/lib/db/derivedtables/lcd_display.ts
+++ b/lib/db/derivedtables/lcd_display.ts
@@ -1,7 +1,7 @@
 import type { DerivedTableSpec } from "./types"
 import type { KyselyDatabaseInstance } from "../kysely-types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface LCDDisplay extends BaseComponent {
   package?: string
@@ -19,6 +19,7 @@ export const lcdDisplayTableSpec: DerivedTableSpec<LCDDisplay> = {
     { name: "display_type", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -64,6 +65,7 @@ export const lcdDisplayTableSpec: DerivedTableSpec<LCDDisplay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c.extra),
           package: String(c.package || ""),
           display_size,
           resolution,

--- a/lib/db/derivedtables/led.ts
+++ b/lib/db/derivedtables/led.ts
@@ -1,7 +1,7 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface Led extends BaseComponent {
   package: string
@@ -37,6 +37,7 @@ export const ledTableSpec: DerivedTableSpec<Led> = {
     { name: "is_rgb", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -165,6 +166,7 @@ export const ledTableSpec: DerivedTableSpec<Led> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c.extra),
         package: c.package || "",
         forward_voltage: forwardVoltage,
         forward_current: forwardCurrent,

--- a/lib/db/derivedtables/led_dot_matrix_display.ts
+++ b/lib/db/derivedtables/led_dot_matrix_display.ts
@@ -1,6 +1,6 @@
 import type { DerivedTableSpec } from "./types"
 import type { KyselyDatabaseInstance } from "../kysely-types"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
 
 export interface LEDDotMatrixDisplay extends BaseComponent {
@@ -18,6 +18,7 @@ export const ledDotMatrixDisplayTableSpec: DerivedTableSpec<LEDDotMatrixDisplay>
       { name: "color", type: "text" },
       { name: "is_basic", type: "boolean" },
       { name: "is_preferred", type: "boolean" },
+      { name: "is_extended_promotional", type: "boolean" },
     ],
     listCandidateComponents(db: KyselyDatabaseInstance) {
       return db
@@ -57,6 +58,7 @@ export const ledDotMatrixDisplayTableSpec: DerivedTableSpec<LEDDotMatrixDisplay>
             in_stock: Boolean((c.stock || 0) > 0),
             is_basic: Boolean(c.basic),
             is_preferred: Boolean(c.preferred),
+            is_extended_promotional: isExtendedPromotional(c.extra),
             package: String(c.package || ""),
             matrix_size,
             color,

--- a/lib/db/derivedtables/led_driver.ts
+++ b/lib/db/derivedtables/led_driver.ts
@@ -9,7 +9,7 @@ type UnwrapGenerated<T> = {
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
 import { parseIntOrNull } from "lib/util/parse-int-or-null"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface LedDriver extends BaseComponent {
   // Optional LED driver specific fields
@@ -42,6 +42,7 @@ export const ledDriverTableSpec: DerivedTableSpec<LedDriver> = {
     { name: "mounting_style", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -77,6 +78,7 @@ export const ledDriverTableSpec: DerivedTableSpec<LedDriver> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c.extra),
           package: String(c.package || ""),
           supply_voltage_min: parseValue(attrs["Input Voltage"]?.split("~")[0]),
           supply_voltage_max: parseValue(attrs["Input Voltage"]?.split("~")[1]),

--- a/lib/db/derivedtables/led_segment_display.ts
+++ b/lib/db/derivedtables/led_segment_display.ts
@@ -1,6 +1,6 @@
 import type { DerivedTableSpec } from "./types"
 import type { KyselyDatabaseInstance } from "../kysely-types"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
 
 const LED_SEGMENT_SUBCATEGORIES = [
@@ -26,6 +26,7 @@ export const ledSegmentDisplayTableSpec: DerivedTableSpec<LEDSegmentDisplay> = {
     { name: "color", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
 
   listCandidateComponents(db: KyselyDatabaseInstance) {
@@ -91,6 +92,7 @@ export const ledSegmentDisplayTableSpec: DerivedTableSpec<LEDSegmentDisplay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c.extra),
           package: String(c.package || ""),
           positions,
           type,

--- a/lib/db/derivedtables/led_with_ic.ts
+++ b/lib/db/derivedtables/led_with_ic.ts
@@ -1,5 +1,5 @@
 import type { DerivedTableSpec } from "./types"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 import type { SelectQueryBuilder, Generated } from "kysely"
 import type { Component } from "../generated/kysely"
 import type { KyselyDatabaseInstance } from "../kysely-types"
@@ -27,6 +27,7 @@ export const ledWithICTableSpec: DerivedTableSpec<LEDWithIC> = {
     { name: "protocol", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -99,6 +100,7 @@ export const ledWithICTableSpec: DerivedTableSpec<LEDWithIC> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c.extra),
           package: String(c.package || ""),
           forward_voltage: forwardVoltage,
           forward_current: forwardCurrent,

--- a/lib/db/derivedtables/microcontroller.ts
+++ b/lib/db/derivedtables/microcontroller.ts
@@ -1,7 +1,7 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface Microcontroller extends BaseComponent {
   // Extra columns
@@ -62,6 +62,7 @@ export const microcontrollerTableSpec: DerivedTableSpec<Microcontroller> = {
     { name: "dac_resolution_bits", type: "integer" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -228,6 +229,7 @@ export const microcontrollerTableSpec: DerivedTableSpec<Microcontroller> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c.extra),
         package: c.package || "",
         cpu_core: cpuCore,
         cpu_speed_hz: cpuSpeed,

--- a/lib/db/derivedtables/mosfet.ts
+++ b/lib/db/derivedtables/mosfet.ts
@@ -9,7 +9,7 @@ type UnwrapGenerated<T> = {
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
 import { parseIntOrNull } from "lib/util/parse-int-or-null"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface Mosfet extends BaseComponent {
   package?: string
@@ -35,6 +35,7 @@ export const mosfetTableSpec: DerivedTableSpec<Mosfet> = {
     { name: "mounting_style", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -68,6 +69,7 @@ export const mosfetTableSpec: DerivedTableSpec<Mosfet> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c.extra),
           package: String(c.package || ""),
           drain_source_voltage: parseValue(
             attrs["Drain Source Voltage (Vdss)"],

--- a/lib/db/derivedtables/oled_display.ts
+++ b/lib/db/derivedtables/oled_display.ts
@@ -1,6 +1,6 @@
 import type { DerivedTableSpec } from "./types"
 import type { KyselyDatabaseInstance } from "../kysely-types"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
 
 export interface OLEDDisplay extends BaseComponent {
@@ -19,6 +19,7 @@ export const oledDisplayTableSpec: DerivedTableSpec<OLEDDisplay> = {
     { name: "pixel_resolution", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
 
   listCandidateComponents(db: KyselyDatabaseInstance) {
@@ -65,6 +66,7 @@ export const oledDisplayTableSpec: DerivedTableSpec<OLEDDisplay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c.extra),
           package: String(c.package || ""),
           protocol: protocol || undefined,
           display_width,

--- a/lib/db/derivedtables/pcie_m2_connector.ts
+++ b/lib/db/derivedtables/pcie_m2_connector.ts
@@ -1,6 +1,6 @@
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface PcieM2Connector extends BaseComponent {
   key: string | null
@@ -14,6 +14,7 @@ export const pcieM2ConnectorTableSpec: DerivedTableSpec<PcieM2Connector> = {
     { name: "is_right_angle", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -49,6 +50,7 @@ export const pcieM2ConnectorTableSpec: DerivedTableSpec<PcieM2Connector> = {
         in_stock: Boolean((c.stock || 0) > 0),
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c.extra),
         key,
         is_right_angle: isRightAngle,
         attributes: attrs,

--- a/lib/db/derivedtables/potentiometer.ts
+++ b/lib/db/derivedtables/potentiometer.ts
@@ -1,7 +1,7 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface Potentiometer extends BaseComponent {
   max_resistance: number
@@ -19,6 +19,7 @@ export const potentiometerTableSpec: DerivedTableSpec<Potentiometer> = {
     { name: "is_surface_mount", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -67,6 +68,7 @@ export const potentiometerTableSpec: DerivedTableSpec<Potentiometer> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c.extra),
         max_resistance: maxResistance,
         pin_variant: pinVariant,
         package: c.package || "",

--- a/lib/db/derivedtables/relay.ts
+++ b/lib/db/derivedtables/relay.ts
@@ -2,7 +2,7 @@ import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import { parseIntOrNull } from "lib/util/parse-int-or-null"
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 import type { KyselyDatabaseInstance } from "../kysely-types"
 
 export interface Relay extends BaseComponent {
@@ -29,6 +29,7 @@ export const relayTableSpec: DerivedTableSpec<Relay> = {
     { name: "pin_number", type: "integer" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -62,6 +63,7 @@ export const relayTableSpec: DerivedTableSpec<Relay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c.extra),
           package: String(c.package || ""),
           relay_type: (c as any).subcategory || "",
           contact_form: attrs["Contact Form"] || null,

--- a/lib/db/derivedtables/resistor.ts
+++ b/lib/db/derivedtables/resistor.ts
@@ -1,7 +1,7 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface Resistor extends BaseComponent {
   resistance: number
@@ -31,6 +31,7 @@ export const resistorTableSpec: DerivedTableSpec<Resistor> = {
     { name: "is_multi_resistor_chip", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -82,6 +83,7 @@ export const resistorTableSpec: DerivedTableSpec<Resistor> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c.extra),
         resistance: resistance,
         tolerance_fraction: tolerance,
         power_watts,

--- a/lib/db/derivedtables/resistor_array.ts
+++ b/lib/db/derivedtables/resistor_array.ts
@@ -1,7 +1,7 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
 import type { DerivedTableSpec } from "./types"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface ResistorArray extends BaseComponent {
   package: string
@@ -69,6 +69,7 @@ export const resistorArrayTableSpec: DerivedTableSpec<ResistorArray> = {
     { name: "is_surface_mount", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db

--- a/lib/db/derivedtables/resistor_array.ts
+++ b/lib/db/derivedtables/resistor_array.ts
@@ -125,6 +125,7 @@ export const resistorArrayTableSpec: DerivedTableSpec<ResistorArray> = {
         in_stock: component.stock > 0,
         is_basic: Boolean(component.basic),
         is_preferred: Boolean(component.preferred),
+        is_extended_promotional: isExtendedPromotional(component.extra),
         package: component.package ?? "",
         resistance,
         tolerance_fraction: tolerance,

--- a/lib/db/derivedtables/switch.ts
+++ b/lib/db/derivedtables/switch.ts
@@ -1,7 +1,7 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface Switch extends BaseComponent {
   package: string
@@ -37,6 +37,7 @@ export const switchTableSpec: DerivedTableSpec<Switch> = {
     { name: "switch_height_mm", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db) {
     return db
@@ -91,6 +92,7 @@ export const switchTableSpec: DerivedTableSpec<Switch> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c.extra),
         package: c.package || "",
         switch_type: (c as any).subcategory || "",
         circuit: attrs["Circuit"] || null,

--- a/lib/db/derivedtables/types.ts
+++ b/lib/db/derivedtables/types.ts
@@ -15,6 +15,7 @@ export interface DerivedTableSpec<
     price1: number | null
     in_stock: boolean
     is_basic: boolean
+    is_extended_promotional: boolean
   },
 > {
   tableName: string

--- a/lib/db/derivedtables/usb_c_connector.ts
+++ b/lib/db/derivedtables/usb_c_connector.ts
@@ -1,7 +1,7 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 import type { KyselyDatabaseInstance } from "../kysely-types"
 
 export interface UsbCConnector extends BaseComponent {
@@ -28,6 +28,7 @@ export const usbCConnectorTableSpec: DerivedTableSpec<UsbCConnector> = {
     { name: "operating_temp_max", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -69,6 +70,7 @@ export const usbCConnectorTableSpec: DerivedTableSpec<UsbCConnector> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c.extra),
           package: String(c.package || ""),
           mounting_style: attrs["Mounting Style"] || null,
           current_rating_a: parseNum(attrs["Current Rating - Power (Max)"]),

--- a/lib/db/derivedtables/voltage_regulator.ts
+++ b/lib/db/derivedtables/voltage_regulator.ts
@@ -1,7 +1,7 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface VoltageRegulator extends BaseComponent {
   package: string
@@ -43,6 +43,7 @@ export const voltageRegulatorTableSpec: DerivedTableSpec<VoltageRegulator> = {
     { name: "topology", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -184,6 +185,7 @@ export const voltageRegulatorTableSpec: DerivedTableSpec<VoltageRegulator> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c.extra),
         package: c.package || "",
         output_type: outputType,
         output_voltage_min: voltageMin,

--- a/lib/db/derivedtables/wifi_module.ts
+++ b/lib/db/derivedtables/wifi_module.ts
@@ -1,7 +1,7 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface WifiModule extends BaseComponent {
   package: string
@@ -45,6 +45,7 @@ export const wifiModuleTableSpec: DerivedTableSpec<WifiModule> = {
     { name: "has_pwm", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -140,6 +141,7 @@ export const wifiModuleTableSpec: DerivedTableSpec<WifiModule> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c.extra),
         package: c.package || "",
         core_processor: attrs["Core Processor"] || null,
         antenna_type: attrs["Antenna Type"] || null,

--- a/lib/db/derivedtables/wire_to_board_connector.ts
+++ b/lib/db/derivedtables/wire_to_board_connector.ts
@@ -1,6 +1,7 @@
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
 import type { BaseComponent } from "./component-base"
+import { isExtendedPromotional } from "./component-base"
 import type { DerivedTableSpec } from "./types"
 import type { KyselyDatabaseInstance } from "../kysely-types"
 
@@ -61,6 +62,7 @@ export const wireToBoardConnectorTableSpec: DerivedTableSpec<WireToBoardConnecto
       { name: "is_smd", type: "boolean" },
       { name: "is_basic", type: "boolean" },
       { name: "is_preferred", type: "boolean" },
+      { name: "is_extended_promotional", type: "boolean" },
     ],
     listCandidateComponents(db: KyselyDatabaseInstance) {
       return db
@@ -100,6 +102,7 @@ export const wireToBoardConnectorTableSpec: DerivedTableSpec<WireToBoardConnecto
             in_stock: Boolean((c.stock || 0) > 0),
             is_basic: Boolean(c.basic),
             is_preferred: Boolean(c.preferred),
+            is_extended_promotional: isExtendedPromotional(c.extra),
             package: String(c.package || ""),
             pitch_mm: pitchMm,
             num_rows: numRows,

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -804,7 +804,6 @@ export interface VComponent {
   datasheet: string | null;
   description: string | null;
   extra: string | null;
-  is_extended_promotional: number | null;
   joints: number | null;
   last_on_stock: number | null;
   lcsc: number | null;

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -192,6 +192,7 @@ export interface Component {
   description: string;
   extra: string | null;
   flag: Generated<number>;
+  is_extended_promotional: Generated<number | null>;
   joints: number;
   last_on_stock: Generated<number>;
   last_update: number;
@@ -712,6 +713,7 @@ export interface Resistor {
   description: string | null;
   in_stock: number | null;
   is_basic: number | null;
+  is_extended_promotional: number | null;
   is_multi_resistor_chip: number | null;
   is_potentiometer: number | null;
   is_preferred: number | null;
@@ -802,6 +804,7 @@ export interface VComponent {
   datasheet: string | null;
   description: string | null;
   extra: string | null;
+  is_extended_promotional: number | null;
   joints: number | null;
   last_on_stock: number | null;
   lcsc: number | null;

--- a/lib/db/optimizations/component-extended-promotional-column.ts
+++ b/lib/db/optimizations/component-extended-promotional-column.ts
@@ -9,12 +9,12 @@ export const componentExtendedPromotionalColumn: DbOptimizationSpec = {
 
   async checkIfAdded(db: KyselyDatabaseInstance) {
     const {
-      rows: [ex],
+      rows: [colCheck],
     } = await sql<any>`
-      SELECT * FROM components LIMIT 1
+      SELECT COUNT(*) as cnt FROM pragma_table_info('components') WHERE name='is_extended_promotional'
     `.execute(db)
 
-    return "is_extended_promotional" in ex
+    return colCheck.cnt > 0
   },
 
   async execute(db: KyselyDatabaseInstance) {

--- a/lib/db/optimizations/component-extended-promotional-column.ts
+++ b/lib/db/optimizations/component-extended-promotional-column.ts
@@ -11,7 +11,7 @@ export const componentExtendedPromotionalColumn: DbOptimizationSpec = {
     const {
       rows: [colCheck],
     } = await sql<any>`
-      SELECT COUNT(*) as cnt FROM pragma_table_info('components') WHERE name='is_extended_promotional'
+      SELECT COUNT(*) as cnt FROM pragma_table_xinfo('components') WHERE name='is_extended_promotional'
     `.execute(db)
 
     return colCheck.cnt > 0

--- a/lib/db/optimizations/component-extended-promotional-column.ts
+++ b/lib/db/optimizations/component-extended-promotional-column.ts
@@ -1,0 +1,50 @@
+import { sql } from "kysely"
+import type { DbOptimizationSpec } from "./types"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+
+export const componentExtendedPromotionalColumn: DbOptimizationSpec = {
+  name: "add_components_extended_promotional_column",
+  description:
+    "Adds is_extended_promotional boolean column to components table derived from extra JSON componentLibraryType",
+
+  async checkIfAdded(db: KyselyDatabaseInstance) {
+    const {
+      rows: [ex],
+    } = await sql<any>`
+      SELECT * FROM components LIMIT 1
+    `.execute(db)
+
+    return "is_extended_promotional" in ex
+  },
+
+  async execute(db: KyselyDatabaseInstance) {
+    const {
+      rows: [colCheck],
+    } = await sql<any>`
+      SELECT COUNT(*) as cnt FROM pragma_table_info('components') WHERE name='jlc_extra'
+    `.execute(db)
+
+    const hasJlcExtra = colCheck.cnt > 0
+
+    const expression = hasJlcExtra
+      ? sql`(
+          json_extract(extra, '$.componentLibraryType') IN ('expand', 'expandPrefer')
+          OR json_extract(jlc_extra, '$.componentLibraryType') IN ('expand', 'expandPrefer')
+        )`
+      : sql`(
+          json_extract(extra, '$.componentLibraryType') IN ('expand', 'expandPrefer')
+        )`
+
+    await sql`
+      ALTER TABLE components
+      ADD COLUMN is_extended_promotional boolean
+      GENERATED ALWAYS AS (${expression})
+    `.execute(db)
+
+    await db.schema
+      .createIndex("idx_components_extended_promotional")
+      .on("components")
+      .column("is_extended_promotional")
+      .execute()
+  },
+}

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -72,7 +72,12 @@ export default withWinterSpec({
     query = query.where("preferred", "=", 1)
   }
   if (req.query.is_extended_promotional) {
-    query = query.where("is_extended_promotional", "=", 1)
+    query = query.where("lcsc", "in", (eb) =>
+      eb
+        .selectFrom("components")
+        .select("lcsc")
+        .where("is_extended_promotional", "=", 1),
+    )
   }
 
   if (req.query.search) {

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -35,6 +35,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -69,6 +70,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("is_extended_promotional", "=", 1)
   }
 
   if (req.query.search) {
@@ -152,6 +156,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/routes/resistors/list.tsx
+++ b/routes/resistors/list.tsx
@@ -13,6 +13,7 @@ export default withWinterSpec({
     package: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
     resistance: z
       .string()
       .optional()
@@ -32,6 +33,7 @@ export default withWinterSpec({
           package: z.string(),
           is_basic: z.boolean(),
           is_preferred: z.boolean(),
+          is_extended_promotional: z.boolean(),
           resistance: z.number(),
           tolerance_fraction: z.number().optional(),
           power_watts: z.number().optional(),
@@ -62,6 +64,9 @@ export default withWinterSpec({
   if (params.is_preferred) {
     query = query.where("is_preferred", "=", 1)
   }
+  if (params.is_extended_promotional) {
+    query = query.where("is_extended_promotional", "=", 1)
+  }
 
   // Apply resistance filter with a small tolerance for rounding errors
   if (params.resistance != null) {
@@ -88,6 +93,7 @@ export default withWinterSpec({
           package: r.package ?? "",
           is_basic: Boolean(r.is_basic),
           is_preferred: Boolean(r.is_preferred),
+          is_extended_promotional: Boolean(r.is_extended_promotional),
           resistance: r.resistance ?? 0,
           tolerance_fraction: r.tolerance_fraction ?? undefined,
           power_watts: r.power_watts ?? undefined,
@@ -142,6 +148,17 @@ export default withWinterSpec({
             />
           </label>
         </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={params.is_extended_promotional}
+            />
+          </label>
+        </div>
 
         <div>
           <label>Resistance:</label>
@@ -163,6 +180,7 @@ export default withWinterSpec({
           package: r.package,
           is_basic: r.is_basic ? "✓" : "",
           is_preferred: r.is_preferred ? "✓" : "",
+          is_extended_promotional: r.is_extended_promotional ? "✓" : "",
           resistance: (
             <span className="tabular-nums">{formatSiUnit(r.resistance)}Ω</span>
           ),

--- a/scripts/setup-7z.ts
+++ b/scripts/setup-7z.ts
@@ -7,10 +7,14 @@ const BINARY_NAME = "7zz"
 
 // Map of platform-arch combinations to download URLs
 const BINARY_URLS: Record<string, string> = {
-  "linux-x64": "https://7-zip.org/a/7z2408-linux-x64.tar.xz",
-  "linux-arm64": "https://7-zip.org/a/7z2408-linux-arm64.tar.xz",
-  "darwin-x64": "https://7-zip.org/a/7z2408-mac.tar.xz",
-  "darwin-arm64": "https://7-zip.org/a/7z2408-mac.tar.xz",
+  "linux-x64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-linux-x64.tar.xz",
+  "linux-arm64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-linux-arm64.tar.xz",
+  "darwin-x64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-mac.tar.xz",
+  "darwin-arm64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-mac.tar.xz",
 }
 
 async function downloadAndExtract7z() {

--- a/scripts/setup-db-optimizations.ts
+++ b/scripts/setup-db-optimizations.ts
@@ -9,6 +9,7 @@ import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
 import { componentPackageIndex } from "lib/db/optimizations/component-indexes"
 import { componentBasicIndex } from "lib/db/optimizations/component-basic-index"
 import { componentPreferredIndex } from "lib/db/optimizations/component-preferred-index"
+import { componentExtendedPromotionalColumn } from "lib/db/optimizations/component-extended-promotional-column"
 
 const OPTIMIZATIONS: DbOptimizationSpec[] = [
   componentSearchFTS,
@@ -20,6 +21,7 @@ const OPTIMIZATIONS: DbOptimizationSpec[] = [
   componentInStockColumn,
   componentCategoryIndex,
   componentInStockCategoryIndex,
+  componentExtendedPromotionalColumn,
 ]
 
 async function main() {

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -1,5 +1,6 @@
 import { afterEach } from "bun:test"
 import { setupDerivedTables } from "lib/db/derivedtables/setup-derived-tables"
+import { getDbClient } from "lib/db/get-db-client"
 
 declare global {
   var deferredCleanupFns: Array<() => void | Promise<void>>
@@ -7,7 +8,10 @@ declare global {
 }
 
 globalThis.deferredCleanupFns ??= []
-globalThis.derivedTablesSetupPromise ??= setupDerivedTables({ populate: false })
+globalThis.derivedTablesSetupPromise ??= setupDerivedTables({
+  db: getDbClient(),
+  populate: false,
+})
 
 await globalThis.derivedTablesSetupPromise
 


### PR DESCRIPTION
## Summary

Closes #92
/claim #92

- Adds a computed `is_extended_promotional` boolean column to the `components` table via a new DB optimization (`component-extended-promotional-column.ts`), derived from `json_extract(extra, '$.componentLibraryType')` matching `'expand'` or `'expandPrefer'`
- Adds `is_extended_promotional` to `BaseComponent` interface and all 37 derived tables (resistor, capacitor, mosfet, led, etc.) with a shared `isExtendedPromotional()` helper
- Adds filter UI (checkbox + query param) to both `/components/list` and `/resistors/list` routes
- Handles the optional `jlc_extra` column gracefully when present

## How it works

JLCPCB components have a `componentLibraryType` field in their JSON `extra` column:
- `"base"` -> Basic part (already tracked via `is_basic`)
- `"extend"` -> Extended part
- `"expand"` / `"expandPrefer"` -> Extended Promotional (temporarily no extra fee)

This PR surfaces the Extended Promotional status so users can filter for parts that avoid the $3 extended part fee.

## Test plan

- [x] DB optimization adds the new column at setup time
- [x] `is_extended_promotional` column present on `components` table
- [x] `/resistors/list` filter checkbox works end-to-end
- [x] `/components/list` filter checkbox works end-to-end
- [x] API responses include `is_extended_promotional` field
- [x] CI green (211 pass / 0 fail on Bun Test)
