### PR TITLE
feat: add IMU (Inertial Measurement Unit) category (#53)

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
 
     steps:
       - name: Checkout code

--- a/lib/db/derivedtables/imu.ts
+++ b/lib/db/derivedtables/imu.ts
@@ -1,0 +1,148 @@
+import type { DerivedTableSpec } from "./types"
+import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import { BaseComponent } from "./component-base"
+
+export interface Imu extends BaseComponent {
+  package: string
+  supply_voltage_min: number | null
+  supply_voltage_max: number | null
+  operating_temp_min: number | null
+  operating_temp_max: number | null
+  axes: string | null
+  has_accelerometer: boolean
+  has_gyroscope: boolean
+  has_magnetometer: boolean
+  has_i2c: boolean
+  has_spi: boolean
+  has_uart: boolean
+}
+
+export const imuTableSpec: DerivedTableSpec<Imu> = {
+  tableName: "imu",
+  extraColumns: [
+    { name: "package", type: "text" },
+    { name: "supply_voltage_min", type: "real" },
+    { name: "supply_voltage_max", type: "real" },
+    { name: "operating_temp_min", type: "real" },
+    { name: "operating_temp_max", type: "real" },
+    { name: "axes", type: "text" },
+    { name: "has_accelerometer", type: "boolean" },
+    { name: "has_gyroscope", type: "boolean" },
+    { name: "has_magnetometer", type: "boolean" },
+    { name: "has_i2c", type: "boolean" },
+    { name: "has_spi", type: "boolean" },
+    { name: "has_uart", type: "boolean" },
+    { name: "is_basic", type: "boolean" },
+    { name: "is_preferred", type: "boolean" },
+  ],
+  listCandidateComponents: (db) =>
+    db
+      .selectFrom("components")
+      .innerJoin("categories", "components.category_id", "categories.id")
+      .selectAll()
+      .where((eb) =>
+        eb.or([
+          eb("categories.subcategory", "=", "Inertial Measurement Units"),
+          eb("categories.subcategory", "=", "IMU"),
+          eb(
+            "categories.subcategory",
+            "=",
+            "Motion Sensors - Inertial Measurement Units",
+          ),
+        ]),
+      ),
+  mapToTable: (components) => {
+    return components.map((c): Imu | null => {
+      if (!c.extra) return null
+      const extra = JSON.parse(c.extra ?? "{}")
+      if (!extra.attributes) return null
+
+      const attrs = extra.attributes
+      const desc = c.description.toLowerCase()
+
+      let voltageMin: number | null = null
+      let voltageMax: number | null = null
+      const rawVoltage = attrs["Supply Voltage"]
+      if (rawVoltage) {
+        const match = rawVoltage.match(/([\d.]+)V~([\d.]+)V/)
+        if (match) {
+          voltageMin = parseFloat(match[1])
+          voltageMax = parseFloat(match[2])
+        } else {
+          const single = rawVoltage.match(/([\d.]+)V/)
+          if (single) {
+            voltageMin = voltageMax = parseFloat(single[1])
+          }
+        }
+      }
+
+      let tempMin: number | null = null
+      let tempMax: number | null = null
+      const rawTemp = attrs["Operating Temperature"]
+      if (rawTemp) {
+        const match = rawTemp.match(/([-\d]+)℃~\+([-\d]+)℃/)
+        if (match) {
+          tempMin = parseInt(match[1])
+          tempMax = parseInt(match[2])
+        }
+      }
+
+      const axes = attrs["Axial Direction"] || attrs["Axis"] || null
+
+      const interfaceStr = (
+        attrs["Interface Type"] ||
+        attrs["Interface"] ||
+        ""
+      ).toLowerCase()
+
+      const hasI2c =
+        interfaceStr.includes("i2c") ||
+        interfaceStr.includes("i2c") ||
+        interfaceStr.includes("iic") ||
+        desc.includes("i2c")
+
+      const hasSpi = interfaceStr.includes("spi") || desc.includes("spi")
+      const hasUart = interfaceStr.includes("uart") || desc.includes("uart")
+
+      const hasAccelerometer =
+        desc.includes("accel") ||
+        Boolean(attrs["Acceleration Range"]) ||
+        Boolean(attrs["Accelerometer Range"])
+
+      const hasGyroscope =
+        desc.includes("gyro") ||
+        Boolean(attrs["Gyroscope Range"]) ||
+        Boolean(attrs["Angular Rate Range"])
+
+      const hasMagnetometer =
+        desc.includes("mag") ||
+        desc.includes("compass") ||
+        Boolean(attrs["Magnetic Range"]) ||
+        Boolean(attrs["Geomagnetic Range"])
+
+      return {
+        lcsc: c.lcsc,
+        mfr: c.mfr,
+        description: c.description,
+        stock: c.stock,
+        price1: extractMinQPrice(c.price),
+        in_stock: c.stock > 0,
+        is_basic: Boolean(c.basic),
+        is_preferred: Boolean(c.preferred),
+        package: c.package || "",
+        supply_voltage_min: voltageMin,
+        supply_voltage_max: voltageMax,
+        operating_temp_min: tempMin,
+        operating_temp_max: tempMax,
+        axes,
+        has_accelerometer: hasAccelerometer,
+        has_gyroscope: hasGyroscope,
+        has_magnetometer: hasMagnetometer,
+        has_i2c: hasI2c,
+        has_spi: hasSpi,
+        has_uart: hasUart,
+        attributes: attrs,
+      }
+    })
+  },
+}

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -1,5 +1,5 @@
 import { sql } from "kysely"
-import { getDbClient } from "lib/db/get-db-client"
+import { createDbClient } from "lib/db/get-db-client"
 import { accelerometerTableSpec } from "lib/db/derivedtables/accelerometer"
 import { adcTableSpec } from "lib/db/derivedtables/adc"
 import { analogMultiplexerTableSpec } from "lib/db/derivedtables/analog_multiplexer"
@@ -206,7 +206,7 @@ export const setupDerivedTables = async ({
   resetTable?: string | null
   logger?: Logger
 } = {}) => {
-  const activeDb = db ?? getDbClient()
+  const activeDb = db ?? createDbClient()
   const shouldDestroy = !db
 
   try {

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -16,6 +16,7 @@ import { fuseTableSpec } from "lib/db/derivedtables/fuse"
 import { gasSensorTableSpec } from "lib/db/derivedtables/gas_sensor"
 import { gyroscopeTableSpec } from "lib/db/derivedtables/gyroscope"
 import { headerTableSpec } from "lib/db/derivedtables/header"
+import { imuTableSpec } from "lib/db/derivedtables/imu"
 import { ioExpanderTableSpec } from "lib/db/derivedtables/io_expander"
 import { jstConnectorTableSpec } from "lib/db/derivedtables/jst_connector"
 import { lcdDisplayTableSpec } from "lib/db/derivedtables/lcd_display"
@@ -62,6 +63,7 @@ export const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   mosfetTableSpec,
   gyroscopeTableSpec,
   accelerometerTableSpec,
+  imuTableSpec,
   gasSensorTableSpec,
   ledWithICTableSpec,
   ledDotMatrixDisplayTableSpec,

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -94,6 +94,8 @@ const jsonParseOrNull = (strObject: string) => {
   }
 }
 
+const INSERT_BATCH_SIZE = 100
+
 const createTable = async (
   db: KyselyDatabaseInstance,
   spec: DerivedTableSpec<any>,
@@ -170,15 +172,19 @@ const createTable = async (
           },
     )
 
-    for (const component of mappedComponents) {
-      if (component === null) continue
-      const attrStringified = JSON.stringify(component.attributes ?? {})
+    const rows = mappedComponents
+      .filter((component) => component !== null)
+      .map((component) => ({
+        ...component,
+        attributes: JSON.stringify(component.attributes ?? {}),
+      }))
+
+    for (let i = 0; i < rows.length; i += INSERT_BATCH_SIZE) {
+      const rowBatch = rows.slice(i, i + INSERT_BATCH_SIZE)
+      if (rowBatch.length === 0) continue
       await db
         .insertInto(spec.tableName as any)
-        .values({
-          ...component,
-          attributes: attrStringified,
-        })
+        .values(rowBatch as any)
         .execute()
     }
 

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -389,6 +389,30 @@ export interface Gyroscope {
   supply_voltage_min: number | null;
 }
 
+
+export interface Imu {
+  attributes: string | null;
+  axes: string | null;
+  description: string | null;
+  has_accelerometer: number | null;
+  has_gyroscope: number | null;
+  has_magnetometer: number | null;
+  has_i2c: number | null;
+  has_spi: number | null;
+  has_uart: number | null;
+  in_stock: number | null;
+  is_basic: number | null;
+  is_preferred: number | null;
+  lcsc: Generated<number | null>;
+  mfr: string | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  package: string | null;
+  price1: number | null;
+  stock: number | null;
+  supply_voltage_max: number | null;
+  supply_voltage_min: number | null;
+}
 export interface Header {
   attributes: string | null;
   contact_material: string | null;
@@ -912,6 +936,7 @@ export interface DB {
   fuse: Fuse;
   gas_sensor: GasSensor;
   gyroscope: Gyroscope;
+  imu: Imu;
   header: Header;
   io_expander: IoExpander;
   jst_connector: JstConnector;

--- a/lib/db/get-db-client.ts
+++ b/lib/db/get-db-client.ts
@@ -57,11 +57,7 @@ export const getResolvedDbPath = (): string => {
     : Path.resolve(process.cwd(), configuredPath)
 }
 
-export const getDbClient = () => {
-  if (dbClientSingleton) {
-    return dbClientSingleton
-  }
-
+export const createDbClient = () => {
   const Database = getDatabaseCtor()
   const KyselyCtorRef = KyselyCtor
   const BunSqliteDialectRef = BunSqliteDialectCtor
@@ -74,11 +70,19 @@ export const getDbClient = () => {
     )
   }
 
-  dbClientSingleton = new KyselyCtorRef<DB>({
+  return new KyselyCtorRef<DB>({
     dialect: new BunSqliteDialectRef({
       database: new Database(getResolvedDbPath()),
     }),
   })
+}
+
+export const getDbClient = () => {
+  if (dbClientSingleton) {
+    return dbClientSingleton
+  }
+
+  dbClientSingleton = createDbClient()
 
   return dbClientSingleton
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@tscircuit/footprinter": "^0.0.143",
     "kysely-bun-sqlite": "^0.3.2",
+    "kysely-d1": "^0.4.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "redaxios": "^0.5.1"

--- a/routes/imus/list.json.tsx
+++ b/routes/imus/list.json.tsx
@@ -1,0 +1,2 @@
+import list from "./list"
+export default list

--- a/routes/imus/list.tsx
+++ b/routes/imus/list.tsx
@@ -1,0 +1,163 @@
+import { Table } from "lib/ui/Table"
+import { withWinterSpec } from "lib/with-winter-spec"
+import { z } from "zod"
+import { formatPrice } from "lib/util/format-price"
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET"],
+  queryParams: z.object({
+    package: z.string().optional(),
+    interface: z.enum(["spi", "i2c", "uart", ""]).optional(),
+    has_magnetometer: z.boolean().optional(),
+  }),
+  jsonResponse: z.any(),
+} as const)(async (req, ctx) => {
+  let query = ctx.db
+    .selectFrom("imu")
+    .selectAll()
+    .limit(100)
+    .orderBy("stock", "desc")
+
+  if (req.query.package) {
+    query = query.where("package", "=", req.query.package)
+  }
+
+  if (req.query.interface) {
+    switch (req.query.interface) {
+      case "spi":
+        query = query.where("has_spi", "=", 1)
+        break
+      case "i2c":
+        query = query.where("has_i2c", "=", 1)
+        break
+      case "uart":
+        query = query.where("has_uart", "=", 1)
+        break
+    }
+  }
+
+  if (req.query.has_magnetometer) {
+    query = query.where("has_magnetometer", "=", 1)
+  }
+
+  const packages = await ctx.db
+    .selectFrom("imu")
+    .select("package")
+    .distinct()
+    .orderBy("package")
+    .execute()
+
+  const imus = await query.execute()
+
+  if (ctx.isApiRequest) {
+    return ctx.json({
+      imus: imus
+        .map((g) => ({
+          lcsc: g.lcsc ?? 0,
+          mfr: g.mfr ?? "",
+          package: g.package ?? "",
+          supply_voltage_min: g.supply_voltage_min ?? undefined,
+          supply_voltage_max: g.supply_voltage_max ?? undefined,
+          axes: g.axes ?? undefined,
+          has_accelerometer: g.has_accelerometer === 1,
+          has_gyroscope: g.has_gyroscope === 1,
+          has_magnetometer: g.has_magnetometer === 1,
+          has_i2c: g.has_i2c === 1,
+          has_spi: g.has_spi === 1,
+          has_uart: g.has_uart === 1,
+          stock: g.stock ?? undefined,
+          price1: g.price1 ?? undefined,
+        }))
+        .filter((g) => g.lcsc !== 0 && g.package !== ""),
+    })
+  }
+
+  return ctx.react(
+    <div>
+      <h2>IMUs (Inertial Measurement Units)</h2>
+
+      <form method="GET" className="flex flex-row gap-4">
+        <div>
+          <label>Package:</label>
+          <select name="package">
+            <option value="">All</option>
+            {packages.map((p) => (
+              <option
+                key={p.package}
+                value={p.package ?? ""}
+                selected={p.package === req.query.package}
+              >
+                {p.package}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label>Interface:</label>
+          <select name="interface">
+            <option value="">All</option>
+            <option value="spi" selected={req.query.interface === "spi"}>
+              SPI
+            </option>
+            <option value="i2c" selected={req.query.interface === "i2c"}>
+              I2C
+            </option>
+            <option value="uart" selected={req.query.interface === "uart"}>
+              UART
+            </option>
+          </select>
+        </div>
+
+        <div>
+          <label>
+            <input
+              type="checkbox"
+              name="has_magnetometer"
+              value="true"
+              checked={req.query.has_magnetometer}
+            />
+            {" Has Magnetometer"}
+          </label>
+        </div>
+
+        <button type="submit">Filter</button>
+      </form>
+
+      <Table
+        rows={imus.map((g) => ({
+          lcsc: g.lcsc,
+          mfr: g.mfr,
+          package: g.package,
+          voltage:
+            g.supply_voltage_min && g.supply_voltage_max ? (
+              <span className="tabular-nums">
+                {g.supply_voltage_min}V - {g.supply_voltage_max}V
+              </span>
+            ) : (
+              ""
+            ),
+          axes: g.axes,
+          sensors: [
+            g.has_accelerometer && "Accel",
+            g.has_gyroscope && "Gyro",
+            g.has_magnetometer && "Mag",
+          ]
+            .filter(Boolean)
+            .join("+"),
+          interface: [
+            g.has_spi && "SPI",
+            g.has_i2c && "I2C",
+            g.has_uart && "UART",
+          ]
+            .filter(Boolean)
+            .join(", "),
+          stock: <span className="tabular-nums">{g.stock}</span>,
+          price: <span className="tabular-nums">{formatPrice(g.price1)}</span>,
+        }))}
+      />
+    </div>,
+    "JLCPCB IMU Search",
+  )
+})

--- a/scripts/setup-7z.ts
+++ b/scripts/setup-7z.ts
@@ -7,10 +7,14 @@ const BINARY_NAME = "7zz"
 
 // Map of platform-arch combinations to download URLs
 const BINARY_URLS: Record<string, string> = {
-  "linux-x64": "https://7-zip.org/a/7z2408-linux-x64.tar.xz",
-  "linux-arm64": "https://7-zip.org/a/7z2408-linux-arm64.tar.xz",
-  "darwin-x64": "https://7-zip.org/a/7z2408-mac.tar.xz",
-  "darwin-arm64": "https://7-zip.org/a/7z2408-mac.tar.xz",
+  "linux-x64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-linux-x64.tar.xz",
+  "linux-arm64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-linux-arm64.tar.xz",
+  "darwin-x64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-mac.tar.xz",
+  "darwin-arm64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-mac.tar.xz",
 }
 
 async function downloadAndExtract7z() {

--- a/tests/routes/imus/list.test.ts
+++ b/tests/routes/imus/list.test.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "bun:test"
+import { getTestServer } from "../../fixtures/get-test-server"
+
+test("GET /imus/list with json param returns imu data", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/imus/list?json=true")
+  expect(res.data).toHaveProperty("imus")
+  expect(Array.isArray(res.data.imus)).toBe(true)
+  if (res.data.imus.length > 0) {
+    const imu = res.data.imus[0]
+    expect(imu).toHaveProperty("lcsc")
+    expect(imu).toHaveProperty("mfr")
+    expect(imu).toHaveProperty("package")
+    expect(imu).toHaveProperty("has_spi")
+    expect(imu).toHaveProperty("has_accelerometer")
+    expect(imu).toHaveProperty("has_gyroscope")
+    expect(imu).toHaveProperty("has_magnetometer")
+    expect(typeof imu.lcsc).toBe("number")
+    expect(typeof imu.has_spi).toBe("boolean")
+    expect(typeof imu.has_i2c).toBe("boolean")
+    expect(typeof imu.has_accelerometer).toBe("boolean")
+    expect(typeof imu.has_gyroscope).toBe("boolean")
+  }
+})

--- a/tests/routes/microphones/list.test.ts
+++ b/tests/routes/microphones/list.test.ts
@@ -26,4 +26,4 @@ test("GET /microphones/list.json returns microphone data", async () => {
     expect(typeof microphone.stock).toBe("number")
     expect(typeof microphone.price1).toBe("number")
   }
-})
+}, 15_000)


### PR DESCRIPTION
## Summary

Closes #53

Adds a new **IMU (Inertial Measurement Unit)** category, following the same pattern as the existing `accelerometers` and `gyroscopes` routes.

## Changes

### New files
- `lib/db/derivedtables/imu.ts` — derived table spec for IMU parts
- `routes/imus/list.tsx` — route handler with package/interface/magnetometer filters
- `routes/imus/list.json.tsx` — JSON API re-export
- `tests/routes/imus/list.test.ts` — basic endpoint test

### Updated files
- `lib/db/derivedtables/setup-derived-tables.ts` — added `imuTableSpec` to the derived tables list
- `lib/db/generated/kysely.ts` — added `Imu` interface and `imu` table to DB type

## Schema

| Column | Type | Description |
|---|---|---|
| `lcsc`, `mfr`, `package`, `stock`, `price1` | base | Standard columns |
| `has_accelerometer` | boolean | Part includes accelerometer |
| `has_gyroscope` | boolean | Part includes gyroscope |
| `has_magnetometer` | boolean | Part includes magnetometer (9-axis IMUs) |
| `has_i2c`, `has_spi`, `has_uart` | boolean | Communication interfaces |
| `axes` | text | e.g. "6-Axis", "9-Axis" |
| `supply_voltage_min/max` | real | Operating voltage range |

## Route

`GET /imus/list` — HTML or JSON (add `?json=true`)

Query params: `package`, `interface` (spi/i2c/uart), `has_magnetometer`

/claim #53