### PR TITLE
[Fix] Add is_extended_promotional component filter

### DIFF
--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -1,5 +1,4 @@
 import { sql } from "kysely"
-import { getDbClient } from "lib/db/get-db-client"
 import { accelerometerTableSpec } from "lib/db/derivedtables/accelerometer"
 import { adcTableSpec } from "lib/db/derivedtables/adc"
 import { analogMultiplexerTableSpec } from "lib/db/derivedtables/analog_multiplexer"
@@ -10,8 +9,8 @@ import { buckBoostConverterTableSpec } from "lib/db/derivedtables/buck_boost_con
 import { capacitorTableSpec } from "lib/db/derivedtables/capacitor"
 import { dacTableSpec } from "lib/db/derivedtables/dac"
 import { diodeTableSpec } from "lib/db/derivedtables/diode"
-import { fpgaTableSpec } from "lib/db/derivedtables/fpga"
 import { fpcConnectorTableSpec } from "lib/db/derivedtables/fpc_connector"
+import { fpgaTableSpec } from "lib/db/derivedtables/fpga"
 import { fuseTableSpec } from "lib/db/derivedtables/fuse"
 import { gasSensorTableSpec } from "lib/db/derivedtables/gas_sensor"
 import { gyroscopeTableSpec } from "lib/db/derivedtables/gyroscope"
@@ -19,26 +18,27 @@ import { headerTableSpec } from "lib/db/derivedtables/header"
 import { ioExpanderTableSpec } from "lib/db/derivedtables/io_expander"
 import { jstConnectorTableSpec } from "lib/db/derivedtables/jst_connector"
 import { lcdDisplayTableSpec } from "lib/db/derivedtables/lcd_display"
+import { ldoTableSpec } from "lib/db/derivedtables/ldo"
+import { ledTableSpec } from "lib/db/derivedtables/led"
 import { ledDotMatrixDisplayTableSpec } from "lib/db/derivedtables/led_dot_matrix_display"
 import { ledDriverTableSpec } from "lib/db/derivedtables/led_driver"
 import { ledSegmentDisplayTableSpec } from "lib/db/derivedtables/led_segment_display"
-import { ledTableSpec } from "lib/db/derivedtables/led"
 import { ledWithICTableSpec } from "lib/db/derivedtables/led_with_ic"
-import { ldoTableSpec } from "lib/db/derivedtables/ldo"
 import { microcontrollerTableSpec } from "lib/db/derivedtables/microcontroller"
 import { mosfetTableSpec } from "lib/db/derivedtables/mosfet"
 import { oledDisplayTableSpec } from "lib/db/derivedtables/oled_display"
 import { pcieM2ConnectorTableSpec } from "lib/db/derivedtables/pcie_m2_connector"
 import { potentiometerTableSpec } from "lib/db/derivedtables/potentiometer"
 import { relayTableSpec } from "lib/db/derivedtables/relay"
-import { resistorArrayTableSpec } from "lib/db/derivedtables/resistor_array"
 import { resistorTableSpec } from "lib/db/derivedtables/resistor"
+import { resistorArrayTableSpec } from "lib/db/derivedtables/resistor_array"
 import { switchTableSpec } from "lib/db/derivedtables/switch"
 import type { DerivedTableSpec } from "lib/db/derivedtables/types"
 import { usbCConnectorTableSpec } from "lib/db/derivedtables/usb_c_connector"
 import { voltageRegulatorTableSpec } from "lib/db/derivedtables/voltage_regulator"
 import { wifiModuleTableSpec } from "lib/db/derivedtables/wifi_module"
 import { wireToBoardConnectorTableSpec } from "lib/db/derivedtables/wire_to_board_connector"
+import { destroyDbClient, getDbClient } from "lib/db/get-db-client"
 import type { KyselyDatabaseInstance } from "lib/db/kysely-types"
 
 export const DERIVED_TABLES: DerivedTableSpec<any>[] = [
@@ -214,7 +214,7 @@ export const setupDerivedTables = async ({
     }
   } finally {
     if (shouldDestroy) {
-      await activeDb.destroy()
+      await destroyDbClient()
     }
   }
 }

--- a/lib/db/get-db-client.ts
+++ b/lib/db/get-db-client.ts
@@ -1,7 +1,7 @@
 import type { Database as BunDatabase } from "bun:sqlite"
+import Path from "node:path"
 import type { Kysely } from "kysely"
 import type { BunSqliteDialect } from "kysely-bun-sqlite"
-import Path from "node:path"
 import type { DB } from "./generated/kysely"
 
 let DatabaseCtor: typeof BunDatabase | undefined
@@ -81,6 +81,14 @@ export const getDbClient = () => {
   })
 
   return dbClientSingleton
+}
+
+export const destroyDbClient = async () => {
+  if (!dbClientSingleton) return
+
+  const activeDb = dbClientSingleton
+  dbClientSingleton = undefined
+  await activeDb.destroy()
 }
 
 export const getBunDatabaseClient = () => {

--- a/lib/db/get-db-client.ts
+++ b/lib/db/get-db-client.ts
@@ -14,6 +14,7 @@ let BunSqliteDialectCtor: typeof BunSqliteDialect | undefined
 let bunSqliteImportError: unknown
 
 let dbClientSingleton: Kysely<DB> | undefined
+let dbClientSingletonPath: string | undefined
 
 if (process.env.WINTERSPEC_CODEGEN !== "true") {
   try {
@@ -58,8 +59,14 @@ export const getResolvedDbPath = (): string => {
 }
 
 export const getDbClient = () => {
+  const dbPath = getResolvedDbPath()
   if (dbClientSingleton) {
-    return dbClientSingleton
+    if (dbClientSingletonPath === dbPath) return dbClientSingleton
+
+    const staleDb = dbClientSingleton
+    dbClientSingleton = undefined
+    dbClientSingletonPath = undefined
+    void staleDb.destroy()
   }
 
   const Database = getDatabaseCtor()
@@ -76,9 +83,10 @@ export const getDbClient = () => {
 
   dbClientSingleton = new KyselyCtorRef<DB>({
     dialect: new BunSqliteDialectRef({
-      database: new Database(getResolvedDbPath()),
+      database: new Database(dbPath),
     }),
   })
+  dbClientSingletonPath = dbPath
 
   return dbClientSingleton
 }
@@ -88,6 +96,7 @@ export const destroyDbClient = async () => {
 
   const activeDb = dbClientSingleton
   dbClientSingleton = undefined
+  dbClientSingletonPath = undefined
   await activeDb.destroy()
 }
 

--- a/lib/util/extended-promotional.ts
+++ b/lib/util/extended-promotional.ts
@@ -1,0 +1,80 @@
+export interface ExtendedPromotionalComponentFields {
+  basic?: number | boolean | null
+  preferred?: number | boolean | null
+  extra?: string | null
+}
+
+const extendedPromotionalKeys = new Set([
+  "is_extended_promotional",
+  "isExtendedPromotional",
+  "extended_promotional",
+  "extendedPromotional",
+  "extendedPromo",
+  "is_extended_promo",
+])
+
+const promotionalStringValues = new Set([
+  "extended promotional",
+  "extended_promotional",
+  "extended-promotional",
+  "extended promo",
+  "extended_promo",
+])
+
+const toBoolean = (value: unknown): boolean | undefined => {
+  if (typeof value === "boolean") return value
+  if (typeof value === "number") return value !== 0
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase()
+    if (["true", "1", "yes", "y"].includes(normalized)) return true
+    if (["false", "0", "no", "n"].includes(normalized)) return false
+    if (promotionalStringValues.has(normalized)) return true
+  }
+}
+
+const findExtendedPromotionalFlag = (value: unknown): boolean | undefined => {
+  const directValue = toBoolean(value)
+  if (directValue !== undefined) return directValue
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const flag = findExtendedPromotionalFlag(item)
+      if (flag !== undefined) return flag
+    }
+    return undefined
+  }
+
+  if (!value || typeof value !== "object") return undefined
+
+  for (const [key, nestedValue] of Object.entries(value)) {
+    if (extendedPromotionalKeys.has(key)) {
+      const flag = toBoolean(nestedValue)
+      if (flag !== undefined) return flag
+    }
+
+    const normalizedKey = key.toLowerCase().replace(/[\s_-]/g, "")
+    if (
+      normalizedKey.includes("extendedpromotional") ||
+      normalizedKey.includes("extendedpromo")
+    ) {
+      const flag = toBoolean(nestedValue)
+      if (flag !== undefined) return flag
+    }
+
+    const nestedFlag = findExtendedPromotionalFlag(nestedValue)
+    if (nestedFlag !== undefined) return nestedFlag
+  }
+}
+
+export const getIsExtendedPromotional = (
+  component: ExtendedPromotionalComponentFields,
+): boolean => {
+  if (component.extra) {
+    try {
+      const extraFlag = findExtendedPromotionalFlag(JSON.parse(component.extra))
+      if (extraFlag !== undefined) return extraFlag
+    } catch {}
+  }
+
+  return Boolean(component.preferred) && !component.basic
+}

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -1,7 +1,8 @@
 import { sql } from "kysely"
+import { getIsExtendedPromotional } from "lib/util/extended-promotional"
 import {
-  buildSearchTokenGroups,
   type SearchTokenGroup,
+  buildSearchTokenGroups,
   tokenizeSearchTerm,
 } from "lib/util/search-token-groups"
 import { withWinterSpec } from "lib/with-winter-spec"
@@ -50,6 +51,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -71,6 +73,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   const baseQuery = query
@@ -193,6 +198,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: getIsExtendedPromotional(c),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -1,6 +1,7 @@
 import { sql } from "kysely"
-import { Table } from "lib/ui/Table"
 import { ExpressionBuilder } from "kysely"
+import { Table } from "lib/ui/Table"
+import { getIsExtendedPromotional } from "lib/util/extended-promotional"
 import { buildSearchTokenGroups } from "lib/util/search-token-groups"
 import { withWinterSpec } from "lib/with-winter-spec"
 import { z } from "zod"
@@ -35,6 +36,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -51,6 +53,7 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -69,6 +72,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   if (req.query.search) {
@@ -111,6 +117,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: getIsExtendedPromotional(c),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +159,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional Part:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/tests/lib/extended-promotional.test.ts
+++ b/tests/lib/extended-promotional.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test"
+import { getIsExtendedPromotional } from "lib/util/extended-promotional"
+
+test("getIsExtendedPromotional falls back to preferred non-basic parts", () => {
+  expect(getIsExtendedPromotional({ preferred: 1, basic: 0 })).toBe(true)
+  expect(getIsExtendedPromotional({ preferred: 1, basic: 1 })).toBe(false)
+  expect(getIsExtendedPromotional({ preferred: 0, basic: 0 })).toBe(false)
+})
+
+test("getIsExtendedPromotional reads explicit metadata from extra", () => {
+  expect(
+    getIsExtendedPromotional({
+      preferred: 0,
+      basic: 0,
+      extra: JSON.stringify({ is_extended_promotional: true }),
+    }),
+  ).toBe(true)
+
+  expect(
+    getIsExtendedPromotional({
+      preferred: 1,
+      basic: 0,
+      extra: JSON.stringify({ attributes: { extendedPromotional: false } }),
+    }),
+  ).toBe(false)
+})

--- a/tests/lib/get-db-client.test.ts
+++ b/tests/lib/get-db-client.test.ts
@@ -3,14 +3,21 @@ import { afterEach, expect, test } from "bun:test"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import Path from "node:path"
-import { getBunDatabaseClient, getResolvedDbPath } from "lib/db/get-db-client"
+import {
+  destroyDbClient,
+  getBunDatabaseClient,
+  getDbClient,
+  getResolvedDbPath,
+} from "lib/db/get-db-client"
 
 let tempDir: string | undefined
 let previousDbPath = process.env.JLCSEARCH_DB_PATH
 
-afterEach(() => {
+afterEach(async () => {
+  await destroyDbClient()
+
   if (previousDbPath === undefined) {
-    delete process.env.JLCSEARCH_DB_PATH
+    process.env.JLCSEARCH_DB_PATH = undefined
   } else {
     process.env.JLCSEARCH_DB_PATH = previousDbPath
   }
@@ -44,4 +51,31 @@ test("getBunDatabaseClient respects JLCSEARCH_DB_PATH", () => {
 
   expect(row?.value).toBe("ok")
   db.close()
+})
+
+test("destroyDbClient allows recreating the singleton after destroy", async () => {
+  tempDir = mkdtempSync(Path.join(tmpdir(), "jlcsearch-db-"))
+  const dbPath = Path.join(tempDir, "singleton.sqlite3")
+
+  const seedDb = new Database(dbPath)
+  seedDb.exec(`
+    CREATE TABLE probe (value TEXT);
+    INSERT INTO probe (value) VALUES ('ok');
+  `)
+  seedDb.close()
+
+  previousDbPath = process.env.JLCSEARCH_DB_PATH
+  process.env.JLCSEARCH_DB_PATH = dbPath
+
+  const firstDb = getDbClient()
+  await destroyDbClient()
+  const secondDb = getDbClient()
+
+  expect(secondDb).not.toBe(firstDb)
+  const row = await secondDb
+    .selectFrom("probe" as never)
+    .select("value" as never)
+    .executeTakeFirst()
+
+  expect(row).toEqual({ value: "ok" })
 })

--- a/tests/routes/api/search.test.ts
+++ b/tests/routes/api/search.test.ts
@@ -18,6 +18,7 @@ test("GET /api/search with search query 'STM32F401RCT6' returns expected compone
   expect(component).toHaveProperty("package")
   expect(component).toHaveProperty("price")
   expect(component).toHaveProperty("stock")
+  expect(component).toHaveProperty("is_extended_promotional")
 })
 
 test("GET /api/search with search query '555 Timer' returns expected components", async () => {
@@ -106,4 +107,21 @@ test("GET /api/search supports '0402 LED'", async () => {
   expect(res.data.components.length).toBeGreaterThan(0)
   expect(res.data.components.every((c: any) => c.package === "0402")).toBe(true)
   expect(res.data.components.some((c: any) => c.lcsc === 965793)).toBe(true)
+})
+
+test("GET /api/search filters extended promotional components", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get(
+    "/api/search?is_extended_promotional=true&limit=5",
+  )
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+  expect(
+    res.data.components.every(
+      (component: any) =>
+        component.is_extended_promotional &&
+        component.is_preferred &&
+        !component.is_basic,
+    ),
+  ).toBe(true)
 })

--- a/tests/routes/components/list.test.ts
+++ b/tests/routes/components/list.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
 import { getTestServer } from "tests/fixtures/get-test-server"
 
 test("GET /components/list with json param returns component data", async () => {
@@ -6,4 +6,24 @@ test("GET /components/list with json param returns component data", async () => 
   const res = await axios.get("/components/list?json=true")
   expect(res.data).toHaveProperty("components")
   expect(Array.isArray(res.data.components)).toBe(true)
+  if (res.data.components.length > 0) {
+    expect(res.data.components[0]).toHaveProperty("is_extended_promotional")
+  }
+})
+
+test("GET /components/list filters extended promotional components", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get(
+    "/components/list?json=true&is_extended_promotional=true",
+  )
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+  expect(
+    res.data.components.every(
+      (component: any) =>
+        component.is_extended_promotional &&
+        component.is_preferred &&
+        !component.is_basic,
+    ),
+  ).toBe(true)
 })


### PR DESCRIPTION
## Summary
- add is_extended_promotional to component/search responses
- support is_extended_promotional query filtering using preferred non-basic parts, with explicit metadata parsing from extra
- make the shared DB client path-aware so tests/runtime can recreate it when JLCSEARCH_DB_PATH changes

## Tests
- bun run format:check
- bunx tsc --noEmit
- bun test tests/lib/get-db-client.test.ts --preload ./tests/preload.ts
- bun test tests/lib/extended-promotional.test.ts --preload ./tests/preload.ts

Note: route integration tests could not be run locally because the checked-in db.sqlite3 fixture lacks the base components/v_components tables; CI setup should generate the full database.