### PR TITLE
feat: add is_extended_promotional filter and field to components

### DIFF
--- a/lib/db/optimizations/component-extended-promotional-index.ts
+++ b/lib/db/optimizations/component-extended-promotional-index.ts
@@ -1,0 +1,26 @@
+import { sql } from "kysely"
+import type { DbOptimizationSpec } from "./types"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+
+export const componentExtendedPromotionalIndex: DbOptimizationSpec = {
+  name: "idx_components_preferred_basic",
+  description:
+    "Compound index on components(preferred, basic) for faster extended promotional queries",
+
+  async checkIfAdded(db: KyselyDatabaseInstance) {
+    const result = await sql`
+      SELECT name FROM sqlite_master
+      WHERE type='index' AND name=${this.name}
+    `.execute(db)
+
+    return result.rows.length > 0
+  },
+
+  async execute(db: KyselyDatabaseInstance) {
+    await db.schema
+      .createIndex(this.name)
+      .on("components")
+      .columns(["preferred", "basic"])
+      .execute()
+  },
+}

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -50,6 +50,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -71,6 +72,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   const baseQuery = query
@@ -193,6 +197,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.preferred) && !Boolean(c.basic),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -35,6 +35,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -51,6 +52,7 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -69,6 +71,10 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    // Extended promotional parts are preferred but not basic — they temporarily get basic-like treatment
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   if (req.query.search) {
@@ -111,6 +117,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.preferred) && !Boolean(c.basic),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +159,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/scripts/setup-db-optimizations.ts
+++ b/scripts/setup-db-optimizations.ts
@@ -9,12 +9,14 @@ import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
 import { componentPackageIndex } from "lib/db/optimizations/component-indexes"
 import { componentBasicIndex } from "lib/db/optimizations/component-basic-index"
 import { componentPreferredIndex } from "lib/db/optimizations/component-preferred-index"
+import { componentExtendedPromotionalIndex } from "lib/db/optimizations/component-extended-promotional-index"
 
 const OPTIMIZATIONS: DbOptimizationSpec[] = [
   componentSearchFTS,
   componentPackageIndex,
   componentBasicIndex,
   componentPreferredIndex,
+  componentExtendedPromotionalIndex,
   removeStaleComponents,
   componentStockIndex,
   componentInStockColumn,

--- a/tests/routes/components/list.test.ts
+++ b/tests/routes/components/list.test.ts
@@ -7,3 +7,26 @@ test("GET /components/list with json param returns component data", async () => 
   expect(res.data).toHaveProperty("components")
   expect(Array.isArray(res.data.components)).toBe(true)
 })
+
+test("GET /components/list returns is_extended_promotional field", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/components/list?json=true")
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+  if (res.data.components.length > 0) {
+    expect(res.data.components[0]).toHaveProperty("is_extended_promotional")
+    expect(typeof res.data.components[0].is_extended_promotional).toBe("boolean")
+  }
+})
+
+test("GET /components/list?is_extended_promotional=true filters extended promotional parts", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/components/list?json=true&is_extended_promotional=true")
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+  for (const component of res.data.components) {
+    expect(component.is_extended_promotional).toBe(true)
+    expect(component.is_preferred).toBe(true)
+    expect(component.is_basic).toBe(false)
+  }
+})


### PR DESCRIPTION
## Summary

Closes #92

Adds `is_extended_promotional` support throughout the components API and UI. Extended promotional parts are those with `preferred=1 AND basic=0` in the JLC data source — they temporarily receive basic-like treatment (no extra surcharge).

## Changes

- Add `is_extended_promotional` query param to `/components/list` and `/api/search`
- Filter logic: `WHERE preferred=1 AND basic=0` when param is `true`
- Expose `is_extended_promotional` boolean in all response payloads
- Add **Extended Promotional** checkbox to `/components/list` UI
- Add compound index on `(preferred, basic)` for query performance
- Tests: field presence + filter correctness

## Example

```bash
# Filter to extended promotional parts only
curl https://jlcsearch.tscircuit.com/components/list.json?is_extended_promotional=true

# Response includes is_extended_promotional on every component
# { lcsc: ..., is_basic: false, is_preferred: true, is_extended_promotional: true, ... }
```

/claim #92