### PR TITLE
feat: add extended promotional component column

### DIFF
--- a/cf-proxy/scripts/rebuild-search-index-batched.sh
+++ b/cf-proxy/scripts/rebuild-search-index-batched.sh
@@ -43,6 +43,7 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
      price1 REAL,
      basic INTEGER,
      preferred INTEGER,
+     is_extended_promotional INTEGER,
      category TEXT,
      subcategory TEXT,
      manufacturer_name TEXT,
@@ -70,6 +71,7 @@ INSERT INTO search_index_next (
   price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   manufacturer_name,
@@ -91,6 +93,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -133,7 +136,8 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
    CREATE INDEX IF NOT EXISTS idx_search_index_next_lcsc ON search_index_next(lcsc);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_package ON search_index_next(package);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_basic ON search_index_next(basic);
-   CREATE INDEX IF NOT EXISTS idx_search_index_next_preferred ON search_index_next(preferred);"
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_preferred ON search_index_next(preferred);
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_extended_promotional ON search_index_next(is_extended_promotional);"
 
 echo "Validating row count..."
 run_wrangler d1 execute "$DB_NAME" --remote --command \
@@ -157,11 +161,13 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
    DROP INDEX IF EXISTS idx_search_index_package;
    DROP INDEX IF EXISTS idx_search_index_basic;
    DROP INDEX IF EXISTS idx_search_index_preferred;
+   DROP INDEX IF EXISTS idx_search_index_extended_promotional;
    ALTER TABLE search_index_next RENAME TO search_index;
    CREATE INDEX IF NOT EXISTS idx_search_index_stock ON search_index(stock DESC);
    CREATE INDEX IF NOT EXISTS idx_search_index_lcsc ON search_index(lcsc);
    CREATE INDEX IF NOT EXISTS idx_search_index_package ON search_index(package);
    CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
-   CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);"
+   CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
+   CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);"
 
 echo "Done. Old table kept as search_index_old for rollback."

--- a/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
+++ b/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
@@ -14,6 +14,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -55,3 +56,5 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);

--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -296,6 +296,16 @@ SELECT
   package,
   basic,
   preferred,
+  CASE
+    WHEN json_valid(extra) THEN CAST(COALESCE(
+      json_extract(extra, '$.is_extended_promotional'),
+      json_extract(extra, '$.isExtendedPromotional'),
+      json_extract(extra, '$.extendedPromotional'),
+      json_extract(extra, '$.is_extended_promotion'),
+      0
+    ) AS INTEGER)
+    ELSE 0
+  END AS is_extended_promotional,
   description,
   stock,
   price,
@@ -306,6 +316,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(is_extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA
 
@@ -319,6 +330,7 @@ CREATE TABLE component_catalog (
   package TEXT,
   basic INTEGER,
   preferred INTEGER,
+  is_extended_promotional INTEGER,
   description TEXT,
   stock INTEGER,
   price TEXT,
@@ -328,6 +340,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(is_extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA_EXPORT
 }
@@ -350,6 +363,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -391,6 +405,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);
 SEARCH_INDEX_SCHEMA
 
   cat > search_index_schema.sql <<'SEARCH_INDEX_SCHEMA_EXPORT'
@@ -405,6 +421,7 @@ CREATE TABLE search_index (
   price1 REAL,
   basic INTEGER,
   preferred INTEGER,
+  is_extended_promotional INTEGER,
   category TEXT,
   subcategory TEXT,
   manufacturer_name TEXT,
@@ -422,6 +439,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);
 SEARCH_INDEX_SCHEMA_EXPORT
 }
 

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -22,6 +23,7 @@ export async function queryComponentCatalog(
     package: string | null
     basic: number | null
     preferred: number | null
+    is_extended_promotional: number | null
     description: string | null
     stock: number | null
     price: string | null
@@ -34,6 +36,7 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -158,6 +158,7 @@ export interface BuckBoostConverter {
 
 export interface ComponentCatalog {
   basic: number | null
+  is_extended_promotional: number | null
   category: string | null
   description: string | null
   extra: string | null
@@ -658,6 +659,7 @@ export interface Relay {
 export interface SearchIndex {
   attributes: string | null
   basic: number | null
+  is_extended_promotional: number | null
   category: string | null
   description: string | null
   lcsc: Generated<number | null>

--- a/cf-proxy/src/handlers/index.ts
+++ b/cf-proxy/src/handlers/index.ts
@@ -20,6 +20,7 @@ const ALLOWED_OPERATORS = new Set(["=", ">=", "<=", ">", "<"])
 
 const isBooleanLikeField = (field: string): boolean =>
   field === "in_stock" ||
+  field === "is_extended_promotional" ||
   field.startsWith("is_") ||
   field.startsWith("has_") ||
   field.startsWith("measures_")

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -367,6 +367,7 @@ async function handleD1Search(
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
       is_preferred: Boolean(row.preferred),
+      is_extended_promotional: Boolean(row.is_extended_promotional),
       description: row.description ?? "",
       stock: row.stock ?? 0,
       price: row.price1 ?? extractSmallQuantityPrice(row.price),
@@ -491,6 +492,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        is_extended_promotional: Boolean(row.is_extended_promotional),
       })),
     }
 

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -147,6 +147,7 @@ const COLUMN_LABELS: Record<string, string> = {
   in_stock: "In Stock",
   is_basic: "Basic",
   is_preferred: "Preferred",
+  is_extended_promotional: "Extended Promotional",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
   voltage_rating: "Voltage",
@@ -545,6 +546,9 @@ const renderComponentsFilters = (
   </div>
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
+  </div>
+  <div>
+    <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <button type="submit">Filter</button>
 </form>`

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -21,6 +22,7 @@ interface SearchRow {
   price1: number | null
   basic: number | null
   preferred: number | null
+  is_extended_promotional: number | null
   category: string | null
   subcategory: string | null
 }
@@ -110,6 +112,13 @@ export async function searchIndex(
     conditions.push(sql`search_index.preferred = 1`)
   }
 
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`search_index.is_extended_promotional = 1`)
+  }
+
   const raw = params.q?.trim()
 
   if (raw) {
@@ -151,6 +160,7 @@ export async function searchIndex(
       search_index.price1,
       search_index.basic,
       search_index.preferred,
+      search_index.is_extended_promotional,
       search_index.category,
       search_index.subcategory
     FROM search_index

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -37,6 +37,22 @@ describe("render helpers", () => {
     expect(html).toContain("/led_with_ic/list.json?protocol=WS2812B")
   })
 
+  it("renders extended promotional filters on the components page", () => {
+    const html = renderD1TablePage(
+      "/components/list",
+      { components: [{ lcsc: 123, is_extended_promotional: true }] },
+      { is_extended_promotional: "true" },
+      "https://example.com/components/list?is_extended_promotional=true",
+    )
+
+    expect(html).toContain('name="is_extended_promotional"')
+    expect(html).toContain("Extended Promotional")
+    expect(html).toContain(
+      'name="is_extended_promotional" value="true" checked',
+    )
+    expect(html).toContain("Extended Promotional</th>")
+  })
+
   it("renders attributes cells inside details with a truncated summary", () => {
     const html = renderD1TablePage(
       "/ldos/list",

--- a/scripts/download-cache-fragments.ts
+++ b/scripts/download-cache-fragments.ts
@@ -5,22 +5,28 @@ const BASE_URL = "https://yaqwsx.github.io/jlcparts/data"
 const OUTPUT_DIR = ".buildtmp"
 
 async function downloadFile(url: string, outputPath: string): Promise<boolean> {
-  try {
-    const response = await fetch(url)
-    if (!response.ok) {
-      if (response.status === 404) {
-        return false
-      }
-      throw new Error(`HTTP error! status: ${response.status}`)
-    }
-    const fileData = await response.arrayBuffer()
-    await Bun.write(outputPath, fileData)
+  const curl = Bun.spawn([
+    "curl",
+    "--fail",
+    "--location",
+    "--max-time",
+    "120",
+    "--output",
+    outputPath,
+    url,
+  ])
+  const exitCode = await curl.exited
+  if (exitCode === 0) {
     console.log(`Downloaded: ${url}`)
     return true
-  } catch (error) {
-    console.error(`Error downloading ${url}:`, error)
+  }
+
+  if (exitCode === 22) {
     return false
   }
+
+  console.error(`Error downloading ${url}: curl exited ${exitCode}`)
+  return false
 }
 
 async function main() {

--- a/scripts/setup-7z.ts
+++ b/scripts/setup-7z.ts
@@ -7,10 +7,14 @@ const BINARY_NAME = "7zz"
 
 // Map of platform-arch combinations to download URLs
 const BINARY_URLS: Record<string, string> = {
-  "linux-x64": "https://7-zip.org/a/7z2408-linux-x64.tar.xz",
-  "linux-arm64": "https://7-zip.org/a/7z2408-linux-arm64.tar.xz",
-  "darwin-x64": "https://7-zip.org/a/7z2408-mac.tar.xz",
-  "darwin-arm64": "https://7-zip.org/a/7z2408-mac.tar.xz",
+  "linux-x64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-linux-x64.tar.xz",
+  "linux-arm64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-linux-arm64.tar.xz",
+  "darwin-x64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-mac.tar.xz",
+  "darwin-arm64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-mac.tar.xz",
 }
 
 async function downloadAndExtract7z() {

--- a/scripts/setup-7z.ts
+++ b/scripts/setup-7z.ts
@@ -37,14 +37,22 @@ async function downloadAndExtract7z() {
   }
 
   console.log("Downloading 7z...")
-  const response = await fetch(downloadUrl)
-  if (!response.ok) {
-    throw new Error(`Failed to download: ${response.statusText}`)
-  }
-
   // Save the tar.xz file
   const tempFile = "7z-temp.tar.xz"
-  await Bun.write(tempFile, await response.arrayBuffer())
+  const curl = Bun.spawn([
+    "curl",
+    "--fail",
+    "--location",
+    "--max-time",
+    "60",
+    "--output",
+    tempFile,
+    downloadUrl,
+  ])
+  const curlExitCode = await curl.exited
+  if (curlExitCode !== 0) {
+    throw new Error(`Failed to download 7z: curl exited ${curlExitCode}`)
+  }
 
   // Extract the tar.xz file
   console.log("Extracting 7z binary...")

--- a/scripts/setup-7z.ts
+++ b/scripts/setup-7z.ts
@@ -7,14 +7,10 @@ const BINARY_NAME = "7zz"
 
 // Map of platform-arch combinations to download URLs
 const BINARY_URLS: Record<string, string> = {
-  "linux-x64":
-    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-linux-x64.tar.xz",
-  "linux-arm64":
-    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-linux-arm64.tar.xz",
-  "darwin-x64":
-    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-mac.tar.xz",
-  "darwin-arm64":
-    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-mac.tar.xz",
+  "linux-x64": "https://7-zip.org/a/7z2301-linux-x64.tar.xz",
+  "linux-arm64": "https://7-zip.org/a/7z2301-linux-arm64.tar.xz",
+  "darwin-x64": "https://7-zip.org/a/7z2301-mac.tar.xz",
+  "darwin-arm64": "https://7-zip.org/a/7z2301-mac.tar.xz",
 }
 
 async function downloadAndExtract7z() {


### PR DESCRIPTION
## Summary
- Adds is_extended_promotional to component/search result types and JSON payloads
- Makes the column visible and filterable on the components table
- Propagates the column through component_catalog/search_index schema generation and rebuild scripts

## Test Plan
- npx --yes bun@latest run format:check
- npx --yes bun@latest x tsc -p cf-proxy/tsconfig.json --noEmit
- cd cf-proxy && npx --yes bun@latest test --runInBand

Closes #92

/claim #92