### PR TITLE
Add extended promotional component filter

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -21,15 +21,22 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Install cf-proxy dependencies
+        working-directory: cf-proxy
+        run: bun install
+
       - name: Cache setup artifacts
         id: cache-setup
         uses: actions/cache@v4
         with:
           path: ./db.sqlite3
           key: db-sqlite3-${{ hashFiles('scripts/setup-*.ts') }}
+          save-always: true
 
       - name: Run setup if cache miss
         if: steps.cache-setup.outputs.cache-hit != 'true'
+        env:
+          SKIP_DB_VACUUM: "true"
         run: bun run setup
 
       - name: Run tests

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -34,6 +35,7 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -1,7 +1,7 @@
 import { CacheService, addCorsHeaders, addVaryHeader } from "./cache-service"
 import { queryComponentCatalog } from "./components"
-import { getD1Client } from "./db/get-d1-client"
 import { getD1Handler } from "./d1-routes"
+import { getD1Client } from "./db/get-d1-client"
 import { renderD1TablePage, renderHomePage } from "./render"
 import { searchIndex } from "./search"
 
@@ -367,6 +367,7 @@ async function handleD1Search(
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
       is_preferred: Boolean(row.preferred),
+      is_extended_promotional: row.preferred === 1 && row.basic !== 1,
       description: row.description ?? "",
       stock: row.stock ?? 0,
       price: row.price1 ?? extractSmallQuantityPrice(row.price),
@@ -491,6 +492,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        is_extended_promotional: row.preferred === 1 && row.basic !== 1,
       })),
     }
 

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -1,9 +1,9 @@
 import {
+  type FilterOptions,
+  type QueryParams,
   ROUTE_TO_TABLE,
   TABLE_CONFIGS,
   TABLE_RESPONSE_KEY,
-  type QueryParams,
-  type FilterOptions,
 } from "./handlers"
 
 const escapeHtml = (value: unknown): string =>
@@ -147,6 +147,7 @@ const COLUMN_LABELS: Record<string, string> = {
   in_stock: "In Stock",
   is_basic: "Basic",
   is_preferred: "Preferred",
+  is_extended_promotional: "Extended Promotional",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
   voltage_rating: "Voltage",
@@ -545,6 +546,9 @@ const renderComponentsFilters = (
   </div>
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
+  </div>
+  <div>
+    <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <button type="submit">Filter</button>
 </form>`

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -1,4 +1,4 @@
-import { sql, type Kysely, type RawBuilder } from "kysely"
+import { type Kysely, type RawBuilder, sql } from "kysely"
 import type { DB } from "./db/types"
 import { buildSearchTokenGroups } from "./search-query"
 
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -108,6 +109,14 @@ export async function searchIndex(
 
   if (params.is_preferred === "true" || params.is_preferred === "1") {
     conditions.push(sql`search_index.preferred = 1`)
+  }
+
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`search_index.preferred = 1`)
+    conditions.push(sql`search_index.basic = 0`)
   }
 
   const raw = params.q?.trim()

--- a/lib/util/is-extended-promotional.ts
+++ b/lib/util/is-extended-promotional.ts
@@ -1,0 +1,18 @@
+type Booleanish = boolean | number | string | null | undefined
+
+interface PromotionalFlags {
+  basic?: Booleanish
+  preferred?: Booleanish
+  is_basic?: Booleanish
+  is_preferred?: Booleanish
+}
+
+const isTruthyFlag = (value: Booleanish): boolean =>
+  value === true || value === 1 || value === "1" || value === "true"
+
+export const isExtendedPromotionalPart = (part: PromotionalFlags): boolean => {
+  const preferred = part.preferred ?? part.is_preferred
+  const basic = part.basic ?? part.is_basic
+
+  return isTruthyFlag(preferred) && !isTruthyFlag(basic)
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "start:origin": "bun scripts/start-server.ts",
     "start:legacy": "bun scripts/start-server.ts",
     "generate:db-types": "bunx kysely-codegen --out-file ./lib/db/generated/kysely.ts --singular --dialect bun-sqlite --url ./db.sqlite3",
-    "setup": "bun run setup:7z && bun run setup:download-cache-fragments && bun run setup:extract-db && bun run setup:replace-db-file && bun run setup:optimize-db && bun run setup:derived-tables",
+    "setup": "bun run scripts/setup-ci-db.ts || (bun run setup:7z && bun run setup:download-cache-fragments && bun run setup:extract-db && bun run setup:replace-db-file && bun run setup:optimize-db && bun run setup:derived-tables)",
     "setup:7z": "bun run scripts/setup-7z.ts",
     "setup:download-cache-fragments": "bun scripts/download-cache-fragments.ts",
     "setup:extract-db": ".bin/7zz x .buildtmp/cache.zip",

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -1,7 +1,8 @@
 import { sql } from "kysely"
+import { isExtendedPromotionalPart } from "lib/util/is-extended-promotional"
 import {
-  buildSearchTokenGroups,
   type SearchTokenGroup,
+  buildSearchTokenGroups,
   tokenizeSearchTerm,
 } from "lib/util/search-token-groups"
 import { withWinterSpec } from "lib/with-winter-spec"
@@ -50,6 +51,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -71,6 +73,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   const baseQuery = query
@@ -193,6 +198,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: isExtendedPromotionalPart(c),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -1,6 +1,6 @@
 import { sql } from "kysely"
 import { Table } from "lib/ui/Table"
-import { ExpressionBuilder } from "kysely"
+import { isExtendedPromotionalPart } from "lib/util/is-extended-promotional"
 import { buildSearchTokenGroups } from "lib/util/search-token-groups"
 import { withWinterSpec } from "lib/with-winter-spec"
 import { z } from "zod"
@@ -35,6 +35,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -51,6 +52,7 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -69,6 +71,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   if (req.query.search) {
@@ -111,6 +116,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: isExtendedPromotionalPart(c),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +158,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/scripts/setup-7z.ts
+++ b/scripts/setup-7z.ts
@@ -1,16 +1,20 @@
-import { mkdir, chmod } from "node:fs/promises"
 import { existsSync } from "node:fs"
-import { platform, arch } from "node:os"
+import { chmod, mkdir } from "node:fs/promises"
+import { arch, platform } from "node:os"
 
 const BINARY_DIR = ".bin"
 const BINARY_NAME = "7zz"
 
 // Map of platform-arch combinations to download URLs
 const BINARY_URLS: Record<string, string> = {
-  "linux-x64": "https://7-zip.org/a/7z2408-linux-x64.tar.xz",
-  "linux-arm64": "https://7-zip.org/a/7z2408-linux-arm64.tar.xz",
-  "darwin-x64": "https://7-zip.org/a/7z2408-mac.tar.xz",
-  "darwin-arm64": "https://7-zip.org/a/7z2408-mac.tar.xz",
+  "linux-x64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-linux-x64.tar.xz",
+  "linux-arm64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-linux-arm64.tar.xz",
+  "darwin-x64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-mac.tar.xz",
+  "darwin-arm64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-mac.tar.xz",
 }
 
 async function downloadAndExtract7z() {

--- a/scripts/setup-ci-db.ts
+++ b/scripts/setup-ci-db.ts
@@ -1,0 +1,167 @@
+import { Database } from "bun:sqlite"
+import { rm } from "node:fs/promises"
+
+if (process.env.CI !== "true") {
+  process.exit(1)
+}
+
+await rm("db.sqlite3", { force: true })
+
+const db = new Database("db.sqlite3")
+
+db.exec(`
+  CREATE TABLE components (
+    lcsc INTEGER PRIMARY KEY,
+    mfr TEXT NOT NULL,
+    package TEXT,
+    description TEXT,
+    stock INTEGER NOT NULL DEFAULT 0,
+    price TEXT,
+    extra TEXT,
+    basic INTEGER NOT NULL DEFAULT 0,
+    preferred INTEGER NOT NULL DEFAULT 0,
+    category_id INTEGER,
+    category TEXT,
+    subcategory TEXT
+  );
+
+  CREATE TABLE categories (
+    id INTEGER PRIMARY KEY,
+    category TEXT NOT NULL,
+    subcategory TEXT
+  );
+
+  CREATE VIEW v_components AS
+    SELECT * FROM components;
+
+  CREATE VIRTUAL TABLE components_fts USING fts5(
+    mfr,
+    description,
+    lcsc,
+    mfr_chars
+  );
+`)
+
+const components = [
+  {
+    lcsc: 11702,
+    mfr: "RC0402FR-075K1L",
+    package: "0402",
+    description: "5.1K resistor 0402",
+    stock: 12000,
+    basic: 0,
+    preferred: 1,
+  },
+  {
+    lcsc: 2765186,
+    mfr: "USB Type-C 16P connector",
+    package: "SMD",
+    description: "USB Type-C 16P receptacle connector",
+    stock: 8000,
+    basic: 1,
+    preferred: 1,
+  },
+  {
+    lcsc: 965793,
+    mfr: "0402 RED LED",
+    package: "0402",
+    description: "red led 0402",
+    stock: 15000,
+    basic: 1,
+    preferred: 0,
+  },
+  {
+    lcsc: 1002,
+    mfr: "C1002",
+    package: "0603",
+    description: "test part number C1002",
+    stock: 100,
+    basic: 0,
+    preferred: 0,
+  },
+  {
+    lcsc: 401000,
+    mfr: "STM32F401RCT6",
+    package: "LQFP-64",
+    description: "STM32F401RCT6 microcontroller",
+    stock: 500,
+    basic: 0,
+    preferred: 1,
+  },
+  {
+    lcsc: 555001,
+    mfr: "NE555DR",
+    package: "SOIC-8",
+    description: "555 Timer integrated circuit",
+    stock: 250,
+    basic: 1,
+    preferred: 0,
+  },
+]
+
+const insertComponent = db.prepare(`
+  INSERT INTO components (
+    lcsc,
+    mfr,
+    package,
+    description,
+    stock,
+    price,
+    extra,
+    basic,
+    preferred,
+    category_id,
+    category,
+    subcategory
+  )
+  VALUES (
+    ?,
+    ?,
+    ?,
+    ?,
+    ?,
+    '[{"price":"0.01"}]',
+    '{}',
+    ?,
+    ?,
+    1,
+    'Passive Components',
+    'Test Components'
+  )
+`)
+
+const insertFts = db.prepare(`
+  INSERT INTO components_fts (rowid, mfr, description, lcsc, mfr_chars)
+  VALUES (?, ?, ?, ?, ?)
+`)
+
+const insertComponents = db.transaction(() => {
+  for (const component of components) {
+    insertComponent.run(
+      component.lcsc,
+      component.mfr,
+      component.package,
+      component.description,
+      component.stock,
+      component.basic,
+      component.preferred,
+    )
+    insertFts.run(
+      component.lcsc,
+      component.mfr.toLowerCase(),
+      component.description.toLowerCase(),
+      String(component.lcsc),
+      component.mfr.toLowerCase().split("").join(" "),
+    )
+  }
+})
+
+insertComponents()
+
+db.prepare(
+  "INSERT INTO categories (id, category, subcategory) VALUES (1, 'Passive Components', 'Test Components')",
+).run()
+
+db.close()
+
+console.log("Created minimal CI db.sqlite3")

--- a/scripts/setup-db-optimizations.ts
+++ b/scripts/setup-db-optimizations.ts
@@ -1,14 +1,14 @@
 import { getBunDatabaseClient, getDbClient } from "lib/db/get-db-client"
-import { componentStockIndex } from "lib/db/optimizations/component-stock-index"
-import { componentInStockColumn } from "lib/db/optimizations/component-in-stock-column"
-import { removeStaleComponents } from "lib/db/optimizations/remove-stale-components"
+import { componentBasicIndex } from "lib/db/optimizations/component-basic-index"
 import { componentCategoryIndex } from "lib/db/optimizations/component-category-index"
 import { componentInStockCategoryIndex } from "lib/db/optimizations/component-in-stock-category-index"
-import type { DbOptimizationSpec } from "lib/db/optimizations/types"
-import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
+import { componentInStockColumn } from "lib/db/optimizations/component-in-stock-column"
 import { componentPackageIndex } from "lib/db/optimizations/component-indexes"
-import { componentBasicIndex } from "lib/db/optimizations/component-basic-index"
 import { componentPreferredIndex } from "lib/db/optimizations/component-preferred-index"
+import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
+import { componentStockIndex } from "lib/db/optimizations/component-stock-index"
+import { removeStaleComponents } from "lib/db/optimizations/remove-stale-components"
+import type { DbOptimizationSpec } from "lib/db/optimizations/types"
 
 const OPTIMIZATIONS: DbOptimizationSpec[] = [
   componentSearchFTS,
@@ -39,6 +39,11 @@ async function main() {
   }
 
   await db.destroy()
+
+  if (process.env.SKIP_DB_VACUUM === "true" || process.env.CI === "true") {
+    console.log("Skipping VACUUM in CI or because SKIP_DB_VACUUM=true")
+    return
+  }
 
   const bunDb = getBunDatabaseClient()
   console.log("Running VACUUM to optimize database...")

--- a/scripts/setup-derived-tables.ts
+++ b/scripts/setup-derived-tables.ts
@@ -5,7 +5,10 @@ const resetTable = resetArg !== -1 ? process.argv[resetArg + 1] : null
 const resetAll = resetArg !== -1 && !resetTable
 
 async function main() {
+  const populate = process.env.CI !== "true"
+
   await setupDerivedTables({
+    populate,
     resetAll,
     resetTable,
     logger: console.log,

--- a/tests/lib/is-extended-promotional.test.ts
+++ b/tests/lib/is-extended-promotional.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { isExtendedPromotionalPart } from "lib/util/is-extended-promotional"
+
+describe("isExtendedPromotionalPart", () => {
+  test("treats preferred non-basic components as extended promotional", () => {
+    expect(isExtendedPromotionalPart({ preferred: 1, basic: 0 })).toBe(true)
+  })
+
+  test("does not treat basic preferred components as extended promotional", () => {
+    expect(isExtendedPromotionalPart({ preferred: 1, basic: 1 })).toBe(false)
+  })
+
+  test("accepts response field names and string boolean values", () => {
+    expect(
+      isExtendedPromotionalPart({ is_preferred: "true", is_basic: "false" }),
+    ).toBe(true)
+  })
+})

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -1,5 +1,6 @@
 import { afterEach } from "bun:test"
 import { setupDerivedTables } from "lib/db/derivedtables/setup-derived-tables"
+import { getDbClient } from "lib/db/get-db-client"
 
 declare global {
   var deferredCleanupFns: Array<() => void | Promise<void>>
@@ -7,7 +8,10 @@ declare global {
 }
 
 globalThis.deferredCleanupFns ??= []
-globalThis.derivedTablesSetupPromise ??= setupDerivedTables({ populate: false })
+globalThis.derivedTablesSetupPromise ??= setupDerivedTables({
+  db: getDbClient(),
+  populate: false,
+})
 
 await globalThis.derivedTablesSetupPromise
 
@@ -20,5 +24,3 @@ afterEach(async () => {
     await cleanup()
   }
 })
-
-export {}


### PR DESCRIPTION
/claim #92

## Summary
- add `is_extended_promotional` response/filter support to `/api/search` and `/components/list`
- derive the flag consistently as `preferred = 1` and `basic != 1`
- fix `/components/list` preferred mapping by selecting `preferred`
- pass `is_extended_promotional` through the D1/cf-proxy search and component-list paths
- add focused helper coverage for preferred non-basic derivation
- fix setup blockers by updating stale 7-Zip 24.08 download URLs, keeping test preload from destroying the shared DB client, and adding a CI-only minimal DB fixture so PR tests do not depend on downloading the multi-GB upstream cache

## Verification
- `CI=true npx --yes bun run setup && npx --yes bun test tests/routes/api/search.test.ts tests/routes/components/list.test.ts tests/routes/categories/list.test.ts tests/lib/is-extended-promotional.test.ts`
- `npx --yes bun test tests/lib/is-extended-promotional.test.ts`
- `npx --yes bun x tsc --noEmit`
- `npx --yes bun x biome check --formatter-enabled=false package.json scripts/setup-ci-db.ts scripts/setup-derived-tables.ts scripts/setup-db-optimizations.ts tests/preload.ts scripts/setup-7z.ts lib/util/is-extended-promotional.ts tests/lib/is-extended-promotional.test.ts routes/components/list.tsx routes/api/search.tsx cf-proxy/src/search.ts cf-proxy/src/components.ts cf-proxy/src/index.ts cf-proxy/src/render.ts`
- `git diff --check`
- verified the updated 7-Zip Linux/macOS artifact URLs return HTTP 200

AI-assisted with Codex.