### PR TITLE
feat: add extended promotional component filter

### DIFF
--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -296,6 +296,10 @@ SELECT
   package,
   basic,
   preferred,
+  CASE
+    WHEN basic = 0 AND preferred = 1 THEN 1
+    ELSE 0
+  END AS is_extended_promotional,
   description,
   stock,
   price,
@@ -306,6 +310,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(is_extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA
 
@@ -319,6 +324,7 @@ CREATE TABLE component_catalog (
   package TEXT,
   basic INTEGER,
   preferred INTEGER,
+  is_extended_promotional INTEGER,
   description TEXT,
   stock INTEGER,
   price TEXT,
@@ -328,6 +334,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(is_extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA_EXPORT
 }
@@ -350,6 +357,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -391,6 +399,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);
 SEARCH_INDEX_SCHEMA
 
   cat > search_index_schema.sql <<'SEARCH_INDEX_SCHEMA_EXPORT'
@@ -405,6 +415,7 @@ CREATE TABLE search_index (
   price1 REAL,
   basic INTEGER,
   preferred INTEGER,
+  is_extended_promotional INTEGER,
   category TEXT,
   subcategory TEXT,
   manufacturer_name TEXT,
@@ -422,6 +433,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);
 SEARCH_INDEX_SCHEMA_EXPORT
 }
 

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -22,6 +23,7 @@ export async function queryComponentCatalog(
     package: string | null
     basic: number | null
     preferred: number | null
+    is_extended_promotional: number | null
     description: string | null
     stock: number | null
     price: string | null
@@ -34,6 +36,7 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -158,6 +158,7 @@ export interface BuckBoostConverter {
 
 export interface ComponentCatalog {
   basic: number | null
+  is_extended_promotional: number | null
   category: string | null
   description: string | null
   extra: string | null
@@ -658,6 +659,7 @@ export interface Relay {
 export interface SearchIndex {
   attributes: string | null
   basic: number | null
+  is_extended_promotional: number | null
   category: string | null
   description: string | null
   lcsc: Generated<number | null>

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -367,6 +367,7 @@ async function handleD1Search(
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
       is_preferred: Boolean(row.preferred),
+      is_extended_promotional: Boolean(row.is_extended_promotional),
       description: row.description ?? "",
       stock: row.stock ?? 0,
       price: row.price1 ?? extractSmallQuantityPrice(row.price),
@@ -491,6 +492,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        is_extended_promotional: Boolean(row.is_extended_promotional),
       })),
     }
 

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -147,6 +147,7 @@ const COLUMN_LABELS: Record<string, string> = {
   in_stock: "In Stock",
   is_basic: "Basic",
   is_preferred: "Preferred",
+  is_extended_promotional: "Extended Promotional",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
   voltage_rating: "Voltage",
@@ -545,6 +546,9 @@ const renderComponentsFilters = (
   </div>
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
+  </div>
+  <div>
+    <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <button type="submit">Filter</button>
 </form>`

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -21,6 +22,7 @@ interface SearchRow {
   price1: number | null
   basic: number | null
   preferred: number | null
+  is_extended_promotional: number | null
   category: string | null
   subcategory: string | null
 }
@@ -110,6 +112,13 @@ export async function searchIndex(
     conditions.push(sql`search_index.preferred = 1`)
   }
 
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`search_index.is_extended_promotional = 1`)
+  }
+
   const raw = params.q?.trim()
 
   if (raw) {
@@ -151,6 +160,7 @@ export async function searchIndex(
       search_index.price1,
       search_index.basic,
       search_index.preferred,
+      search_index.is_extended_promotional,
       search_index.category,
       search_index.subcategory
     FROM search_index

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -616,6 +616,13 @@
             "schema": {
               "type": ["boolean"]
             }
+          },
+          {
+            "name": "is_extended_promotional",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
           }
         ],
         "operationId": "apiSearchGet"
@@ -2204,6 +2211,13 @@
             "schema": {
               "type": ["boolean"]
             }
+          },
+          {
+            "name": "is_extended_promotional",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
           }
         ],
         "operationId": "componentsList.jsonGet"
@@ -2266,6 +2280,13 @@
           },
           {
             "name": "is_preferred",
+            "in": "query",
+            "schema": {
+              "type": ["boolean"]
+            }
+          },
+          {
+            "name": "is_extended_promotional",
             "in": "query",
             "schema": {
               "type": ["boolean"]


### PR DESCRIPTION
## Summary
- Adds `is_extended_promotional` to the cf-proxy search/component data flow
- Supports `is_extended_promotional=true` / `1` filtering in `/api/search`
- Exposes the field in rendered component responses and the OpenAPI schema
- Updates the DB sync path to carry the new promotional flag into the search index

## Bounty / issue context
Addresses part of #92: making extended-promotional component data available as a filterable field.

/claim #92

## Project-convention notes
- Kept the change scoped to existing cf-proxy patterns: Kysely SQL builders, existing `true`/`1` boolean query style, and existing render/type mapping.
- No hardcoded credentials, local paths, or ad-hoc SQL string concatenation.
- No unrelated refactors.

## Test plan
- `cd cf-proxy && npm test` — 125 tests passed
- `cd cf-proxy && npx tsc --noEmit` — no TypeScript errors

## Intentional limits
- This PR does not change unrelated legacy route/UI behavior beyond the files touched here.
