### PR TITLE
feat: add is_extended_promotional field to components

### DIFF
--- a/lib/db/derivedtables/component-base.ts
+++ b/lib/db/derivedtables/component-base.ts
@@ -7,5 +7,6 @@ export interface BaseComponent {
   in_stock: boolean
   is_basic: boolean
   is_preferred: boolean
+  is_extended_promotional?: boolean
   attributes: Record<string, string>
 }

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -1,5 +1,4 @@
 import { sql } from "kysely"
-import { getDbClient } from "lib/db/get-db-client"
 import { accelerometerTableSpec } from "lib/db/derivedtables/accelerometer"
 import { adcTableSpec } from "lib/db/derivedtables/adc"
 import { analogMultiplexerTableSpec } from "lib/db/derivedtables/analog_multiplexer"
@@ -10,8 +9,8 @@ import { buckBoostConverterTableSpec } from "lib/db/derivedtables/buck_boost_con
 import { capacitorTableSpec } from "lib/db/derivedtables/capacitor"
 import { dacTableSpec } from "lib/db/derivedtables/dac"
 import { diodeTableSpec } from "lib/db/derivedtables/diode"
-import { fpgaTableSpec } from "lib/db/derivedtables/fpga"
 import { fpcConnectorTableSpec } from "lib/db/derivedtables/fpc_connector"
+import { fpgaTableSpec } from "lib/db/derivedtables/fpga"
 import { fuseTableSpec } from "lib/db/derivedtables/fuse"
 import { gasSensorTableSpec } from "lib/db/derivedtables/gas_sensor"
 import { gyroscopeTableSpec } from "lib/db/derivedtables/gyroscope"
@@ -19,26 +18,27 @@ import { headerTableSpec } from "lib/db/derivedtables/header"
 import { ioExpanderTableSpec } from "lib/db/derivedtables/io_expander"
 import { jstConnectorTableSpec } from "lib/db/derivedtables/jst_connector"
 import { lcdDisplayTableSpec } from "lib/db/derivedtables/lcd_display"
+import { ldoTableSpec } from "lib/db/derivedtables/ldo"
+import { ledTableSpec } from "lib/db/derivedtables/led"
 import { ledDotMatrixDisplayTableSpec } from "lib/db/derivedtables/led_dot_matrix_display"
 import { ledDriverTableSpec } from "lib/db/derivedtables/led_driver"
 import { ledSegmentDisplayTableSpec } from "lib/db/derivedtables/led_segment_display"
-import { ledTableSpec } from "lib/db/derivedtables/led"
 import { ledWithICTableSpec } from "lib/db/derivedtables/led_with_ic"
-import { ldoTableSpec } from "lib/db/derivedtables/ldo"
 import { microcontrollerTableSpec } from "lib/db/derivedtables/microcontroller"
 import { mosfetTableSpec } from "lib/db/derivedtables/mosfet"
 import { oledDisplayTableSpec } from "lib/db/derivedtables/oled_display"
 import { pcieM2ConnectorTableSpec } from "lib/db/derivedtables/pcie_m2_connector"
 import { potentiometerTableSpec } from "lib/db/derivedtables/potentiometer"
 import { relayTableSpec } from "lib/db/derivedtables/relay"
-import { resistorArrayTableSpec } from "lib/db/derivedtables/resistor_array"
 import { resistorTableSpec } from "lib/db/derivedtables/resistor"
+import { resistorArrayTableSpec } from "lib/db/derivedtables/resistor_array"
 import { switchTableSpec } from "lib/db/derivedtables/switch"
 import type { DerivedTableSpec } from "lib/db/derivedtables/types"
 import { usbCConnectorTableSpec } from "lib/db/derivedtables/usb_c_connector"
 import { voltageRegulatorTableSpec } from "lib/db/derivedtables/voltage_regulator"
 import { wifiModuleTableSpec } from "lib/db/derivedtables/wifi_module"
 import { wireToBoardConnectorTableSpec } from "lib/db/derivedtables/wire_to_board_connector"
+import { getDbClient } from "lib/db/get-db-client"
 import type { KyselyDatabaseInstance } from "lib/db/kysely-types"
 
 export const DERIVED_TABLES: DerivedTableSpec<any>[] = [
@@ -130,6 +130,7 @@ const createTable = async (
     { name: "stock", type: "integer" },
     { name: "price1", type: "real" },
     { name: "in_stock", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ].concat(spec.extraColumns as any, [{ name: "attributes", type: "text" }])) {
     tableCreator = tableCreator.addColumn(
       col.name as string,
@@ -164,6 +165,8 @@ const createTable = async (
         ? null
         : {
             ...c,
+            is_extended_promotional:
+              Boolean(components[i].preferred) && !components[i].basic,
             attributes: jsonParseOrNull(components[i].extra)?.attributes,
           },
     )

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -1,7 +1,7 @@
 import { sql } from "kysely"
 import {
-  buildSearchTokenGroups,
   type SearchTokenGroup,
+  buildSearchTokenGroups,
   tokenizeSearchTerm,
 } from "lib/util/search-token-groups"
 import { withWinterSpec } from "lib/with-winter-spec"
@@ -50,6 +50,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -71,6 +72,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   const baseQuery = query
@@ -193,6 +197,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.preferred) && !c.basic,
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -1,6 +1,6 @@
 import { sql } from "kysely"
-import { Table } from "lib/ui/Table"
 import { ExpressionBuilder } from "kysely"
+import { Table } from "lib/ui/Table"
 import { buildSearchTokenGroups } from "lib/util/search-token-groups"
 import { withWinterSpec } from "lib/with-winter-spec"
 import { z } from "zod"
@@ -35,6 +35,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -51,6 +52,7 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -69,6 +71,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   if (req.query.search) {
@@ -111,6 +116,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.preferred) && !c.basic,
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +158,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/tests/routes/api/search.test.ts
+++ b/tests/routes/api/search.test.ts
@@ -107,3 +107,44 @@ test("GET /api/search supports '0402 LED'", async () => {
   expect(res.data.components.every((c: any) => c.package === "0402")).toBe(true)
   expect(res.data.components.some((c: any) => c.lcsc === 965793)).toBe(true)
 })
+
+test("GET /api/search includes is_extended_promotional in response", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/api/search?q=resistor&limit=10")
+
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+
+  if (res.data.components.length > 0) {
+    const component = res.data.components[0]
+    expect(component).toHaveProperty("is_extended_promotional")
+    expect(typeof component.is_extended_promotional).toBe("boolean")
+  }
+})
+
+test("GET /api/search with is_extended_promotional=true returns only extended promotional components", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/api/search?is_extended_promotional=true")
+
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+
+  for (const component of res.data.components) {
+    expect(component.is_extended_promotional).toBe(true)
+    expect(component.is_preferred).toBe(true)
+    expect(component.is_basic).toBe(false)
+  }
+})
+
+test("GET /api/search is_extended_promotional is consistent with is_preferred and is_basic", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/api/search?limit=50")
+
+  expect(res.data).toHaveProperty("components")
+
+  for (const component of res.data.components) {
+    const expectedExtendedPromotional =
+      component.is_preferred === true && component.is_basic === false
+    expect(component.is_extended_promotional).toBe(expectedExtendedPromotional)
+  }
+})

--- a/tests/routes/components/list.test.ts
+++ b/tests/routes/components/list.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
 import { getTestServer } from "tests/fixtures/get-test-server"
 
 test("GET /components/list with json param returns component data", async () => {
@@ -6,4 +6,44 @@ test("GET /components/list with json param returns component data", async () => 
   const res = await axios.get("/components/list?json=true")
   expect(res.data).toHaveProperty("components")
   expect(Array.isArray(res.data.components)).toBe(true)
+})
+
+test("GET /components/list includes is_extended_promotional field in response", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/components/list?json=true")
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+
+  if (res.data.components.length > 0) {
+    const component = res.data.components[0]
+    expect(component).toHaveProperty("is_extended_promotional")
+    expect(typeof component.is_extended_promotional).toBe("boolean")
+  }
+})
+
+test("GET /components/list with is_extended_promotional=true returns only extended promotional components", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get(
+    "/components/list?json=true&is_extended_promotional=true",
+  )
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+
+  for (const component of res.data.components) {
+    expect(component.is_extended_promotional).toBe(true)
+    expect(component.is_preferred).toBe(true)
+    expect(component.is_basic).toBe(false)
+  }
+})
+
+test("GET /components/list is_extended_promotional is consistent with is_preferred and is_basic", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/components/list?json=true")
+  expect(res.data).toHaveProperty("components")
+
+  for (const component of res.data.components) {
+    const expectedExtendedPromotional =
+      component.is_preferred === true && component.is_basic === false
+    expect(component.is_extended_promotional).toBe(expectedExtendedPromotional)
+  }
 })


### PR DESCRIPTION
## Summary

- Adds `is_extended_promotional` field (where `preferred = 1 AND basic = 0`) to `BaseComponent` interface
- Exposes field in `/components/list` and `/api/search` API responses
- Adds `is_extended_promotional=true` filter parameter to both routes
- Adds `is_extended_promotional` column to all derived component tables via `setup-derived-tables.ts`

## Changes

- `lib/db/derivedtables/component-base.ts`: Added `is_extended_promotional?: boolean` to `BaseComponent`
- `lib/db/derivedtables/setup-derived-tables.ts`: Added `is_extended_promotional` column to base columns list, computed in batch processing
- `routes/components/list.tsx`: Added query param, filter logic, `preferred` to SELECT, and field to response
- `routes/api/search.tsx`: Added query param, filter logic, and field to response
- `tests/routes/components/list.test.ts`: 3 new tests for field presence, filtering, and consistency
- `tests/routes/api/search.test.ts`: 3 new tests for field presence, filtering, and consistency

## Test plan

- [x] `is_extended_promotional` present in all component API responses as a boolean
- [x] `is_extended_promotional=true` filter returns only components where `is_preferred=true` AND `is_basic=false`
- [x] `is_extended_promotional` is consistent with `is_preferred && !is_basic` across all returned components
- [x] TypeScript type check passes (`bun tsc --noEmit`)
- [x] Biome lint/format check passes

/claim #92