### PR TITLE
Add extended promotional component filter

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Install cf-proxy dependencies
+        run: cd cf-proxy && bun install
+
       - name: Cache setup artifacts
         id: cache-setup
         uses: actions/cache@v4
@@ -31,6 +34,8 @@ jobs:
       - name: Run setup if cache miss
         if: steps.cache-setup.outputs.cache-hit != 'true'
         run: bun run setup
+        env:
+          SKIP_DB_VACUUM: "true"
 
       - name: Run tests
         run: bun test

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -22,6 +23,7 @@ export async function queryComponentCatalog(
     package: string | null
     basic: number | null
     preferred: number | null
+    is_extended_promotional: number | null
     description: string | null
     stock: number | null
     price: string | null
@@ -34,6 +36,7 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -367,6 +367,7 @@ async function handleD1Search(
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
       is_preferred: Boolean(row.preferred),
+      is_extended_promotional: Boolean(row.is_extended_promotional),
       description: row.description ?? "",
       stock: row.stock ?? 0,
       price: row.price1 ?? extractSmallQuantityPrice(row.price),
@@ -491,6 +492,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        is_extended_promotional: Boolean(row.is_extended_promotional),
       })),
     }
 

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -147,6 +147,7 @@ const COLUMN_LABELS: Record<string, string> = {
   in_stock: "In Stock",
   is_basic: "Basic",
   is_preferred: "Preferred",
+  is_extended_promotional: "Extended Promotional",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
   voltage_rating: "Voltage",
@@ -545,6 +546,9 @@ const renderComponentsFilters = (
   </div>
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
+  </div>
+  <div>
+    <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <button type="submit">Filter</button>
 </form>`

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -21,6 +22,7 @@ interface SearchRow {
   price1: number | null
   basic: number | null
   preferred: number | null
+  is_extended_promotional: number | null
   category: string | null
   subcategory: string | null
 }
@@ -110,6 +112,14 @@ export async function searchIndex(
     conditions.push(sql`search_index.preferred = 1`)
   }
 
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`search_index.preferred = 1`)
+    conditions.push(sql`search_index.basic = 0`)
+  }
+
   const raw = params.q?.trim()
 
   if (raw) {
@@ -151,6 +161,10 @@ export async function searchIndex(
       search_index.price1,
       search_index.basic,
       search_index.preferred,
+      CASE
+        WHEN search_index.preferred = 1 AND search_index.basic = 0 THEN 1
+        ELSE 0
+      END AS is_extended_promotional,
       search_index.category,
       search_index.subcategory
     FROM search_index

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -50,6 +50,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -58,6 +59,11 @@ export default withWinterSpec({
   let query = ctx.db
     .selectFrom("components")
     .selectAll()
+    .select(
+      sql<number>`CASE WHEN preferred = 1 AND basic = 0 THEN 1 ELSE 0 END`.as(
+        "is_extended_promotional",
+      ),
+    )
     .limit(limit)
     .orderBy("stock", "desc")
     .where("stock", ">", 0)
@@ -71,6 +77,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   const baseQuery = query
@@ -193,6 +202,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.is_extended_promotional),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -35,6 +35,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -51,6 +52,10 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
+      sql<number>`CASE WHEN preferred = 1 AND basic = 0 THEN 1 ELSE 0 END`.as(
+        "is_extended_promotional",
+      ),
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -69,6 +74,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   if (req.query.search) {
@@ -111,6 +119,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.is_extended_promotional),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +161,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/scripts/setup-7z.ts
+++ b/scripts/setup-7z.ts
@@ -7,10 +7,14 @@ const BINARY_NAME = "7zz"
 
 // Map of platform-arch combinations to download URLs
 const BINARY_URLS: Record<string, string> = {
-  "linux-x64": "https://7-zip.org/a/7z2408-linux-x64.tar.xz",
-  "linux-arm64": "https://7-zip.org/a/7z2408-linux-arm64.tar.xz",
-  "darwin-x64": "https://7-zip.org/a/7z2408-mac.tar.xz",
-  "darwin-arm64": "https://7-zip.org/a/7z2408-mac.tar.xz",
+  "linux-x64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-linux-x64.tar.xz",
+  "linux-arm64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-linux-arm64.tar.xz",
+  "darwin-x64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-mac.tar.xz",
+  "darwin-arm64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-mac.tar.xz",
 }
 
 async function downloadAndExtract7z() {

--- a/scripts/setup-db-optimizations.ts
+++ b/scripts/setup-db-optimizations.ts
@@ -40,6 +40,11 @@ async function main() {
 
   await db.destroy()
 
+  if (process.env.SKIP_DB_VACUUM === "true") {
+    console.log("Skipping VACUUM because SKIP_DB_VACUUM=true")
+    return
+  }
+
   const bunDb = getBunDatabaseClient()
   console.log("Running VACUUM to optimize database...")
   await bunDb.exec("VACUUM")

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -1,5 +1,6 @@
 import { afterEach } from "bun:test"
 import { setupDerivedTables } from "lib/db/derivedtables/setup-derived-tables"
+import { getDbClient } from "lib/db/get-db-client"
 
 declare global {
   var deferredCleanupFns: Array<() => void | Promise<void>>
@@ -7,7 +8,10 @@ declare global {
 }
 
 globalThis.deferredCleanupFns ??= []
-globalThis.derivedTablesSetupPromise ??= setupDerivedTables({ populate: false })
+globalThis.derivedTablesSetupPromise ??= setupDerivedTables({
+  db: getDbClient(),
+  populate: false,
+})
 
 await globalThis.derivedTablesSetupPromise
 

--- a/tests/routes/components/extended-promotional.test.ts
+++ b/tests/routes/components/extended-promotional.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+const expectExtendedPromotionalComponents = (components: any[]) => {
+  expect(components.length).toBeGreaterThan(0)
+
+  for (const component of components) {
+    expect(component).toHaveProperty("is_basic", false)
+    expect(component).toHaveProperty("is_preferred", true)
+    expect(component).toHaveProperty("is_extended_promotional", true)
+  }
+}
+
+test("GET /api/search exposes and filters extended promotional components", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get(
+    "/api/search?limit=25&is_extended_promotional=true",
+  )
+
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+  expectExtendedPromotionalComponents(res.data.components)
+})
+
+test("GET /components/list exposes and filters extended promotional components", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get(
+    "/components/list?json=true&is_extended_promotional=true",
+  )
+
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+  expectExtendedPromotionalComponents(res.data.components)
+})


### PR DESCRIPTION
## Summary
- exposes `is_extended_promotional` on `/api/search` and `/components/list`, derived from `preferred = 1 AND basic = 0`
- adds `is_extended_promotional=true` filtering and an Extended Promotional checkbox on the components list UI
- wires the same flag/filter through the D1/cf-proxy component search path
- keeps test setup alive by passing the shared DB client, refreshes the stale 7-Zip setup URL, and makes the test workflow install cf-proxy deps/skip CI VACUUM on cache misses

## Verification
- `bun run format:check`
- `bunx tsc --noEmit`
- `cd cf-proxy && npx tsc --noEmit`
- `bun test tests/routes/api/search.test.ts tests/routes/components/list.test.ts tests/routes/components/extended-promotional.test.ts`
- `cd cf-proxy && npm test`
- `bun test`

AI-assisted with Codex.

/claim #92