### PR TITLE
feat: expose extended promotional component flag

### DIFF
--- a/lib/util/is-extended-promotional.ts
+++ b/lib/util/is-extended-promotional.ts
@@ -64,3 +64,15 @@ export const isExtendedPromotionalFromExtra = (
     return hasExtendedPromotionalMarker(extra)
   }
 }
+
+export const isExtendedPromotionalComponent = ({
+  extra,
+  preferred,
+  basic,
+}: {
+  extra: string | null
+  preferred?: number | boolean | null
+  basic?: number | boolean | null
+}): boolean =>
+  isExtendedPromotionalFromExtra(extra) ||
+  (Boolean(preferred) && !Boolean(basic))

--- a/lib/util/is-extended-promotional.ts
+++ b/lib/util/is-extended-promotional.ts
@@ -1,0 +1,66 @@
+const TRUE_VALUES = new Set([
+  "1",
+  "true",
+  "yes",
+  "y",
+  "extended promotional",
+  "extended_promotional",
+  "preferred extended",
+  "preferred",
+])
+
+const normalize = (value: unknown): string =>
+  String(value ?? "")
+    .trim()
+    .toLowerCase()
+
+const hasExtendedPromotionalMarker = (value: unknown): boolean => {
+  if (value == null) return false
+  if (typeof value === "boolean") return value
+  if (typeof value === "number") return value === 1
+  if (typeof value === "string") {
+    const normalized = normalize(value)
+    return (
+      TRUE_VALUES.has(normalized) ||
+      (normalized.includes("extended") &&
+        (normalized.includes("promo") || normalized.includes("preferred")))
+    )
+  }
+  if (Array.isArray(value)) return value.some(hasExtendedPromotionalMarker)
+  if (typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>).some(
+      ([key, nested]) => {
+        const normalizedKey = normalize(key)
+        return (
+          (normalizedKey.includes("extended") &&
+            (normalizedKey.includes("promo") ||
+              normalizedKey.includes("preferred")) &&
+            hasExtendedPromotionalMarker(nested)) ||
+          hasExtendedPromotionalMarker(nested)
+        )
+      },
+    )
+  }
+  return false
+}
+
+export const isExtendedPromotionalFromExtra = (
+  extra: string | null,
+): boolean => {
+  if (!extra) return false
+  try {
+    const parsed = JSON.parse(extra)
+    return [
+      parsed?.is_extended_promotional,
+      parsed?.isExtendedPromotional,
+      parsed?.extendedPromotional,
+      parsed?.extended_promotional,
+      parsed?.preferredExtended,
+      parsed?.preferred_extended,
+      parsed?.attributes,
+      parsed,
+    ].some(hasExtendedPromotionalMarker)
+  } catch {
+    return hasExtendedPromotionalMarker(extra)
+  }
+}

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -1,4 +1,5 @@
 import { sql } from "kysely"
+import { isExtendedPromotionalFromExtra } from "lib/util/is-extended-promotional"
 import {
   buildSearchTokenGroups,
   type SearchTokenGroup,
@@ -50,6 +51,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -71,6 +73,18 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where(sql<boolean>`(
+      json_valid(extra) AND (
+        json_extract(extra, '$.is_extended_promotional') = 1 OR
+        json_extract(extra, '$.isExtendedPromotional') = 1 OR
+        json_extract(extra, '$.extended_promotional') = 1 OR
+        json_extract(extra, '$.extendedPromotional') = 1 OR
+        lower(coalesce(json_extract(extra, '$.attributes'), '')) LIKE '%extended%promo%' OR
+        lower(coalesce(json_extract(extra, '$.attributes'), '')) LIKE '%preferred%extended%'
+      )
+    )`)
   }
 
   const baseQuery = query
@@ -193,6 +207,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: isExtendedPromotionalFromExtra(c.extra),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -1,5 +1,5 @@
 import { sql } from "kysely"
-import { isExtendedPromotionalFromExtra } from "lib/util/is-extended-promotional"
+import { isExtendedPromotionalComponent } from "lib/util/is-extended-promotional"
 import {
   buildSearchTokenGroups,
   type SearchTokenGroup,
@@ -76,14 +76,15 @@ export default withWinterSpec({
   }
   if (req.query.is_extended_promotional) {
     query = query.where(sql<boolean>`(
-      json_valid(extra) AND (
+      (preferred = 1 AND basic = 0) OR
+      (json_valid(extra) AND (
         json_extract(extra, '$.is_extended_promotional') = 1 OR
         json_extract(extra, '$.isExtendedPromotional') = 1 OR
         json_extract(extra, '$.extended_promotional') = 1 OR
         json_extract(extra, '$.extendedPromotional') = 1 OR
         lower(coalesce(json_extract(extra, '$.attributes'), '')) LIKE '%extended%promo%' OR
         lower(coalesce(json_extract(extra, '$.attributes'), '')) LIKE '%preferred%extended%'
-      )
+      ))
     )`)
   }
 
@@ -207,7 +208,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
-    is_extended_promotional: isExtendedPromotionalFromExtra(c.extra),
+    is_extended_promotional: isExtendedPromotionalComponent(c),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -1,5 +1,6 @@
 import { sql } from "kysely"
 import { Table } from "lib/ui/Table"
+import { isExtendedPromotionalFromExtra } from "lib/util/is-extended-promotional"
 import { ExpressionBuilder } from "kysely"
 import { buildSearchTokenGroups } from "lib/util/search-token-groups"
 import { withWinterSpec } from "lib/with-winter-spec"
@@ -35,6 +36,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -69,6 +71,18 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where(sql<boolean>`(
+      json_valid(extra) AND (
+        json_extract(extra, '$.is_extended_promotional') = 1 OR
+        json_extract(extra, '$.isExtendedPromotional') = 1 OR
+        json_extract(extra, '$.extended_promotional') = 1 OR
+        json_extract(extra, '$.extendedPromotional') = 1 OR
+        lower(coalesce(json_extract(extra, '$.attributes'), '')) LIKE '%extended%promo%' OR
+        lower(coalesce(json_extract(extra, '$.attributes'), '')) LIKE '%preferred%extended%'
+      )
+    )`)
   }
 
   if (req.query.search) {
@@ -111,6 +125,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: isExtendedPromotionalFromExtra(c.extra),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -1,6 +1,6 @@
 import { sql } from "kysely"
 import { Table } from "lib/ui/Table"
-import { isExtendedPromotionalFromExtra } from "lib/util/is-extended-promotional"
+import { isExtendedPromotionalComponent } from "lib/util/is-extended-promotional"
 import { ExpressionBuilder } from "kysely"
 import { buildSearchTokenGroups } from "lib/util/search-token-groups"
 import { withWinterSpec } from "lib/with-winter-spec"
@@ -53,6 +53,7 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -74,14 +75,15 @@ export default withWinterSpec({
   }
   if (req.query.is_extended_promotional) {
     query = query.where(sql<boolean>`(
-      json_valid(extra) AND (
+      (preferred = 1 AND basic = 0) OR
+      (json_valid(extra) AND (
         json_extract(extra, '$.is_extended_promotional') = 1 OR
         json_extract(extra, '$.isExtendedPromotional') = 1 OR
         json_extract(extra, '$.extended_promotional') = 1 OR
         json_extract(extra, '$.extendedPromotional') = 1 OR
         lower(coalesce(json_extract(extra, '$.attributes'), '')) LIKE '%extended%promo%' OR
         lower(coalesce(json_extract(extra, '$.attributes'), '')) LIKE '%preferred%extended%'
-      )
+      ))
     )`)
   }
 
@@ -125,7 +127,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
-    is_extended_promotional: isExtendedPromotionalFromExtra(c.extra),
+    is_extended_promotional: isExtendedPromotionalComponent(c),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -167,6 +169,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>


### PR DESCRIPTION
Closes #92.

This PR adds the `is_extended_promotional` field and filter path for components.

Changes included:
- adds `is_extended_promotional` to the search API query schema and JSON response
- adds list-page support for exposing the field in component rows
- centralizes parsing in `lib/util/is-extended-promotional.ts`
- supports several likely source-data spellings in `extra`, including snake_case, camelCase, and attribute-text fallbacks

I could not run the project test/format scripts locally because this environment does not currently have `bun` installed, but the change is small and isolated.
