### PR TITLE
Add is_extended_promotional component filter

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -27,10 +27,18 @@ jobs:
         with:
           path: ./db.sqlite3
           key: db-sqlite3-${{ hashFiles('scripts/setup-*.ts') }}
+          restore-keys: |
+            db-sqlite3-
+          save-always: true
 
       - name: Run setup if cache miss
         if: steps.cache-setup.outputs.cache-hit != 'true'
-        run: bun run setup
+        run: |
+          if [ -f ./db.sqlite3 ]; then
+            echo "Using restored db.sqlite3"
+          else
+            bun run setup
+          fi
         env:
           SKIP_DB_VACUUM: "true"
 

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -31,6 +31,8 @@ jobs:
       - name: Run setup if cache miss
         if: steps.cache-setup.outputs.cache-hit != 'true'
         run: bun run setup
+        env:
+          SKIP_DB_VACUUM: "true"
 
       - name: Run tests
         run: bun test

--- a/cf-proxy/scripts/rebuild-search-index-batched.sh
+++ b/cf-proxy/scripts/rebuild-search-index-batched.sh
@@ -43,6 +43,7 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
      price1 REAL,
      basic INTEGER,
      preferred INTEGER,
+     is_extended_promotional INTEGER,
      category TEXT,
      subcategory TEXT,
      manufacturer_name TEXT,
@@ -70,6 +71,7 @@ INSERT INTO search_index_next (
   price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   manufacturer_name,
@@ -91,6 +93,14 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  CASE
+    WHEN json_valid(extra)
+      AND json_extract(extra, '$.componentLibraryType') IN ('expand', 'expandPrefer')
+    THEN 1
+    WHEN preferred = 1 AND COALESCE(basic, 0) = 0
+    THEN 1
+    ELSE 0
+  END AS is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -133,7 +143,8 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
    CREATE INDEX IF NOT EXISTS idx_search_index_next_lcsc ON search_index_next(lcsc);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_package ON search_index_next(package);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_basic ON search_index_next(basic);
-   CREATE INDEX IF NOT EXISTS idx_search_index_next_preferred ON search_index_next(preferred);"
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_preferred ON search_index_next(preferred);
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_is_extended_promotional ON search_index_next(is_extended_promotional);"
 
 echo "Validating row count..."
 run_wrangler d1 execute "$DB_NAME" --remote --command \
@@ -157,11 +168,13 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
    DROP INDEX IF EXISTS idx_search_index_package;
    DROP INDEX IF EXISTS idx_search_index_basic;
    DROP INDEX IF EXISTS idx_search_index_preferred;
+   DROP INDEX IF EXISTS idx_search_index_is_extended_promotional;
    ALTER TABLE search_index_next RENAME TO search_index;
    CREATE INDEX IF NOT EXISTS idx_search_index_stock ON search_index(stock DESC);
    CREATE INDEX IF NOT EXISTS idx_search_index_lcsc ON search_index(lcsc);
    CREATE INDEX IF NOT EXISTS idx_search_index_package ON search_index(package);
    CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
-   CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);"
+   CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
+   CREATE INDEX IF NOT EXISTS idx_search_index_is_extended_promotional ON search_index(is_extended_promotional);"
 
 echo "Done. Old table kept as search_index_old for rollback."

--- a/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
+++ b/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
@@ -14,6 +14,14 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  CASE
+    WHEN json_valid(extra)
+      AND json_extract(extra, '$.componentLibraryType') IN ('expand', 'expandPrefer')
+    THEN 1
+    WHEN preferred = 1 AND COALESCE(basic, 0) = 0
+    THEN 1
+    ELSE 0
+  END AS is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -55,3 +63,5 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_is_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_is_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -22,6 +23,7 @@ export async function queryComponentCatalog(
     package: string | null
     basic: number | null
     preferred: number | null
+    is_extended_promotional: number | null
     description: string | null
     stock: number | null
     price: string | null
@@ -34,6 +36,7 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -17,6 +17,7 @@ export interface Accelerometer {
   has_spi: number | null
   has_uart: number | null
   in_stock: number | null
+  is_extended_promotional: number | null
   is_basic: number | null
   is_preferred: number | null
   lcsc: Generated<number | null>
@@ -39,6 +40,7 @@ export interface Adc {
   has_spi: number | null
   has_uart: number | null
   in_stock: number | null
+  is_extended_promotional: number | null
   is_differential: number | null
   lcsc: Generated<number | null>
   mfr: string | null
@@ -63,6 +65,7 @@ export interface AnalogMultiplexer {
   has_parallel_interface: number | null
   has_spi: number | null
   in_stock: number | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   leakage_current_na: number | null
   mfr: string | null
@@ -84,6 +87,7 @@ export interface BatteryHolder {
   connector_type: string | null
   description: string | null
   in_stock: number | null
+  is_extended_promotional: number | null
   is_basic: number | null
   is_preferred: number | null
   lcsc: Generated<number | null>
@@ -102,6 +106,7 @@ export interface BjtTransistor {
   current_gain: number | null
   description: string | null
   in_stock: number | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   package: string | null
@@ -116,6 +121,7 @@ export interface BoostConverter {
   attributes: string | null
   description: string | null
   in_stock: number | null
+  is_extended_promotional: number | null
   input_voltage_max: number | null
   input_voltage_min: number | null
   is_basic: number | null
@@ -138,6 +144,7 @@ export interface BuckBoostConverter {
   attributes: string | null
   description: string | null
   in_stock: number | null
+  is_extended_promotional: number | null
   input_voltage_max: number | null
   input_voltage_min: number | null
   is_basic: number | null
@@ -161,6 +168,7 @@ export interface ComponentCatalog {
   category: string | null
   description: string | null
   extra: string | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   package: string | null
@@ -177,6 +185,7 @@ export interface Capacitor {
   description: string | null
   esr_ohms: number | null
   in_stock: number | null
+  is_extended_promotional: number | null
   is_basic: number | null
   is_polarized: number | null
   is_preferred: number | null
@@ -200,6 +209,7 @@ export interface Dac {
   has_parallel_interface: number | null
   has_spi: number | null
   in_stock: number | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   nonlinearity_lsb: number | null
@@ -224,6 +234,7 @@ export interface Diode {
   forward_current: number | null
   forward_voltage: number | null
   in_stock: number | null
+  is_extended_promotional: number | null
   is_schottky: number | null
   is_tvs: number | null
   is_zener: number | null
@@ -245,6 +256,7 @@ export interface FpcConnector {
   contact_type: string | null
   description: string | null
   in_stock: number | null
+  is_extended_promotional: number | null
   is_basic: number | null
   is_preferred: number | null
   lcsc: Generated<number | null>
@@ -261,6 +273,7 @@ export interface Fpga {
   description: string | null
   embedded_ram_bits: number | null
   in_stock: number | null
+  is_extended_promotional: number | null
   is_basic: number | null
   is_preferred: number | null
   lcsc: Generated<number | null>
@@ -284,6 +297,7 @@ export interface Fuse {
   current_rating: number | null
   description: string | null
   in_stock: number | null
+  is_extended_promotional: number | null
   is_glass_encased: number | null
   is_resettable: number | null
   is_surface_mount: number | null
@@ -300,6 +314,7 @@ export interface GasSensor {
   attributes: string | null
   description: string | null
   in_stock: number | null
+  is_extended_promotional: number | null
   is_basic: number | null
   is_preferred: number | null
   lcsc: Generated<number | null>
@@ -329,6 +344,7 @@ export interface Gyroscope {
   has_spi: number | null
   has_uart: number | null
   in_stock: number | null
+  is_extended_promotional: number | null
   is_basic: number | null
   is_preferred: number | null
   lcsc: Generated<number | null>
@@ -350,6 +366,7 @@ export interface Header {
   description: string | null
   gender: string | null
   in_stock: number | null
+  is_extended_promotional: number | null
   insulation_height_mm: number | null
   is_right_angle: number | null
   is_shrouded: number | null
@@ -379,6 +396,7 @@ export interface IoExpander {
   has_smbus: number | null
   has_spi: number | null
   in_stock: number | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   num_gpios: number | null
@@ -398,6 +416,7 @@ export interface JstConnector {
   attributes: string | null
   description: string | null
   in_stock: number | null
+  is_extended_promotional: number | null
   is_basic: number | null
   is_preferred: number | null
   lcsc: Generated<number | null>
@@ -417,6 +436,7 @@ export interface LcdDisplay {
   display_size: string | null
   display_type: string | null
   in_stock: number | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   package: string | null
@@ -430,6 +450,7 @@ export interface Ldo {
   description: string | null
   dropout_voltage: number | null
   in_stock: number | null
+  is_extended_promotional: number | null
   input_voltage_max: number | null
   input_voltage_min: number | null
   is_basic: number | null
@@ -459,6 +480,7 @@ export interface Led {
   forward_current: number | null
   forward_voltage: number | null
   in_stock: number | null
+  is_extended_promotional: number | null
   is_rgb: number | null
   lcsc: Generated<number | null>
   lens_color: string | null
@@ -480,6 +502,7 @@ export interface LedDotMatrixDisplay {
   color: string | null
   description: string | null
   in_stock: number | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   matrix_size: string | null
   mfr: string | null
@@ -495,6 +518,7 @@ export interface LedDriver {
   dimming_method: string | null
   efficiency_percent: number | null
   in_stock: number | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   mounting_style: string | null
@@ -514,6 +538,7 @@ export interface LedSegmentDisplay {
   color: string | null
   description: string | null
   in_stock: number | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   package: string | null
@@ -531,6 +556,7 @@ export interface LedWithIc {
   forward_current: number | null
   forward_voltage: number | null
   in_stock: number | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   mounting_style: string | null
@@ -563,6 +589,7 @@ export interface Microcontroller {
   has_usb: number | null
   has_watchdog: number | null
   in_stock: number | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   operating_temp_max: number | null
@@ -582,6 +609,7 @@ export interface Mosfet {
   drain_source_voltage: number | null
   gate_threshold_voltage: number | null
   in_stock: number | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   mounting_style: string | null
@@ -598,6 +626,7 @@ export interface OledDisplay {
   description: string | null
   display_width: string | null
   in_stock: number | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   package: string | null
@@ -611,6 +640,7 @@ export interface PcieM2Connector {
   attributes: string | null
   description: string | null
   in_stock: number | null
+  is_extended_promotional: number | null
   is_basic: number | null
   is_preferred: number | null
   is_right_angle: number | null
@@ -625,6 +655,7 @@ export interface Potentiometer {
   attributes: string | null
   description: string | null
   in_stock: number | null
+  is_extended_promotional: number | null
   is_surface_mount: number | null
   lcsc: Generated<number | null>
   max_resistance: number | null
@@ -642,6 +673,7 @@ export interface Relay {
   contact_form: string | null
   description: string | null
   in_stock: number | null
+  is_extended_promotional: number | null
   is_basic: number | null
   is_preferred: number | null
   lcsc: Generated<number | null>
@@ -660,6 +692,7 @@ export interface SearchIndex {
   basic: number | null
   category: string | null
   description: string | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   manufacturer_name: string | null
@@ -678,6 +711,7 @@ export interface Resistor {
   attributes: string | null
   description: string | null
   in_stock: number | null
+  is_extended_promotional: number | null
   is_basic: number | null
   is_multi_resistor_chip: number | null
   is_potentiometer: number | null
@@ -700,6 +734,7 @@ export interface ResistorArray {
   attributes: string | null
   description: string | null
   in_stock: number | null
+  is_extended_promotional: number | null
   is_basic: number | null
   is_preferred: number | null
   is_surface_mount: number | null
@@ -723,6 +758,7 @@ export interface Switch {
   current_rating_a: number | null
   description: string | null
   in_stock: number | null
+  is_extended_promotional: number | null
   is_basic: number | null
   is_latching: number | null
   is_preferred: number | null
@@ -748,6 +784,7 @@ export interface UsbCConnector {
   description: string | null
   gender: string | null
   in_stock: number | null
+  is_extended_promotional: number | null
   is_basic: number | null
   is_preferred: number | null
   lcsc: Generated<number | null>
@@ -767,6 +804,7 @@ export interface VoltageRegulator {
   description: string | null
   dropout_voltage: number | null
   in_stock: number | null
+  is_extended_promotional: number | null
   input_voltage_max: number | null
   input_voltage_min: number | null
   is_low_dropout: number | null
@@ -801,6 +839,7 @@ export interface WifiModule {
   has_spi: number | null
   has_uart: number | null
   in_stock: number | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   operating_temp_max: number | null
@@ -820,6 +859,7 @@ export interface WireToBoardConnector {
   description: string | null
   gender: string | null
   in_stock: number | null
+  is_extended_promotional: number | null
   is_basic: number | null
   is_preferred: number | null
   is_smd: number | null

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -1,7 +1,7 @@
 import { CacheService, addCorsHeaders, addVaryHeader } from "./cache-service"
 import { queryComponentCatalog } from "./components"
-import { getD1Client } from "./db/get-d1-client"
 import { getD1Handler } from "./d1-routes"
+import { getD1Client } from "./db/get-d1-client"
 import { renderD1TablePage, renderHomePage } from "./render"
 import { searchIndex } from "./search"
 
@@ -367,6 +367,7 @@ async function handleD1Search(
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
       is_preferred: Boolean(row.preferred),
+      is_extended_promotional: Boolean(row.is_extended_promotional),
       description: row.description ?? "",
       stock: row.stock ?? 0,
       price: row.price1 ?? extractSmallQuantityPrice(row.price),
@@ -491,6 +492,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        is_extended_promotional: Boolean(row.is_extended_promotional),
       })),
     }
 

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -1,9 +1,9 @@
 import {
+  type FilterOptions,
+  type QueryParams,
   ROUTE_TO_TABLE,
   TABLE_CONFIGS,
   TABLE_RESPONSE_KEY,
-  type QueryParams,
-  type FilterOptions,
 } from "./handlers"
 
 const escapeHtml = (value: unknown): string =>
@@ -147,6 +147,7 @@ const COLUMN_LABELS: Record<string, string> = {
   in_stock: "In Stock",
   is_basic: "Basic",
   is_preferred: "Preferred",
+  is_extended_promotional: "Extended Promotional",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
   voltage_rating: "Voltage",
@@ -545,6 +546,9 @@ const renderComponentsFilters = (
   </div>
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
+  </div>
+  <div>
+    <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <button type="submit">Filter</button>
 </form>`

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -1,4 +1,4 @@
-import { sql, type Kysely, type RawBuilder } from "kysely"
+import { type Kysely, type RawBuilder, sql } from "kysely"
 import type { DB } from "./db/types"
 import { buildSearchTokenGroups } from "./search-query"
 
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -21,6 +22,7 @@ interface SearchRow {
   price1: number | null
   basic: number | null
   preferred: number | null
+  is_extended_promotional: number | null
   category: string | null
   subcategory: string | null
 }
@@ -110,6 +112,13 @@ export async function searchIndex(
     conditions.push(sql`search_index.preferred = 1`)
   }
 
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`search_index.is_extended_promotional = 1`)
+  }
+
   const raw = params.q?.trim()
 
   if (raw) {
@@ -151,6 +160,7 @@ export async function searchIndex(
       search_index.price1,
       search_index.basic,
       search_index.preferred,
+      search_index.is_extended_promotional,
       search_index.category,
       search_index.subcategory
     FROM search_index

--- a/lib/db/derivedtables/accelerometer.ts
+++ b/lib/db/derivedtables/accelerometer.ts
@@ -1,6 +1,6 @@
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface Accelerometer extends BaseComponent {
   package: string
@@ -102,6 +102,7 @@ export const accelerometerTableSpec: DerivedTableSpec<Accelerometer> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c),
         package: c.package || "",
         supply_voltage_min: voltageMin,
         supply_voltage_max: voltageMax,

--- a/lib/db/derivedtables/adc.ts
+++ b/lib/db/derivedtables/adc.ts
@@ -1,7 +1,7 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface Adc extends BaseComponent {
   // Extra columns
@@ -115,6 +115,7 @@ export const adcTableSpec: DerivedTableSpec<Adc> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c),
         package: c.package || "",
         resolution_bits: resolution,
         sampling_rate_hz: samplingRate,

--- a/lib/db/derivedtables/analog_multiplexer.ts
+++ b/lib/db/derivedtables/analog_multiplexer.ts
@@ -1,7 +1,7 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface AnalogMultiplexer extends BaseComponent {
   // Extra columns
@@ -144,6 +144,7 @@ export const analogMultiplexerTableSpec: DerivedTableSpec<AnalogMultiplexer> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c),
         package: c.package || "",
         num_channels: numChannels,
         num_bits: numBits,

--- a/lib/db/derivedtables/battery_holder.ts
+++ b/lib/db/derivedtables/battery_holder.ts
@@ -1,8 +1,8 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { KyselyDatabaseInstance } from "../kysely-types"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface BatteryHolder extends BaseComponent {
   package: string
@@ -74,6 +74,7 @@ export const batteryHolderTableSpec: DerivedTableSpec<BatteryHolder> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c),
           package: String(c.package || ""),
           connector_type: attrs["Connector Type"] || null,
           battery_type: attrs["Battery Type"] || null,

--- a/lib/db/derivedtables/bjt_transistor.ts
+++ b/lib/db/derivedtables/bjt_transistor.ts
@@ -1,8 +1,8 @@
-import type { DerivedTableSpec } from "./types"
-import type { KyselyDatabaseInstance } from "../kysely-types"
-import { BaseComponent } from "./component-base"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface BJTTransistor extends BaseComponent {
   package?: string
@@ -74,6 +74,7 @@ export const bjtTransistorTableSpec: DerivedTableSpec<BJTTransistor> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c),
           package: c.package || "",
           current_gain: current_gain,
           collector_current: collector_current,

--- a/lib/db/derivedtables/boost_converter.ts
+++ b/lib/db/derivedtables/boost_converter.ts
@@ -1,6 +1,6 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 import type { DerivedTableSpec } from "./types"
 
 export interface BoostConverter extends BaseComponent {
@@ -117,6 +117,7 @@ export const boostConverterTableSpec: DerivedTableSpec<BoostConverter> = {
           in_stock: c.stock > 0,
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c),
           package: c.package || "",
           input_voltage_min: inputMin,
           input_voltage_max: inputMax,

--- a/lib/db/derivedtables/buck_boost_converter.ts
+++ b/lib/db/derivedtables/buck_boost_converter.ts
@@ -1,6 +1,6 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 import type { DerivedTableSpec } from "./types"
 
 export interface BuckBoostConverter extends BaseComponent {
@@ -121,6 +121,7 @@ export const buckBoostConverterTableSpec: DerivedTableSpec<BuckBoostConverter> =
             in_stock: c.stock > 0,
             is_basic: Boolean(c.basic),
             is_preferred: Boolean(c.preferred),
+            is_extended_promotional: isExtendedPromotional(c),
             package: c.package || "",
             input_voltage_min: inputMin,
             input_voltage_max: inputMax,

--- a/lib/db/derivedtables/capacitor.ts
+++ b/lib/db/derivedtables/capacitor.ts
@@ -1,7 +1,7 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface Capacitor extends BaseComponent {
   // Extra columns
@@ -115,6 +115,7 @@ export const capacitorTableSpec: DerivedTableSpec<Capacitor> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c),
         capacitance_farads: capacitance,
         tolerance_fraction: tolerance,
         voltage_rating: voltage,

--- a/lib/db/derivedtables/component-base.ts
+++ b/lib/db/derivedtables/component-base.ts
@@ -7,5 +7,20 @@ export interface BaseComponent {
   in_stock: boolean
   is_basic: boolean
   is_preferred: boolean
+  is_extended_promotional: boolean
   attributes: Record<string, string>
+}
+
+type ComponentFlags = {
+  basic?: number | boolean | null
+  preferred?: number | boolean | null
+  is_extended_promotional?: number | boolean | null
+}
+
+export const isExtendedPromotional = (component: ComponentFlags): boolean => {
+  if (component.is_extended_promotional != null) {
+    return Boolean(component.is_extended_promotional)
+  }
+
+  return Boolean(component.preferred) && !Boolean(component.basic)
 }

--- a/lib/db/derivedtables/dac.ts
+++ b/lib/db/derivedtables/dac.ts
@@ -1,7 +1,7 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface Dac extends BaseComponent {
   // Extra columns
@@ -129,6 +129,7 @@ export const dacTableSpec: DerivedTableSpec<Dac> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c),
         package: c.package || "",
         resolution_bits: resolution,
         num_channels: numChannels,

--- a/lib/db/derivedtables/diode.ts
+++ b/lib/db/derivedtables/diode.ts
@@ -1,7 +1,7 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface Diode extends BaseComponent {
   // Extra columns
@@ -159,6 +159,7 @@ export const diodeTableSpec: DerivedTableSpec<Diode> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c),
         package: c.package || "",
         forward_voltage: forwardVoltage,
         reverse_voltage: reverseVoltage,

--- a/lib/db/derivedtables/fpc_connector.ts
+++ b/lib/db/derivedtables/fpc_connector.ts
@@ -1,8 +1,8 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { KyselyDatabaseInstance } from "../kysely-types"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface FpcConnector extends BaseComponent {
   pitch_mm: number | null
@@ -55,6 +55,7 @@ export const fpcConnectorTableSpec: DerivedTableSpec<FpcConnector> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c),
           pitch_mm: parseNum(attrs["Pitch"]),
           number_of_contacts: isNaN(contacts) ? null : contacts,
           contact_type: attrs["Contact Type"] || null,

--- a/lib/db/derivedtables/fpga.ts
+++ b/lib/db/derivedtables/fpga.ts
@@ -1,6 +1,6 @@
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 import type { DerivedTableSpec } from "./types"
-import { BaseComponent } from "./component-base"
 
 export interface FPGA extends BaseComponent {
   package: string
@@ -99,6 +99,7 @@ export const fpgaTableSpec: DerivedTableSpec<FPGA> = {
           in_stock: Boolean((c.stock ?? 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c),
           package: extra?.package ?? c.package ?? "",
           type: attrs["Type"] ?? null,
           logic_array_blocks: parseNumericValue(attrs["Logic Array Blocks"]),

--- a/lib/db/derivedtables/fuse.ts
+++ b/lib/db/derivedtables/fuse.ts
@@ -1,7 +1,7 @@
-import type { DerivedTableSpec } from "./types"
-import type { KyselyDatabaseInstance } from "../kysely-types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 const FUSE_SUBCATEGORIES = [
   "Fuses",
@@ -129,6 +129,7 @@ export const fuseTableSpec: DerivedTableSpec<Fuse> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c),
           current_rating: current_rating as number,
           voltage_rating: voltage_rating as number,
           response_time,

--- a/lib/db/derivedtables/gas_sensor.ts
+++ b/lib/db/derivedtables/gas_sensor.ts
@@ -1,6 +1,6 @@
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface GasSensor extends BaseComponent {
   package: string
@@ -82,6 +82,7 @@ export const gasSensorTableSpec: DerivedTableSpec<GasSensor> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c),
         package: c.package || "",
         sensor_type: sensorType,
         measures_air_quality: measuresAirQuality,

--- a/lib/db/derivedtables/gyroscope.ts
+++ b/lib/db/derivedtables/gyroscope.ts
@@ -1,6 +1,6 @@
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface Gyroscope extends BaseComponent {
   package: string
@@ -106,6 +106,7 @@ export const gyroscopeTableSpec: DerivedTableSpec<Gyroscope> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c),
         package: c.package || "",
         supply_voltage_min: voltageMin,
         supply_voltage_max: voltageMax,

--- a/lib/db/derivedtables/header.ts
+++ b/lib/db/derivedtables/header.ts
@@ -1,7 +1,7 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface Header extends BaseComponent {
   // Extra columns
@@ -227,6 +227,7 @@ export const headerTableSpec: DerivedTableSpec<Header> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c),
         price1: extractMinQPrice(c.price)!,
         package: c.package || "",
         pitch_mm: pitch,

--- a/lib/db/derivedtables/io_expander.ts
+++ b/lib/db/derivedtables/io_expander.ts
@@ -1,7 +1,7 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface IoExpander extends BaseComponent {
   // Extra columns
@@ -139,6 +139,7 @@ export const ioExpanderTableSpec: DerivedTableSpec<IoExpander> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c),
         package: c.package || "",
         num_gpios: numGpios,
         supply_voltage_min: voltageMin,

--- a/lib/db/derivedtables/jst_connector.ts
+++ b/lib/db/derivedtables/jst_connector.ts
@@ -1,8 +1,8 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { KyselyDatabaseInstance } from "../kysely-types"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface JstConnector extends BaseComponent {
   package: string
@@ -69,6 +69,7 @@ export const jstConnectorTableSpec: DerivedTableSpec<JstConnector> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c),
           package: String(c.package || ""),
           pitch_mm: parseNum(attrs["Pitch"]),
           num_rows: isNaN(numRows) ? null : numRows,

--- a/lib/db/derivedtables/lcd_display.ts
+++ b/lib/db/derivedtables/lcd_display.ts
@@ -1,7 +1,7 @@
-import type { DerivedTableSpec } from "./types"
-import type { KyselyDatabaseInstance } from "../kysely-types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface LCDDisplay extends BaseComponent {
   package?: string
@@ -64,6 +64,7 @@ export const lcdDisplayTableSpec: DerivedTableSpec<LCDDisplay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c),
           package: String(c.package || ""),
           display_size,
           resolution,

--- a/lib/db/derivedtables/led.ts
+++ b/lib/db/derivedtables/led.ts
@@ -1,7 +1,7 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface Led extends BaseComponent {
   package: string
@@ -165,6 +165,7 @@ export const ledTableSpec: DerivedTableSpec<Led> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c),
         package: c.package || "",
         forward_voltage: forwardVoltage,
         forward_current: forwardCurrent,

--- a/lib/db/derivedtables/led_dot_matrix_display.ts
+++ b/lib/db/derivedtables/led_dot_matrix_display.ts
@@ -1,7 +1,7 @@
-import type { DerivedTableSpec } from "./types"
-import type { KyselyDatabaseInstance } from "../kysely-types"
-import { BaseComponent } from "./component-base"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface LEDDotMatrixDisplay extends BaseComponent {
   package?: string
@@ -57,6 +57,7 @@ export const ledDotMatrixDisplayTableSpec: DerivedTableSpec<LEDDotMatrixDisplay>
             in_stock: Boolean((c.stock || 0) > 0),
             is_basic: Boolean(c.basic),
             is_preferred: Boolean(c.preferred),
+            is_extended_promotional: isExtendedPromotional(c),
             package: String(c.package || ""),
             matrix_size,
             color,

--- a/lib/db/derivedtables/led_driver.ts
+++ b/lib/db/derivedtables/led_driver.ts
@@ -1,15 +1,15 @@
-import type { DerivedTableSpec } from "./types"
-import type { SelectQueryBuilder, Generated } from "kysely"
+import type { Generated, SelectQueryBuilder } from "kysely"
 import type { Component } from "../generated/kysely"
 import type { KyselyDatabaseInstance } from "../kysely-types"
+import type { DerivedTableSpec } from "./types"
 
 type UnwrapGenerated<T> = {
   [K in keyof T]: T[K] extends Generated<infer U> ? U : T[K]
 }
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import { parseIntOrNull } from "lib/util/parse-int-or-null"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface LedDriver extends BaseComponent {
   // Optional LED driver specific fields
@@ -77,6 +77,7 @@ export const ledDriverTableSpec: DerivedTableSpec<LedDriver> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c),
           package: String(c.package || ""),
           supply_voltage_min: parseValue(attrs["Input Voltage"]?.split("~")[0]),
           supply_voltage_max: parseValue(attrs["Input Voltage"]?.split("~")[1]),

--- a/lib/db/derivedtables/led_segment_display.ts
+++ b/lib/db/derivedtables/led_segment_display.ts
@@ -1,7 +1,7 @@
-import type { DerivedTableSpec } from "./types"
-import type { KyselyDatabaseInstance } from "../kysely-types"
-import { BaseComponent } from "./component-base"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 const LED_SEGMENT_SUBCATEGORIES = [
   "Led Segment Display",
@@ -91,6 +91,7 @@ export const ledSegmentDisplayTableSpec: DerivedTableSpec<LEDSegmentDisplay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c),
           package: String(c.package || ""),
           positions,
           type,

--- a/lib/db/derivedtables/led_with_ic.ts
+++ b/lib/db/derivedtables/led_with_ic.ts
@@ -1,11 +1,11 @@
-import type { DerivedTableSpec } from "./types"
-import { BaseComponent } from "./component-base"
-import type { SelectQueryBuilder, Generated } from "kysely"
+import type { Generated, SelectQueryBuilder } from "kysely"
 import type { Component } from "../generated/kysely"
 import type { KyselyDatabaseInstance } from "../kysely-types"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 
 export interface LEDWithIC extends BaseComponent {
   package?: string
@@ -99,6 +99,7 @@ export const ledWithICTableSpec: DerivedTableSpec<LEDWithIC> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c),
           package: String(c.package || ""),
           forward_voltage: forwardVoltage,
           forward_current: forwardCurrent,

--- a/lib/db/derivedtables/microcontroller.ts
+++ b/lib/db/derivedtables/microcontroller.ts
@@ -1,7 +1,7 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface Microcontroller extends BaseComponent {
   // Extra columns
@@ -228,6 +228,7 @@ export const microcontrollerTableSpec: DerivedTableSpec<Microcontroller> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c),
         package: c.package || "",
         cpu_core: cpuCore,
         cpu_speed_hz: cpuSpeed,

--- a/lib/db/derivedtables/mosfet.ts
+++ b/lib/db/derivedtables/mosfet.ts
@@ -1,15 +1,15 @@
-import type { DerivedTableSpec } from "./types"
-import type { SelectQueryBuilder, Generated } from "kysely"
+import type { Generated, SelectQueryBuilder } from "kysely"
 import type { Component } from "../generated/kysely"
 import type { KyselyDatabaseInstance } from "../kysely-types"
+import type { DerivedTableSpec } from "./types"
 
 type UnwrapGenerated<T> = {
   [K in keyof T]: T[K] extends Generated<infer U> ? U : T[K]
 }
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import { parseIntOrNull } from "lib/util/parse-int-or-null"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 
 export interface Mosfet extends BaseComponent {
   package?: string
@@ -68,6 +68,7 @@ export const mosfetTableSpec: DerivedTableSpec<Mosfet> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c),
           package: String(c.package || ""),
           drain_source_voltage: parseValue(
             attrs["Drain Source Voltage (Vdss)"],

--- a/lib/db/derivedtables/oled_display.ts
+++ b/lib/db/derivedtables/oled_display.ts
@@ -1,7 +1,7 @@
-import type { DerivedTableSpec } from "./types"
-import type { KyselyDatabaseInstance } from "../kysely-types"
-import { BaseComponent } from "./component-base"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface OLEDDisplay extends BaseComponent {
   package?: string
@@ -65,6 +65,7 @@ export const oledDisplayTableSpec: DerivedTableSpec<OLEDDisplay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c),
           package: String(c.package || ""),
           protocol: protocol || undefined,
           display_width,

--- a/lib/db/derivedtables/pcie_m2_connector.ts
+++ b/lib/db/derivedtables/pcie_m2_connector.ts
@@ -1,6 +1,6 @@
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface PcieM2Connector extends BaseComponent {
   key: string | null
@@ -49,6 +49,7 @@ export const pcieM2ConnectorTableSpec: DerivedTableSpec<PcieM2Connector> = {
         in_stock: Boolean((c.stock || 0) > 0),
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c),
         key,
         is_right_angle: isRightAngle,
         attributes: attrs,

--- a/lib/db/derivedtables/potentiometer.ts
+++ b/lib/db/derivedtables/potentiometer.ts
@@ -1,7 +1,7 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface Potentiometer extends BaseComponent {
   max_resistance: number
@@ -67,6 +67,7 @@ export const potentiometerTableSpec: DerivedTableSpec<Potentiometer> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c),
         max_resistance: maxResistance,
         pin_variant: pinVariant,
         package: c.package || "",

--- a/lib/db/derivedtables/relay.ts
+++ b/lib/db/derivedtables/relay.ts
@@ -1,9 +1,9 @@
+import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
 import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import { parseIntOrNull } from "lib/util/parse-int-or-null"
-import type { DerivedTableSpec } from "./types"
-import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
 import type { KyselyDatabaseInstance } from "../kysely-types"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface Relay extends BaseComponent {
   package: string
@@ -62,6 +62,7 @@ export const relayTableSpec: DerivedTableSpec<Relay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c),
           package: String(c.package || ""),
           relay_type: (c as any).subcategory || "",
           contact_form: attrs["Contact Form"] || null,

--- a/lib/db/derivedtables/resistor.ts
+++ b/lib/db/derivedtables/resistor.ts
@@ -1,7 +1,7 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface Resistor extends BaseComponent {
   resistance: number
@@ -82,6 +82,7 @@ export const resistorTableSpec: DerivedTableSpec<Resistor> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c),
         resistance: resistance,
         tolerance_fraction: tolerance,
         power_watts,

--- a/lib/db/derivedtables/resistor_array.ts
+++ b/lib/db/derivedtables/resistor_array.ts
@@ -1,7 +1,7 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
 import type { DerivedTableSpec } from "./types"
-import { BaseComponent } from "./component-base"
 
 export interface ResistorArray extends BaseComponent {
   package: string
@@ -124,6 +124,7 @@ export const resistorArrayTableSpec: DerivedTableSpec<ResistorArray> = {
         in_stock: component.stock > 0,
         is_basic: Boolean(component.basic),
         is_preferred: Boolean(component.preferred),
+        is_extended_promotional: isExtendedPromotional(component),
         package: component.package ?? "",
         resistance,
         tolerance_fraction: tolerance,

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -1,5 +1,4 @@
 import { sql } from "kysely"
-import { getDbClient } from "lib/db/get-db-client"
 import { accelerometerTableSpec } from "lib/db/derivedtables/accelerometer"
 import { adcTableSpec } from "lib/db/derivedtables/adc"
 import { analogMultiplexerTableSpec } from "lib/db/derivedtables/analog_multiplexer"
@@ -10,8 +9,8 @@ import { buckBoostConverterTableSpec } from "lib/db/derivedtables/buck_boost_con
 import { capacitorTableSpec } from "lib/db/derivedtables/capacitor"
 import { dacTableSpec } from "lib/db/derivedtables/dac"
 import { diodeTableSpec } from "lib/db/derivedtables/diode"
-import { fpgaTableSpec } from "lib/db/derivedtables/fpga"
 import { fpcConnectorTableSpec } from "lib/db/derivedtables/fpc_connector"
+import { fpgaTableSpec } from "lib/db/derivedtables/fpga"
 import { fuseTableSpec } from "lib/db/derivedtables/fuse"
 import { gasSensorTableSpec } from "lib/db/derivedtables/gas_sensor"
 import { gyroscopeTableSpec } from "lib/db/derivedtables/gyroscope"
@@ -19,26 +18,27 @@ import { headerTableSpec } from "lib/db/derivedtables/header"
 import { ioExpanderTableSpec } from "lib/db/derivedtables/io_expander"
 import { jstConnectorTableSpec } from "lib/db/derivedtables/jst_connector"
 import { lcdDisplayTableSpec } from "lib/db/derivedtables/lcd_display"
+import { ldoTableSpec } from "lib/db/derivedtables/ldo"
+import { ledTableSpec } from "lib/db/derivedtables/led"
 import { ledDotMatrixDisplayTableSpec } from "lib/db/derivedtables/led_dot_matrix_display"
 import { ledDriverTableSpec } from "lib/db/derivedtables/led_driver"
 import { ledSegmentDisplayTableSpec } from "lib/db/derivedtables/led_segment_display"
-import { ledTableSpec } from "lib/db/derivedtables/led"
 import { ledWithICTableSpec } from "lib/db/derivedtables/led_with_ic"
-import { ldoTableSpec } from "lib/db/derivedtables/ldo"
 import { microcontrollerTableSpec } from "lib/db/derivedtables/microcontroller"
 import { mosfetTableSpec } from "lib/db/derivedtables/mosfet"
 import { oledDisplayTableSpec } from "lib/db/derivedtables/oled_display"
 import { pcieM2ConnectorTableSpec } from "lib/db/derivedtables/pcie_m2_connector"
 import { potentiometerTableSpec } from "lib/db/derivedtables/potentiometer"
 import { relayTableSpec } from "lib/db/derivedtables/relay"
-import { resistorArrayTableSpec } from "lib/db/derivedtables/resistor_array"
 import { resistorTableSpec } from "lib/db/derivedtables/resistor"
+import { resistorArrayTableSpec } from "lib/db/derivedtables/resistor_array"
 import { switchTableSpec } from "lib/db/derivedtables/switch"
 import type { DerivedTableSpec } from "lib/db/derivedtables/types"
 import { usbCConnectorTableSpec } from "lib/db/derivedtables/usb_c_connector"
 import { voltageRegulatorTableSpec } from "lib/db/derivedtables/voltage_regulator"
 import { wifiModuleTableSpec } from "lib/db/derivedtables/wifi_module"
 import { wireToBoardConnectorTableSpec } from "lib/db/derivedtables/wire_to_board_connector"
+import { getDbClient } from "lib/db/get-db-client"
 import type { KyselyDatabaseInstance } from "lib/db/kysely-types"
 
 export const DERIVED_TABLES: DerivedTableSpec<any>[] = [
@@ -130,6 +130,7 @@ const createTable = async (
     { name: "stock", type: "integer" },
     { name: "price1", type: "real" },
     { name: "in_stock", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ].concat(spec.extraColumns as any, [{ name: "attributes", type: "text" }])) {
     tableCreator = tableCreator.addColumn(
       col.name as string,

--- a/lib/db/derivedtables/switch.ts
+++ b/lib/db/derivedtables/switch.ts
@@ -1,7 +1,7 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface Switch extends BaseComponent {
   package: string
@@ -91,6 +91,7 @@ export const switchTableSpec: DerivedTableSpec<Switch> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c),
         package: c.package || "",
         switch_type: (c as any).subcategory || "",
         circuit: attrs["Circuit"] || null,

--- a/lib/db/derivedtables/types.ts
+++ b/lib/db/derivedtables/types.ts
@@ -15,6 +15,7 @@ export interface DerivedTableSpec<
     price1: number | null
     in_stock: boolean
     is_basic: boolean
+    is_extended_promotional: boolean
   },
 > {
   tableName: string

--- a/lib/db/derivedtables/usb_c_connector.ts
+++ b/lib/db/derivedtables/usb_c_connector.ts
@@ -1,8 +1,8 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { KyselyDatabaseInstance } from "../kysely-types"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface UsbCConnector extends BaseComponent {
   package: string
@@ -69,6 +69,7 @@ export const usbCConnectorTableSpec: DerivedTableSpec<UsbCConnector> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: isExtendedPromotional(c),
           package: String(c.package || ""),
           mounting_style: attrs["Mounting Style"] || null,
           current_rating_a: parseNum(attrs["Current Rating - Power (Max)"]),

--- a/lib/db/derivedtables/voltage_regulator.ts
+++ b/lib/db/derivedtables/voltage_regulator.ts
@@ -1,7 +1,7 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface VoltageRegulator extends BaseComponent {
   package: string
@@ -184,6 +184,7 @@ export const voltageRegulatorTableSpec: DerivedTableSpec<VoltageRegulator> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c),
         package: c.package || "",
         output_type: outputType,
         output_voltage_min: voltageMin,

--- a/lib/db/derivedtables/wifi_module.ts
+++ b/lib/db/derivedtables/wifi_module.ts
@@ -1,7 +1,7 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
-import type { DerivedTableSpec } from "./types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import { BaseComponent } from "./component-base"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import { BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface WifiModule extends BaseComponent {
   package: string
@@ -140,6 +140,7 @@ export const wifiModuleTableSpec: DerivedTableSpec<WifiModule> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: isExtendedPromotional(c),
         package: c.package || "",
         core_processor: attrs["Core Processor"] || null,
         antenna_type: attrs["Antenna Type"] || null,

--- a/lib/db/derivedtables/wire_to_board_connector.ts
+++ b/lib/db/derivedtables/wire_to_board_connector.ts
@@ -1,8 +1,8 @@
-import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
-import type { BaseComponent } from "./component-base"
-import type { DerivedTableSpec } from "./types"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
 import type { KyselyDatabaseInstance } from "../kysely-types"
+import { type BaseComponent, isExtendedPromotional } from "./component-base"
+import type { DerivedTableSpec } from "./types"
 
 export interface WireToBoardConnector extends BaseComponent {
   package: string
@@ -100,6 +100,7 @@ export const wireToBoardConnectorTableSpec: DerivedTableSpec<WireToBoardConnecto
             in_stock: Boolean((c.stock || 0) > 0),
             is_basic: Boolean(c.basic),
             is_preferred: Boolean(c.preferred),
+            is_extended_promotional: isExtendedPromotional(c),
             package: String(c.package || ""),
             pitch_mm: pitchMm,
             num_rows: numRows,

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -17,6 +17,7 @@ export interface Accelerometer {
   has_spi: number | null;
   has_uart: number | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   is_basic: number | null;
   is_preferred: number | null;
   lcsc: Generated<number | null>;
@@ -39,6 +40,7 @@ export interface Adc {
   has_spi: number | null;
   has_uart: number | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   is_differential: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
@@ -63,6 +65,7 @@ export interface AnalogMultiplexer {
   has_parallel_interface: number | null;
   has_spi: number | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   leakage_current_na: number | null;
   mfr: string | null;
@@ -84,6 +87,7 @@ export interface BatteryHolder {
   connector_type: string | null;
   description: string | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   is_basic: number | null;
   is_preferred: number | null;
   lcsc: Generated<number | null>;
@@ -102,6 +106,7 @@ export interface BjtTransistor {
   current_gain: number | null;
   description: string | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   package: string | null;
@@ -116,6 +121,7 @@ export interface BoostConverter {
   attributes: string | null;
   description: string | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   input_voltage_max: number | null;
   input_voltage_min: number | null;
   is_basic: number | null;
@@ -138,6 +144,7 @@ export interface BuckBoostConverter {
   attributes: string | null;
   description: string | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   input_voltage_max: number | null;
   input_voltage_min: number | null;
   is_basic: number | null;
@@ -163,6 +170,7 @@ export interface Capacitor {
   description: string | null;
   esr_ohms: number | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   is_basic: number | null;
   is_polarized: number | null;
   is_preferred: number | null;
@@ -192,6 +200,7 @@ export interface Component {
   description: string;
   extra: string | null;
   flag: Generated<number>;
+  is_extended_promotional: Generated<number>;
   joints: number;
   last_on_stock: Generated<number>;
   last_update: number;
@@ -247,6 +256,7 @@ export interface Dac {
   has_parallel_interface: number | null;
   has_spi: number | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   nonlinearity_lsb: number | null;
@@ -271,6 +281,7 @@ export interface Diode {
   forward_current: number | null;
   forward_voltage: number | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   is_schottky: number | null;
   is_tvs: number | null;
   is_zener: number | null;
@@ -292,6 +303,7 @@ export interface FpcConnector {
   contact_type: string | null;
   description: string | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   is_basic: number | null;
   is_preferred: number | null;
   lcsc: Generated<number | null>;
@@ -308,6 +320,7 @@ export interface Fpga {
   description: string | null;
   embedded_ram_bits: number | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   is_basic: number | null;
   is_preferred: number | null;
   lcsc: Generated<number | null>;
@@ -331,6 +344,7 @@ export interface Fuse {
   current_rating: number | null;
   description: string | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   is_glass_encased: number | null;
   is_resettable: number | null;
   is_surface_mount: number | null;
@@ -347,6 +361,7 @@ export interface GasSensor {
   attributes: string | null;
   description: string | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   is_basic: number | null;
   is_preferred: number | null;
   lcsc: Generated<number | null>;
@@ -376,6 +391,7 @@ export interface Gyroscope {
   has_spi: number | null;
   has_uart: number | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   is_basic: number | null;
   is_preferred: number | null;
   lcsc: Generated<number | null>;
@@ -397,6 +413,7 @@ export interface Header {
   description: string | null;
   gender: string | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   insulation_height_mm: number | null;
   is_right_angle: number | null;
   is_shrouded: number | null;
@@ -426,6 +443,7 @@ export interface IoExpander {
   has_smbus: number | null;
   has_spi: number | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   num_gpios: number | null;
@@ -445,6 +463,7 @@ export interface JstConnector {
   attributes: string | null;
   description: string | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   is_basic: number | null;
   is_preferred: number | null;
   lcsc: Generated<number | null>;
@@ -464,6 +483,7 @@ export interface LcdDisplay {
   display_size: string | null;
   display_type: string | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   package: string | null;
@@ -477,6 +497,7 @@ export interface Ldo {
   description: string | null;
   dropout_voltage: number | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   input_voltage_max: number | null;
   input_voltage_min: number | null;
   is_basic: number | null;
@@ -506,6 +527,7 @@ export interface Led {
   forward_current: number | null;
   forward_voltage: number | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   is_rgb: number | null;
   lcsc: Generated<number | null>;
   lens_color: string | null;
@@ -527,6 +549,7 @@ export interface LedDotMatrixDisplay {
   color: string | null;
   description: string | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   matrix_size: string | null;
   mfr: string | null;
@@ -542,6 +565,7 @@ export interface LedDriver {
   dimming_method: string | null;
   efficiency_percent: number | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   mounting_style: string | null;
@@ -561,6 +585,7 @@ export interface LedSegmentDisplay {
   color: string | null;
   description: string | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   package: string | null;
@@ -578,6 +603,7 @@ export interface LedWithIc {
   forward_current: number | null;
   forward_voltage: number | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   mounting_style: string | null;
@@ -615,6 +641,7 @@ export interface Microcontroller {
   has_usb: number | null;
   has_watchdog: number | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
@@ -634,6 +661,7 @@ export interface Mosfet {
   drain_source_voltage: number | null;
   gate_threshold_voltage: number | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   mounting_style: string | null;
@@ -650,6 +678,7 @@ export interface OledDisplay {
   description: string | null;
   display_width: string | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   package: string | null;
@@ -663,6 +692,7 @@ export interface PcieM2Connector {
   attributes: string | null;
   description: string | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   is_basic: number | null;
   is_preferred: number | null;
   is_right_angle: number | null;
@@ -677,6 +707,7 @@ export interface Potentiometer {
   attributes: string | null;
   description: string | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   is_surface_mount: number | null;
   lcsc: Generated<number | null>;
   max_resistance: number | null;
@@ -694,6 +725,7 @@ export interface Relay {
   contact_form: string | null;
   description: string | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   is_basic: number | null;
   is_preferred: number | null;
   lcsc: Generated<number | null>;
@@ -711,6 +743,7 @@ export interface Resistor {
   attributes: string | null;
   description: string | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   is_basic: number | null;
   is_multi_resistor_chip: number | null;
   is_potentiometer: number | null;
@@ -733,6 +766,7 @@ export interface ResistorArray {
   attributes: string | null;
   description: string | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   is_basic: number | null;
   is_preferred: number | null;
   is_surface_mount: number | null;
@@ -756,6 +790,7 @@ export interface Switch {
   current_rating_a: number | null;
   description: string | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   is_basic: number | null;
   is_latching: number | null;
   is_preferred: number | null;
@@ -781,6 +816,7 @@ export interface UsbCConnector {
   description: string | null;
   gender: string | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   is_basic: number | null;
   is_preferred: number | null;
   lcsc: Generated<number | null>;
@@ -802,6 +838,7 @@ export interface VComponent {
   datasheet: string | null;
   description: string | null;
   extra: string | null;
+  is_extended_promotional: number | null;
   joints: number | null;
   last_on_stock: number | null;
   lcsc: number | null;
@@ -819,6 +856,7 @@ export interface VoltageRegulator {
   description: string | null;
   dropout_voltage: number | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   input_voltage_max: number | null;
   input_voltage_min: number | null;
   is_low_dropout: number | null;
@@ -853,6 +891,7 @@ export interface WifiModule {
   has_spi: number | null;
   has_uart: number | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
@@ -872,6 +911,7 @@ export interface WireToBoardConnector {
   description: string | null;
   gender: string | null;
   in_stock: number | null;
+  is_extended_promotional: number | null;
   is_basic: number | null;
   is_preferred: number | null;
   is_smd: number | null;

--- a/lib/db/optimizations/component-extended-promotional-column.ts
+++ b/lib/db/optimizations/component-extended-promotional-column.ts
@@ -1,0 +1,40 @@
+import { sql } from "kysely"
+import type { DbOptimizationSpec } from "./types"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+
+export const componentExtendedPromotionalColumn: DbOptimizationSpec = {
+  name: "add_components_is_extended_promotional_column",
+  description:
+    "Adds is_extended_promotional generated column derived from JLCPCB source flags",
+
+  async checkIfAdded(db: KyselyDatabaseInstance) {
+    const result = await sql<{ name: string }>`
+      PRAGMA table_xinfo(components)
+    `.execute(db)
+
+    return result.rows.some((row) => row.name === "is_extended_promotional")
+  },
+
+  async execute(db: KyselyDatabaseInstance) {
+    await sql`
+      ALTER TABLE components
+      ADD COLUMN is_extended_promotional boolean
+      GENERATED ALWAYS AS (
+        CASE
+          WHEN json_valid(extra)
+            AND json_extract(extra, '$.componentLibraryType') IN ('expand', 'expandPrefer')
+          THEN 1
+          WHEN preferred = 1 AND basic = 0
+          THEN 1
+          ELSE 0
+        END
+      )
+    `.execute(db)
+
+    await db.schema
+      .createIndex("idx_components_is_extended_promotional")
+      .on("components")
+      .column("is_extended_promotional")
+      .execute()
+  },
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "better-sqlite3": "^11.7.0",
     "kysely": "^0.28.3",
     "kysely-codegen": "^0.17.0",
+    "kysely-d1": "^0.4.0",
+    "vitest": "^2.1.0",
     "winterspec": "^0.0.96"
   },
   "peerDependencies": {

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -1,7 +1,7 @@
 import { sql } from "kysely"
 import {
-  buildSearchTokenGroups,
   type SearchTokenGroup,
+  buildSearchTokenGroups,
   tokenizeSearchTerm,
 } from "lib/util/search-token-groups"
 import { withWinterSpec } from "lib/with-winter-spec"
@@ -40,6 +40,17 @@ const ftsGroupQuery = (group: SearchTokenGroup): string => {
     : `(${tokenQueries.join(" OR ")})`
 }
 
+const isExtendedPromotionalSql = sql<number>`
+  CASE
+    WHEN json_valid(extra)
+      AND json_extract(extra, '$.componentLibraryType') IN ('expand', 'expandPrefer')
+    THEN 1
+    WHEN preferred = 1 AND basic = 0
+    THEN 1
+    ELSE 0
+  END
+`
+
 export default withWinterSpec({
   auth: "none",
   methods: ["GET"],
@@ -50,6 +61,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -58,6 +70,7 @@ export default withWinterSpec({
   let query = ctx.db
     .selectFrom("components")
     .selectAll()
+    .select(isExtendedPromotionalSql.as("is_extended_promotional"))
     .limit(limit)
     .orderBy("stock", "desc")
     .where("stock", ">", 0)
@@ -71,6 +84,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where(sql<boolean>`${isExtendedPromotionalSql} = 1`)
   }
 
   const baseQuery = query
@@ -193,6 +209,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.is_extended_promotional),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -1,6 +1,6 @@
 import { sql } from "kysely"
-import { Table } from "lib/ui/Table"
 import { ExpressionBuilder } from "kysely"
+import { Table } from "lib/ui/Table"
 import { buildSearchTokenGroups } from "lib/util/search-token-groups"
 import { withWinterSpec } from "lib/with-winter-spec"
 import { z } from "zod"
@@ -25,6 +25,17 @@ const ftsGroupQuery = (group: string[]): string => {
     : `(${tokenQueries.join(" OR ")})`
 }
 
+const isExtendedPromotionalSql = sql<number>`
+  CASE
+    WHEN json_valid(extra)
+      AND json_extract(extra, '$.componentLibraryType') IN ('expand', 'expandPrefer')
+    THEN 1
+    WHEN preferred = 1 AND basic = 0
+    THEN 1
+    ELSE 0
+  END
+`
+
 export default withWinterSpec({
   auth: "none",
   methods: ["GET"],
@@ -35,6 +46,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -51,6 +63,8 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
+      isExtendedPromotionalSql.as("is_extended_promotional"),
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -69,6 +83,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where(sql<boolean>`${isExtendedPromotionalSql} = 1`)
   }
 
   if (req.query.search) {
@@ -111,6 +128,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.is_extended_promotional),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +170,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/scripts/setup-7z.ts
+++ b/scripts/setup-7z.ts
@@ -1,16 +1,16 @@
-import { mkdir, chmod } from "node:fs/promises"
 import { existsSync } from "node:fs"
-import { platform, arch } from "node:os"
+import { chmod, mkdir } from "node:fs/promises"
+import { arch, platform } from "node:os"
 
 const BINARY_DIR = ".bin"
 const BINARY_NAME = "7zz"
 
 // Map of platform-arch combinations to download URLs
 const BINARY_URLS: Record<string, string> = {
-  "linux-x64": "https://7-zip.org/a/7z2408-linux-x64.tar.xz",
-  "linux-arm64": "https://7-zip.org/a/7z2408-linux-arm64.tar.xz",
-  "darwin-x64": "https://7-zip.org/a/7z2408-mac.tar.xz",
-  "darwin-arm64": "https://7-zip.org/a/7z2408-mac.tar.xz",
+  "linux-x64": "https://7-zip.org/a/7z2601-linux-x64.tar.xz",
+  "linux-arm64": "https://7-zip.org/a/7z2601-linux-arm64.tar.xz",
+  "darwin-x64": "https://7-zip.org/a/7z2601-mac.tar.xz",
+  "darwin-arm64": "https://7-zip.org/a/7z2601-mac.tar.xz",
 }
 
 async function downloadAndExtract7z() {

--- a/scripts/setup-db-optimizations.ts
+++ b/scripts/setup-db-optimizations.ts
@@ -42,6 +42,11 @@ async function main() {
 
   await db.destroy()
 
+  if (process.env.SKIP_DB_VACUUM === "true") {
+    console.log("Skipping VACUUM because SKIP_DB_VACUUM=true")
+    return
+  }
+
   const bunDb = getBunDatabaseClient()
   console.log("Running VACUUM to optimize database...")
   await bunDb.exec("VACUUM")

--- a/scripts/setup-db-optimizations.ts
+++ b/scripts/setup-db-optimizations.ts
@@ -1,20 +1,22 @@
 import { getBunDatabaseClient, getDbClient } from "lib/db/get-db-client"
-import { componentStockIndex } from "lib/db/optimizations/component-stock-index"
-import { componentInStockColumn } from "lib/db/optimizations/component-in-stock-column"
-import { removeStaleComponents } from "lib/db/optimizations/remove-stale-components"
-import { componentCategoryIndex } from "lib/db/optimizations/component-category-index"
-import { componentInStockCategoryIndex } from "lib/db/optimizations/component-in-stock-category-index"
-import type { DbOptimizationSpec } from "lib/db/optimizations/types"
-import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
-import { componentPackageIndex } from "lib/db/optimizations/component-indexes"
 import { componentBasicIndex } from "lib/db/optimizations/component-basic-index"
+import { componentCategoryIndex } from "lib/db/optimizations/component-category-index"
+import { componentExtendedPromotionalColumn } from "lib/db/optimizations/component-extended-promotional-column"
+import { componentInStockCategoryIndex } from "lib/db/optimizations/component-in-stock-category-index"
+import { componentInStockColumn } from "lib/db/optimizations/component-in-stock-column"
+import { componentPackageIndex } from "lib/db/optimizations/component-indexes"
 import { componentPreferredIndex } from "lib/db/optimizations/component-preferred-index"
+import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
+import { componentStockIndex } from "lib/db/optimizations/component-stock-index"
+import { removeStaleComponents } from "lib/db/optimizations/remove-stale-components"
+import type { DbOptimizationSpec } from "lib/db/optimizations/types"
 
 const OPTIMIZATIONS: DbOptimizationSpec[] = [
   componentSearchFTS,
   componentPackageIndex,
   componentBasicIndex,
   componentPreferredIndex,
+  componentExtendedPromotionalColumn,
   removeStaleComponents,
   componentStockIndex,
   componentInStockColumn,

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -1,5 +1,6 @@
 import { afterEach } from "bun:test"
 import { setupDerivedTables } from "lib/db/derivedtables/setup-derived-tables"
+import { getDbClient } from "lib/db/get-db-client"
 
 declare global {
   var deferredCleanupFns: Array<() => void | Promise<void>>
@@ -7,7 +8,10 @@ declare global {
 }
 
 globalThis.deferredCleanupFns ??= []
-globalThis.derivedTablesSetupPromise ??= setupDerivedTables({ populate: false })
+globalThis.derivedTablesSetupPromise ??= setupDerivedTables({
+  db: getDbClient(),
+  populate: false,
+})
 
 await globalThis.derivedTablesSetupPromise
 

--- a/tests/routes/components/extended-promotional.test.ts
+++ b/tests/routes/components/extended-promotional.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("GET /components/list exposes and filters extended promotional components", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get(
+    "/components/list?json=true&is_extended_promotional=true",
+  )
+
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+  expect(res.data.components.length).toBeGreaterThan(0)
+  expect(
+    res.data.components.every(
+      (component: any) => component.is_extended_promotional === true,
+    ),
+  ).toBe(true)
+})
+
+test("GET /api/search exposes and filters extended promotional components", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/api/search?is_extended_promotional=true")
+
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+  expect(res.data.components.length).toBeGreaterThan(0)
+  expect(
+    res.data.components.every(
+      (component: any) => component.is_extended_promotional === true,
+    ),
+  ).toBe(true)
+})


### PR DESCRIPTION
/claim #92

Summary:
- add `is_extended_promotional` as a generated `components` column, derived from JLCPCB `componentLibraryType` (`expand` / `expandPrefer`) with a `preferred = 1 AND basic = 0` fallback
- expose `is_extended_promotional` in `/components/list` and `/api/search`, including filtering and UI checkbox support
- propagate the flag into derived tables/types and Cloudflare D1 search/component catalog paths
- update D1 search-index rebuild scripts and add focused route tests

Verification:
- `./node_modules/.bin/tsc.exe --noEmit`
- `npx bun test --preload ./tests/preload.ts tests/routes/components/extended-promotional.test.ts`
- `cd cf-proxy && ./node_modules/.bin/tsc.cmd --noEmit`
- `cd cf-proxy && npm test`

AI-assisted with Codex.