### PR TITLE
fix: update 7z download URLs for setup script

### DIFF
--- a/cf-proxy/scripts/rebuild-search-index-batched.sh
+++ b/cf-proxy/scripts/rebuild-search-index-batched.sh
@@ -43,6 +43,7 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
      price1 REAL,
      basic INTEGER,
      preferred INTEGER,
+     is_extended_promotional INTEGER,
      category TEXT,
      subcategory TEXT,
      manufacturer_name TEXT,
@@ -70,6 +71,7 @@ INSERT INTO search_index_next (
   price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   manufacturer_name,
@@ -91,6 +93,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -133,7 +136,8 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
    CREATE INDEX IF NOT EXISTS idx_search_index_next_lcsc ON search_index_next(lcsc);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_package ON search_index_next(package);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_basic ON search_index_next(basic);
-   CREATE INDEX IF NOT EXISTS idx_search_index_next_preferred ON search_index_next(preferred);"
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_preferred ON search_index_next(preferred);
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_extended_promotional ON search_index_next(is_extended_promotional);"
 
 echo "Validating row count..."
 run_wrangler d1 execute "$DB_NAME" --remote --command \
@@ -157,11 +161,13 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
    DROP INDEX IF EXISTS idx_search_index_package;
    DROP INDEX IF EXISTS idx_search_index_basic;
    DROP INDEX IF EXISTS idx_search_index_preferred;
+   DROP INDEX IF EXISTS idx_search_index_extended_promotional;
    ALTER TABLE search_index_next RENAME TO search_index;
    CREATE INDEX IF NOT EXISTS idx_search_index_stock ON search_index(stock DESC);
    CREATE INDEX IF NOT EXISTS idx_search_index_lcsc ON search_index(lcsc);
    CREATE INDEX IF NOT EXISTS idx_search_index_package ON search_index(package);
    CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
-   CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);"
+   CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
+   CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);"
 
 echo "Done. Old table kept as search_index_old for rollback."

--- a/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
+++ b/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
@@ -14,6 +14,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -55,3 +56,5 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);

--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -296,6 +296,15 @@ SELECT
   package,
   basic,
   preferred,
+  CASE
+    WHEN json_valid(extra) AND lower(coalesce(json_extract(extra, '$.libraryType'), '')) IN ('extended promotional', 'extended_promo', 'extended-promo') THEN 1
+    WHEN json_valid(extra) AND lower(coalesce(json_extract(extra, '$.library_type'), '')) IN ('extended promotional', 'extended_promo', 'extended-promo') THEN 1
+    WHEN json_valid(extra) AND lower(coalesce(json_extract(extra, '$.extendedPromotional'), '')) IN ('1', 'true', 'yes') THEN 1
+    WHEN json_valid(extra) AND lower(coalesce(json_extract(extra, '$.isExtendedPromotional'), '')) IN ('1', 'true', 'yes') THEN 1
+    WHEN json_valid(extra) AND lower(coalesce(json_extract(extra, '$.extended_promotional'), '')) IN ('1', 'true', 'yes') THEN 1
+    WHEN json_valid(extra) AND lower(coalesce(json_extract(extra, '$.is_extended_promotional'), '')) IN ('1', 'true', 'yes') THEN 1
+    ELSE 0
+  END AS is_extended_promotional,
   description,
   stock,
   price,
@@ -306,6 +315,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(is_extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA
 
@@ -319,6 +329,7 @@ CREATE TABLE component_catalog (
   package TEXT,
   basic INTEGER,
   preferred INTEGER,
+  is_extended_promotional INTEGER,
   description TEXT,
   stock INTEGER,
   price TEXT,
@@ -328,6 +339,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(is_extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA_EXPORT
 }
@@ -350,6 +362,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -391,6 +404,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);
 SEARCH_INDEX_SCHEMA
 
   cat > search_index_schema.sql <<'SEARCH_INDEX_SCHEMA_EXPORT'
@@ -405,6 +420,7 @@ CREATE TABLE search_index (
   price1 REAL,
   basic INTEGER,
   preferred INTEGER,
+  is_extended_promotional INTEGER,
   category TEXT,
   subcategory TEXT,
   manufacturer_name TEXT,
@@ -422,6 +438,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);
 SEARCH_INDEX_SCHEMA_EXPORT
 }
 

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -22,6 +23,7 @@ export async function queryComponentCatalog(
     package: string | null
     basic: number | null
     preferred: number | null
+    is_extended_promotional: number | null
     description: string | null
     stock: number | null
     price: string | null
@@ -34,6 +36,7 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -158,6 +158,7 @@ export interface BuckBoostConverter {
 
 export interface ComponentCatalog {
   basic: number | null
+  is_extended_promotional: number | null
   category: string | null
   description: string | null
   extra: string | null
@@ -658,6 +659,7 @@ export interface Relay {
 export interface SearchIndex {
   attributes: string | null
   basic: number | null
+  is_extended_promotional: number | null
   category: string | null
   description: string | null
   lcsc: Generated<number | null>

--- a/cf-proxy/src/extended-promotional.ts
+++ b/cf-proxy/src/extended-promotional.ts
@@ -1,0 +1,34 @@
+const EXTENDED_PROMOTIONAL_FIELDS = [
+  "libraryType",
+  "library_type",
+  "extendedPromotional",
+  "isExtendedPromotional",
+  "extended_promotional",
+  "is_extended_promotional",
+] as const
+
+const EXTENDED_PROMOTIONAL_LIBRARY_TYPES = new Set([
+  "extended promotional",
+  "extended_promo",
+  "extended-promo",
+])
+
+const TRUTHY_EXTENDED_PROMOTIONAL_VALUES = new Set(["1", "true", "yes"])
+
+const normalize = (value: unknown): string => String(value ?? "").toLowerCase()
+
+export function isExtendedPromotionalMetadata(extra: unknown): boolean {
+  if (!extra || typeof extra !== "object") return false
+
+  const metadata = extra as Record<string, unknown>
+  for (const field of EXTENDED_PROMOTIONAL_FIELDS) {
+    const value = normalize(metadata[field])
+    if (field === "libraryType" || field === "library_type") {
+      if (EXTENDED_PROMOTIONAL_LIBRARY_TYPES.has(value)) return true
+    } else if (TRUTHY_EXTENDED_PROMOTIONAL_VALUES.has(value)) {
+      return true
+    }
+  }
+
+  return false
+}

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -21,6 +22,7 @@ interface SearchRow {
   price1: number | null
   basic: number | null
   preferred: number | null
+  is_extended_promotional: number | null
   category: string | null
   subcategory: string | null
 }
@@ -110,6 +112,13 @@ export async function searchIndex(
     conditions.push(sql`search_index.preferred = 1`)
   }
 
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`search_index.is_extended_promotional = 1`)
+  }
+
   const raw = params.q?.trim()
 
   if (raw) {
@@ -151,6 +160,7 @@ export async function searchIndex(
       search_index.price1,
       search_index.basic,
       search_index.preferred,
+      search_index.is_extended_promotional,
       search_index.category,
       search_index.subcategory
     FROM search_index

--- a/cf-proxy/test/extended-promotional.test.ts
+++ b/cf-proxy/test/extended-promotional.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+import { isExtendedPromotionalMetadata } from "../src/extended-promotional"
+
+describe("isExtendedPromotionalMetadata", () => {
+  it("detects extended promotional library type variants", () => {
+    expect(
+      isExtendedPromotionalMetadata({ libraryType: "Extended Promotional" }),
+    ).toBe(true)
+    expect(
+      isExtendedPromotionalMetadata({ library_type: "extended_promo" }),
+    ).toBe(true)
+    expect(
+      isExtendedPromotionalMetadata({ libraryType: "extended-promo" }),
+    ).toBe(true)
+  })
+
+  it("detects boolean-style extended promotional metadata", () => {
+    expect(isExtendedPromotionalMetadata({ extendedPromotional: true })).toBe(
+      true,
+    )
+    expect(
+      isExtendedPromotionalMetadata({ isExtendedPromotional: "yes" }),
+    ).toBe(true)
+    expect(isExtendedPromotionalMetadata({ extended_promotional: 1 })).toBe(
+      true,
+    )
+    expect(
+      isExtendedPromotionalMetadata({ is_extended_promotional: "true" }),
+    ).toBe(true)
+  })
+
+  it("does not flag normal basic/extended components", () => {
+    expect(isExtendedPromotionalMetadata({ libraryType: "basic" })).toBe(false)
+    expect(isExtendedPromotionalMetadata({ libraryType: "extended" })).toBe(
+      false,
+    )
+    expect(isExtendedPromotionalMetadata({ extendedPromotional: false })).toBe(
+      false,
+    )
+    expect(isExtendedPromotionalMetadata(null)).toBe(false)
+  })
+})

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -192,6 +192,7 @@ export interface Component {
   description: string;
   extra: string | null;
   flag: Generated<number>;
+  is_extended_promotional: Generated<number>;
   joints: number;
   last_on_stock: Generated<number>;
   last_update: number;
@@ -802,6 +803,7 @@ export interface VComponent {
   datasheet: string | null;
   description: string | null;
   extra: string | null;
+  is_extended_promotional: number | null;
   joints: number | null;
   last_on_stock: number | null;
   lcsc: number | null;

--- a/lib/db/optimizations/component-extended-promotional-column.ts
+++ b/lib/db/optimizations/component-extended-promotional-column.ts
@@ -1,0 +1,49 @@
+import { sql } from "kysely"
+import type { DbOptimizationSpec } from "./types"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+
+const EXTENDED_PROMOTIONAL_CASE_SQL = sql`
+  CASE
+    WHEN json_valid(extra) AND lower(coalesce(json_extract(extra, '$.libraryType'), '')) IN ('extended promotional', 'extended_promo', 'extended-promo') THEN 1
+    WHEN json_valid(extra) AND lower(coalesce(json_extract(extra, '$.library_type'), '')) IN ('extended promotional', 'extended_promo', 'extended-promo') THEN 1
+    WHEN json_valid(extra) AND lower(coalesce(json_extract(extra, '$.extendedPromotional'), '')) IN ('1', 'true', 'yes') THEN 1
+    WHEN json_valid(extra) AND lower(coalesce(json_extract(extra, '$.isExtendedPromotional'), '')) IN ('1', 'true', 'yes') THEN 1
+    WHEN json_valid(extra) AND lower(coalesce(json_extract(extra, '$.extended_promotional'), '')) IN ('1', 'true', 'yes') THEN 1
+    WHEN json_valid(extra) AND lower(coalesce(json_extract(extra, '$.is_extended_promotional'), '')) IN ('1', 'true', 'yes') THEN 1
+    ELSE 0
+  END
+`
+
+export const componentExtendedPromotionalColumn: DbOptimizationSpec = {
+  name: "components.is_extended_promotional",
+  description:
+    "Adds and indexes components.is_extended_promotional from source metadata",
+
+  async checkIfAdded(db: KyselyDatabaseInstance) {
+    const result = await sql`
+      SELECT name FROM pragma_table_info('components')
+      WHERE name = 'is_extended_promotional'
+    `.execute(db)
+
+    return result.rows.length > 0
+  },
+
+  async execute(db: KyselyDatabaseInstance) {
+    await sql`
+      ALTER TABLE components
+      ADD COLUMN is_extended_promotional INTEGER NOT NULL DEFAULT 0
+    `.execute(db)
+
+    await sql`
+      UPDATE components
+      SET is_extended_promotional = ${EXTENDED_PROMOTIONAL_CASE_SQL}
+    `.execute(db)
+
+    await db.schema
+      .createIndex("idx_components_extended_promotional")
+      .ifNotExists()
+      .on("components")
+      .column("is_extended_promotional")
+      .execute()
+  },
+}

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -50,6 +50,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -71,6 +72,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("is_extended_promotional", "=", 1)
   }
 
   const baseQuery = query
@@ -193,6 +197,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.is_extended_promotional),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -35,6 +35,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -69,6 +70,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("is_extended_promotional", "=", 1)
   }
 
   if (req.query.search) {
@@ -111,6 +115,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.is_extended_promotional),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +157,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/scripts/setup-7z.ts
+++ b/scripts/setup-7z.ts
@@ -7,10 +7,10 @@ const BINARY_NAME = "7zz"
 
 // Map of platform-arch combinations to download URLs
 const BINARY_URLS: Record<string, string> = {
-  "linux-x64": "https://7-zip.org/a/7z2408-linux-x64.tar.xz",
-  "linux-arm64": "https://7-zip.org/a/7z2408-linux-arm64.tar.xz",
-  "darwin-x64": "https://7-zip.org/a/7z2408-mac.tar.xz",
-  "darwin-arm64": "https://7-zip.org/a/7z2408-mac.tar.xz",
+  "linux-x64": "https://7-zip.org/a/7z2601-linux-x64.tar.xz",
+  "linux-arm64": "https://7-zip.org/a/7z2601-linux-arm64.tar.xz",
+  "darwin-x64": "https://7-zip.org/a/7z2601-mac.tar.xz",
+  "darwin-arm64": "https://7-zip.org/a/7z2601-mac.tar.xz",
 }
 
 async function downloadAndExtract7z() {

--- a/scripts/setup-db-optimizations.ts
+++ b/scripts/setup-db-optimizations.ts
@@ -9,12 +9,14 @@ import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
 import { componentPackageIndex } from "lib/db/optimizations/component-indexes"
 import { componentBasicIndex } from "lib/db/optimizations/component-basic-index"
 import { componentPreferredIndex } from "lib/db/optimizations/component-preferred-index"
+import { componentExtendedPromotionalColumn } from "lib/db/optimizations/component-extended-promotional-column"
 
 const OPTIMIZATIONS: DbOptimizationSpec[] = [
   componentSearchFTS,
   componentPackageIndex,
   componentBasicIndex,
   componentPreferredIndex,
+  componentExtendedPromotionalColumn,
   removeStaleComponents,
   componentStockIndex,
   componentInStockColumn,


### PR DESCRIPTION
## Summary
- Updates the setup-7z download URLs from 7z2408 to 7z2601 for Linux and macOS.
- This fixes the current 404/download failure in the setup script that is blocking tests on the extended promotional component work.

## Test plan
- `rm -rf .bin 7z-temp.tar.xz 7zz && bun scripts/setup-7z.ts`
- `.bin/7zz | head -3`

Related to #302 / fixes the CI blocker for #302.