### PR TITLE
Add extended promotional component filter

### DIFF
--- a/cf-proxy/scripts/rebuild-search-index-batched.sh
+++ b/cf-proxy/scripts/rebuild-search-index-batched.sh
@@ -43,6 +43,7 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
      price1 REAL,
      basic INTEGER,
      preferred INTEGER,
+     is_extended_promotional INTEGER,
      category TEXT,
      subcategory TEXT,
      manufacturer_name TEXT,
@@ -70,6 +71,7 @@ INSERT INTO search_index_next (
   price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   manufacturer_name,
@@ -91,6 +93,12 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  CASE
+    WHEN json_valid(extra)
+      AND lower(json_extract(extra, '$.componentLibraryType')) IN ('expand', 'expandprefer') THEN 1
+    WHEN preferred = 1 AND coalesce(basic, 0) = 0 THEN 1
+    ELSE 0
+  END AS is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -133,7 +141,8 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
    CREATE INDEX IF NOT EXISTS idx_search_index_next_lcsc ON search_index_next(lcsc);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_package ON search_index_next(package);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_basic ON search_index_next(basic);
-   CREATE INDEX IF NOT EXISTS idx_search_index_next_preferred ON search_index_next(preferred);"
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_preferred ON search_index_next(preferred);
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_extended_promotional ON search_index_next(is_extended_promotional);"
 
 echo "Validating row count..."
 run_wrangler d1 execute "$DB_NAME" --remote --command \
@@ -157,11 +166,13 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
    DROP INDEX IF EXISTS idx_search_index_package;
    DROP INDEX IF EXISTS idx_search_index_basic;
    DROP INDEX IF EXISTS idx_search_index_preferred;
+   DROP INDEX IF EXISTS idx_search_index_extended_promotional;
    ALTER TABLE search_index_next RENAME TO search_index;
    CREATE INDEX IF NOT EXISTS idx_search_index_stock ON search_index(stock DESC);
    CREATE INDEX IF NOT EXISTS idx_search_index_lcsc ON search_index(lcsc);
    CREATE INDEX IF NOT EXISTS idx_search_index_package ON search_index(package);
    CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
-   CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);"
+   CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
+   CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);"
 
 echo "Done. Old table kept as search_index_old for rollback."

--- a/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
+++ b/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
@@ -14,6 +14,12 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  CASE
+    WHEN json_valid(extra)
+      AND lower(json_extract(extra, '$.componentLibraryType')) IN ('expand', 'expandprefer') THEN 1
+    WHEN preferred = 1 AND coalesce(basic, 0) = 0 THEN 1
+    ELSE 0
+  END AS is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -55,3 +61,5 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);

--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -297,6 +297,12 @@ SELECT
   package,
   basic,
   preferred,
+  CASE
+    WHEN json_valid(extra)
+      AND lower(json_extract(extra, '$.componentLibraryType')) IN ('expand', 'expandprefer') THEN 1
+    WHEN preferred = 1 AND coalesce(basic, 0) = 0 THEN 1
+    ELSE 0
+  END AS is_extended_promotional,
   description,
   stock,
   price,
@@ -307,6 +313,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(is_extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA
 
@@ -320,6 +327,7 @@ CREATE TABLE component_catalog (
   package TEXT,
   basic INTEGER,
   preferred INTEGER,
+  is_extended_promotional INTEGER,
   description TEXT,
   stock INTEGER,
   price TEXT,
@@ -329,6 +337,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(is_extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA_EXPORT
 }
@@ -351,6 +360,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -392,6 +402,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);
 SEARCH_INDEX_SCHEMA
 
   cat > search_index_schema.sql <<'SEARCH_INDEX_SCHEMA_EXPORT'
@@ -406,6 +418,7 @@ CREATE TABLE search_index (
   price1 REAL,
   basic INTEGER,
   preferred INTEGER,
+  is_extended_promotional INTEGER,
   category TEXT,
   subcategory TEXT,
   manufacturer_name TEXT,
@@ -423,6 +436,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);
 SEARCH_INDEX_SCHEMA_EXPORT
 }
 

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -22,6 +23,7 @@ export async function queryComponentCatalog(
     package: string | null
     basic: number | null
     preferred: number | null
+    is_extended_promotional: number | null
     description: string | null
     stock: number | null
     price: string | null
@@ -34,6 +36,7 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -161,6 +161,7 @@ export interface ComponentCatalog {
   category: string | null
   description: string | null
   extra: string | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   package: string | null
@@ -660,6 +661,7 @@ export interface SearchIndex {
   basic: number | null
   category: string | null
   description: string | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   manufacturer_name: string | null

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -367,6 +367,7 @@ async function handleD1Search(
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
       is_preferred: Boolean(row.preferred),
+      is_extended_promotional: Boolean(row.is_extended_promotional),
       description: row.description ?? "",
       stock: row.stock ?? 0,
       price: row.price1 ?? extractSmallQuantityPrice(row.price),
@@ -491,6 +492,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        is_extended_promotional: Boolean(row.is_extended_promotional),
       })),
     }
 

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -148,6 +148,7 @@ const COLUMN_LABELS: Record<string, string> = {
   in_stock: "In Stock",
   is_basic: "Basic",
   is_preferred: "Preferred",
+  is_extended_promotional: "Extended Promotional",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
   voltage_rating: "Voltage",
@@ -546,6 +547,9 @@ const renderComponentsFilters = (
   </div>
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
+  </div>
+  <div>
+    <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <button type="submit">Filter</button>
 </form>`

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -21,6 +22,7 @@ interface SearchRow {
   price1: number | null
   basic: number | null
   preferred: number | null
+  is_extended_promotional: number | null
   category: string | null
   subcategory: string | null
 }
@@ -50,6 +52,17 @@ async function isFtsSearchReady(db: Kysely<DB>): Promise<boolean> {
     if (isMissingFtsReadinessTable(error)) return false
     throw error
   }
+}
+
+async function hasExtendedPromotionalColumn(db: Kysely<DB>): Promise<boolean> {
+  const result = await sql`
+    SELECT name
+    FROM pragma_table_info('search_index')
+    WHERE name = 'is_extended_promotional'
+    LIMIT 1
+  `.execute(db)
+
+  return result.rows.length > 0
 }
 
 const getSearchTokenGroups = (raw: string): string[][] => {
@@ -90,6 +103,12 @@ export async function searchIndex(
   params: SearchQueryParams,
 ): Promise<SearchRow[]> {
   const limit = Number.parseInt(params.limit ?? "100", 10) || 100
+  const extendedPromotionalExpression = (await hasExtendedPromotionalColumn(db))
+    ? sql`search_index.is_extended_promotional`
+    : sql`CASE
+        WHEN search_index.preferred = 1 AND coalesce(search_index.basic, 0) = 0 THEN 1
+        ELSE 0
+      END`
   const conditions: RawBuilder<unknown>[] = [sql`search_index.stock > 0`]
   const fallbackSearchConditions: RawBuilder<unknown>[] = []
   const ftsSearchConditions: RawBuilder<unknown>[] = []
@@ -108,6 +127,13 @@ export async function searchIndex(
 
   if (params.is_preferred === "true" || params.is_preferred === "1") {
     conditions.push(sql`search_index.preferred = 1`)
+  }
+
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`${extendedPromotionalExpression} = 1`)
   }
 
   const raw = params.q?.trim()
@@ -151,6 +177,7 @@ export async function searchIndex(
       search_index.price1,
       search_index.basic,
       search_index.preferred,
+      ${extendedPromotionalExpression} AS is_extended_promotional,
       search_index.category,
       search_index.subcategory
     FROM search_index

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -69,6 +69,28 @@ describe("render helpers", () => {
     expect(html).toContain("/led_with_ic/list.json?protocol=WS2812B")
   })
 
+  it("renders the extended promotional component filter and result column", () => {
+    const html = renderD1TablePage(
+      "/components/list",
+      {
+        components: [
+          {
+            lcsc: 123,
+            mfr: "PROMO-123",
+            is_extended_promotional: true,
+          },
+        ],
+      },
+      { is_extended_promotional: "true" },
+      "https://example.com/components/list?is_extended_promotional=true",
+    )
+
+    expect(html).toContain('name="is_extended_promotional"')
+    expect(html).toContain('value="true" checked')
+    expect(html).toContain("Extended Promotional")
+    expect(html).toContain("PROMO-123")
+  })
+
   it("renders attributes cells inside details with a truncated summary", () => {
     const html = renderD1TablePage(
       "/ldos/list",

--- a/lib/db/derive-extended-promotional.ts
+++ b/lib/db/derive-extended-promotional.ts
@@ -1,0 +1,48 @@
+type ComponentSource = {
+  basic?: number | boolean | null
+  preferred?: number | boolean | null
+  extra?: string | Record<string, unknown> | null
+}
+
+const EXTENDED_PROMOTIONAL_LIBRARY_TYPES = new Set(["expand", "expandprefer"])
+
+const parseExtra = (
+  extra: string | Record<string, unknown> | null | undefined,
+): Record<string, unknown> | null => {
+  if (!extra) return null
+  if (typeof extra === "object") return extra
+
+  try {
+    const parsed = JSON.parse(extra)
+    return parsed && typeof parsed === "object" ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+export const isExtendedPromotionalLibraryType = (value: unknown): boolean =>
+  typeof value === "string" &&
+  EXTENDED_PROMOTIONAL_LIBRARY_TYPES.has(value.toLowerCase())
+
+export const deriveIsExtendedPromotional = (
+  component: ComponentSource,
+): boolean => {
+  const extra = parseExtra(component.extra)
+  const libraryType = extra?.componentLibraryType
+
+  if (isExtendedPromotionalLibraryType(libraryType)) {
+    return true
+  }
+
+  return Boolean(component.preferred) && !Boolean(component.basic)
+}
+
+export const extendedPromotionalSqlCondition = `
+  (
+    CASE
+      WHEN json_valid(extra) THEN lower(json_extract(extra, '$.componentLibraryType')) IN ('expand', 'expandprefer')
+      ELSE 0
+    END
+    OR (preferred = 1 AND coalesce(basic, 0) = 0)
+  )
+`

--- a/lib/db/derivedtables/component-base.ts
+++ b/lib/db/derivedtables/component-base.ts
@@ -7,5 +7,6 @@ export interface BaseComponent {
   in_stock: boolean
   is_basic: boolean
   is_preferred: boolean
+  is_extended_promotional?: boolean
   attributes: Record<string, string>
 }

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -1,4 +1,5 @@
 import { sql } from "kysely"
+import { deriveIsExtendedPromotional } from "lib/db/derive-extended-promotional"
 import { destroyDbClient, getDbClient } from "lib/db/get-db-client"
 import { accelerometerTableSpec } from "lib/db/derivedtables/accelerometer"
 import { adcTableSpec } from "lib/db/derivedtables/adc"
@@ -132,6 +133,7 @@ const createTable = async (
     { name: "stock", type: "integer" },
     { name: "price1", type: "real" },
     { name: "in_stock", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ].concat(spec.extraColumns as any, [{ name: "attributes", type: "text" }])) {
     tableCreator = tableCreator.addColumn(
       col.name as string,
@@ -166,6 +168,9 @@ const createTable = async (
         ? null
         : {
             ...c,
+            is_extended_promotional: deriveIsExtendedPromotional(
+              components[i] as any,
+            ),
             attributes: jsonParseOrNull(components[i].extra)?.attributes,
           },
     )

--- a/lib/db/derivedtables/types.ts
+++ b/lib/db/derivedtables/types.ts
@@ -15,6 +15,7 @@ export interface DerivedTableSpec<
     price1: number | null
     in_stock: boolean
     is_basic: boolean
+    is_extended_promotional?: boolean
   },
 > {
   tableName: string

--- a/tests/lib/derive-extended-promotional.test.ts
+++ b/tests/lib/derive-extended-promotional.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test"
+import { deriveIsExtendedPromotional } from "lib/db/derive-extended-promotional"
+
+describe("deriveIsExtendedPromotional", () => {
+  test("uses the JLCPCB extended promotional library type when present", () => {
+    expect(
+      deriveIsExtendedPromotional({
+        basic: 1,
+        preferred: 0,
+        extra: JSON.stringify({ componentLibraryType: "expand" }),
+      }),
+    ).toBe(true)
+
+    expect(
+      deriveIsExtendedPromotional({
+        basic: 0,
+        preferred: 0,
+        extra: { componentLibraryType: "expandPrefer" },
+      }),
+    ).toBe(true)
+  })
+
+  test("falls back to preferred non-basic source flags", () => {
+    expect(
+      deriveIsExtendedPromotional({
+        basic: 0,
+        preferred: 1,
+        extra: JSON.stringify({ componentLibraryType: "preferred" }),
+      }),
+    ).toBe(true)
+
+    expect(
+      deriveIsExtendedPromotional({
+        basic: 1,
+        preferred: 1,
+        extra: JSON.stringify({ componentLibraryType: "base" }),
+      }),
+    ).toBe(false)
+
+    expect(
+      deriveIsExtendedPromotional({
+        basic: 0,
+        preferred: 1,
+        extra: "not-json",
+      }),
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
Summary:
- derive `is_extended_promotional` from JLCPCB component metadata, with preferred/non-basic fallback handling
- expose and filter the field through the current D1 `/components/list` and `/api/search` worker paths
- include the field in component-catalog and search-index rebuild/sync scripts, indexes, response types, and rendered filters
- propagate the flag into derived-table setup and add focused derivation/render coverage
- rebase onto current `main` after the legacy site routes were removed, keeping the patch scoped to the surviving worker and database architecture

Tests:
- `bun run format:check`
- `bunx tsc --noEmit`
- `bunx tsc --noEmit --project cf-proxy/tsconfig.json`
- `bun test`
- direct SQLite derivation check for metadata, preferred/non-basic fallback, malformed metadata, and negative cases
- `git diff --check upstream/main...HEAD`

/claim #92

## Payout
Payment method: Algora bounty-platform payout to GitHub user @jamilahmadzai for claim #92.