### PR TITLE
feat: add is_extended_promotional filter and response field

### DIFF
--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -50,6 +50,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -71,6 +72,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   const baseQuery = query
@@ -196,6 +200,7 @@ export default withWinterSpec({
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
+    is_extended_promotional: Boolean(c.preferred) && !Boolean(c.basic),
   }))
 
   return ctx.json({

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -35,6 +35,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -51,6 +52,7 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -69,6 +71,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   if (req.query.search) {
@@ -114,6 +119,7 @@ export default withWinterSpec({
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
+    is_extended_promotional: Boolean(c.preferred) && !Boolean(c.basic),
   }))
 
   if (ctx.isApiRequest) {
@@ -152,6 +158,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/tests/routes/api/search.test.ts
+++ b/tests/routes/api/search.test.ts
@@ -107,3 +107,17 @@ test("GET /api/search supports '0402 LED'", async () => {
   expect(res.data.components.every((c: any) => c.package === "0402")).toBe(true)
   expect(res.data.components.some((c: any) => c.lcsc === 965793)).toBe(true)
 })
+
+test("GET /api/search exposes and filters extended promotional components", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/api/search?is_extended_promotional=true")
+
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+
+  for (const component of res.data.components) {
+    expect(component).toHaveProperty("is_extended_promotional", true)
+    expect(component).toHaveProperty("is_preferred", true)
+    expect(component).toHaveProperty("is_basic", false)
+  }
+})

--- a/tests/routes/components/list.test.ts
+++ b/tests/routes/components/list.test.ts
@@ -7,3 +7,19 @@ test("GET /components/list with json param returns component data", async () => 
   expect(res.data).toHaveProperty("components")
   expect(Array.isArray(res.data.components)).toBe(true)
 })
+
+test("GET /components/list exposes and filters extended promotional components", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get(
+    "/components/list?json=true&is_extended_promotional=true",
+  )
+
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+
+  for (const component of res.data.components) {
+    expect(component).toHaveProperty("is_extended_promotional", true)
+    expect(component).toHaveProperty("is_preferred", true)
+    expect(component).toHaveProperty("is_basic", false)
+  }
+})


### PR DESCRIPTION
Closes #92

/claim #92

Adds is_extended_promotional query param and response field to:
- GET /components/list
- GET /api/search

Logic: preferred=1 AND basic=0. Tests added for both routes.