### PR TITLE
Add extended promotional filter

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 40
 
     steps:
       - name: Checkout code

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Install cf-proxy dependencies
+        run: cd cf-proxy && bun install
+
       - name: Cache setup artifacts
         id: cache-setup
         uses: actions/cache@v4

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -34,6 +35,7 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -2,6 +2,7 @@ import { CacheService, addCorsHeaders, addVaryHeader } from "./cache-service"
 import { queryComponentCatalog } from "./components"
 import { getD1Client } from "./db/get-d1-client"
 import { getD1Handler } from "./d1-routes"
+import { isExtendedPromotional } from "./is-extended-promotional"
 import { renderD1TablePage, renderHomePage } from "./render"
 import { searchIndex } from "./search"
 
@@ -367,6 +368,7 @@ async function handleD1Search(
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
       is_preferred: Boolean(row.preferred),
+      is_extended_promotional: isExtendedPromotional(row),
       description: row.description ?? "",
       stock: row.stock ?? 0,
       price: row.price1 ?? extractSmallQuantityPrice(row.price),
@@ -491,6 +493,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        is_extended_promotional: isExtendedPromotional(row),
       })),
     }
 

--- a/cf-proxy/src/is-extended-promotional.ts
+++ b/cf-proxy/src/is-extended-promotional.ts
@@ -1,4 +1,4 @@
 export const isExtendedPromotional = (component: {
   basic?: number | boolean | null
   preferred?: number | boolean | null
-}): boolean => Boolean(component.preferred) && !Boolean(component.basic)
+}): boolean => component.preferred === 1 && component.basic === 0

--- a/cf-proxy/src/is-extended-promotional.ts
+++ b/cf-proxy/src/is-extended-promotional.ts
@@ -1,0 +1,4 @@
+export const isExtendedPromotional = (component: {
+  basic?: number | boolean | null
+  preferred?: number | boolean | null
+}): boolean => Boolean(component.preferred) && !Boolean(component.basic)

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -147,6 +147,7 @@ const COLUMN_LABELS: Record<string, string> = {
   in_stock: "In Stock",
   is_basic: "Basic",
   is_preferred: "Preferred",
+  is_extended_promotional: "Extended Promotional",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
   voltage_rating: "Voltage",
@@ -545,6 +546,9 @@ const renderComponentsFilters = (
   </div>
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
+  </div>
+  <div>
+    <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <button type="submit">Filter</button>
 </form>`

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -108,6 +109,14 @@ export async function searchIndex(
 
   if (params.is_preferred === "true" || params.is_preferred === "1") {
     conditions.push(sql`search_index.preferred = 1`)
+  }
+
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`search_index.preferred = 1`)
+    conditions.push(sql`search_index.basic = 0`)
   }
 
   const raw = params.q?.trim()

--- a/cf-proxy/test/is-extended-promotional.test.ts
+++ b/cf-proxy/test/is-extended-promotional.test.ts
@@ -4,9 +4,10 @@ import { isExtendedPromotional } from "../src/is-extended-promotional"
 describe("isExtendedPromotional", () => {
   it("derives extended promotional from preferred but not basic", () => {
     expect(isExtendedPromotional({ preferred: 1, basic: 0 })).toBe(true)
-    expect(isExtendedPromotional({ preferred: true, basic: false })).toBe(true)
     expect(isExtendedPromotional({ preferred: 1, basic: 1 })).toBe(false)
     expect(isExtendedPromotional({ preferred: 0, basic: 0 })).toBe(false)
+    expect(isExtendedPromotional({ preferred: 1, basic: null })).toBe(false)
+    expect(isExtendedPromotional({ preferred: true, basic: false })).toBe(false)
     expect(isExtendedPromotional({ preferred: null, basic: null })).toBe(false)
   })
 })

--- a/cf-proxy/test/is-extended-promotional.test.ts
+++ b/cf-proxy/test/is-extended-promotional.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest"
+import { isExtendedPromotional } from "../src/is-extended-promotional"
+
+describe("isExtendedPromotional", () => {
+  it("derives extended promotional from preferred but not basic", () => {
+    expect(isExtendedPromotional({ preferred: 1, basic: 0 })).toBe(true)
+    expect(isExtendedPromotional({ preferred: true, basic: false })).toBe(true)
+    expect(isExtendedPromotional({ preferred: 1, basic: 1 })).toBe(false)
+    expect(isExtendedPromotional({ preferred: 0, basic: 0 })).toBe(false)
+    expect(isExtendedPromotional({ preferred: null, basic: null })).toBe(false)
+  })
+})

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -59,4 +59,27 @@ describe("render helpers", () => {
       "Feature&quot;:&quot;Overcurrent Protection(OCP)&quot;",
     )
   })
+
+  it("renders extended promotional filter for the components list", () => {
+    const html = renderD1TablePage(
+      "/components/list",
+      {
+        components: [
+          {
+            lcsc: 123,
+            mfr: "ABC",
+            is_extended_promotional: true,
+          },
+        ],
+      },
+      { is_extended_promotional: "true" },
+      "https://example.com/components/list?is_extended_promotional=true",
+    )
+
+    expect(html).toContain("Extended Promotional")
+    expect(html).toContain('name="is_extended_promotional"')
+    expect(html).toContain(
+      'name="is_extended_promotional" value="true" checked',
+    )
+  })
 })

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -1,5 +1,5 @@
 import { sql } from "kysely"
-import { getDbClient } from "lib/db/get-db-client"
+import { destroyDbClient, getDbClient } from "lib/db/get-db-client"
 import { accelerometerTableSpec } from "lib/db/derivedtables/accelerometer"
 import { adcTableSpec } from "lib/db/derivedtables/adc"
 import { analogMultiplexerTableSpec } from "lib/db/derivedtables/analog_multiplexer"
@@ -214,7 +214,7 @@ export const setupDerivedTables = async ({
     }
   } finally {
     if (shouldDestroy) {
-      await activeDb.destroy()
+      await destroyDbClient()
     }
   }
 }

--- a/lib/db/get-db-client.ts
+++ b/lib/db/get-db-client.ts
@@ -49,8 +49,10 @@ const getDatabaseCtor = (): typeof BunDatabase => {
 
 const DEFAULT_DB_PATH = Path.join(import.meta.dir, "../../db.sqlite3")
 
-export const getResolvedDbPath = (): string => {
-  const configuredPath = process.env.JLCSEARCH_DB_PATH?.trim()
+export const getResolvedDbPath = (
+  configuredDbPath = process.env.JLCSEARCH_DB_PATH,
+): string => {
+  const configuredPath = configuredDbPath?.trim()
   if (!configuredPath) return DEFAULT_DB_PATH
   return Path.isAbsolute(configuredPath)
     ? configuredPath
@@ -83,7 +85,15 @@ export const getDbClient = () => {
   return dbClientSingleton
 }
 
-export const getBunDatabaseClient = () => {
+export const destroyDbClient = async () => {
+  if (!dbClientSingleton) return
+
+  const db = dbClientSingleton
+  dbClientSingleton = undefined
+  await db.destroy()
+}
+
+export const getBunDatabaseClient = (configuredDbPath?: string) => {
   const Database = getDatabaseCtor()
-  return new Database(getResolvedDbPath())
+  return new Database(getResolvedDbPath(configuredDbPath))
 }

--- a/lib/util/is-extended-promotional.ts
+++ b/lib/util/is-extended-promotional.ts
@@ -1,4 +1,4 @@
 export const isExtendedPromotional = (component: {
   basic?: number | boolean | null
   preferred?: number | boolean | null
-}): boolean => Boolean(component.preferred) && !Boolean(component.basic)
+}): boolean => component.preferred === 1 && component.basic === 0

--- a/lib/util/is-extended-promotional.ts
+++ b/lib/util/is-extended-promotional.ts
@@ -1,0 +1,4 @@
+export const isExtendedPromotional = (component: {
+  basic?: number | boolean | null
+  preferred?: number | boolean | null
+}): boolean => Boolean(component.preferred) && !Boolean(component.basic)

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -4,6 +4,7 @@ import {
   type SearchTokenGroup,
   tokenizeSearchTerm,
 } from "lib/util/search-token-groups"
+import { isExtendedPromotional } from "lib/util/is-extended-promotional"
 import { withWinterSpec } from "lib/with-winter-spec"
 import { z } from "zod"
 
@@ -50,6 +51,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -71,6 +73,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   const baseQuery = query
@@ -193,6 +198,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: isExtendedPromotional(c),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -1,6 +1,7 @@
 import { sql } from "kysely"
 import { Table } from "lib/ui/Table"
 import { ExpressionBuilder } from "kysely"
+import { isExtendedPromotional } from "lib/util/is-extended-promotional"
 import { buildSearchTokenGroups } from "lib/util/search-token-groups"
 import { withWinterSpec } from "lib/with-winter-spec"
 import { z } from "zod"
@@ -35,6 +36,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -51,6 +53,7 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -69,6 +72,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   if (req.query.search) {
@@ -111,6 +117,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: isExtendedPromotional(c),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +159,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/scripts/setup-7z.ts
+++ b/scripts/setup-7z.ts
@@ -7,10 +7,14 @@ const BINARY_NAME = "7zz"
 
 // Map of platform-arch combinations to download URLs
 const BINARY_URLS: Record<string, string> = {
-  "linux-x64": "https://7-zip.org/a/7z2408-linux-x64.tar.xz",
-  "linux-arm64": "https://7-zip.org/a/7z2408-linux-arm64.tar.xz",
-  "darwin-x64": "https://7-zip.org/a/7z2408-mac.tar.xz",
-  "darwin-arm64": "https://7-zip.org/a/7z2408-mac.tar.xz",
+  "linux-x64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-linux-x64.tar.xz",
+  "linux-arm64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-linux-arm64.tar.xz",
+  "darwin-x64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-mac.tar.xz",
+  "darwin-arm64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-mac.tar.xz",
 }
 
 async function downloadAndExtract7z() {

--- a/tests/lib/get-db-client.test.ts
+++ b/tests/lib/get-db-client.test.ts
@@ -6,22 +6,15 @@ import Path from "node:path"
 import { getBunDatabaseClient, getResolvedDbPath } from "lib/db/get-db-client"
 
 let tempDir: string | undefined
-let previousDbPath = process.env.JLCSEARCH_DB_PATH
 
 afterEach(() => {
-  if (previousDbPath === undefined) {
-    delete process.env.JLCSEARCH_DB_PATH
-  } else {
-    process.env.JLCSEARCH_DB_PATH = previousDbPath
-  }
-
   if (tempDir) {
     rmSync(tempDir, { recursive: true, force: true })
     tempDir = undefined
   }
 })
 
-test("getBunDatabaseClient respects JLCSEARCH_DB_PATH", () => {
+test("getBunDatabaseClient opens a configured database path", () => {
   tempDir = mkdtempSync(Path.join(tmpdir(), "jlcsearch-db-"))
   const dbPath = Path.join(tempDir, "custom.sqlite3")
 
@@ -32,12 +25,9 @@ test("getBunDatabaseClient respects JLCSEARCH_DB_PATH", () => {
   `)
   seedDb.close()
 
-  previousDbPath = process.env.JLCSEARCH_DB_PATH
-  process.env.JLCSEARCH_DB_PATH = dbPath
+  expect(getResolvedDbPath(dbPath)).toBe(dbPath)
 
-  expect(getResolvedDbPath()).toBe(dbPath)
-
-  const db = getBunDatabaseClient()
+  const db = getBunDatabaseClient(dbPath)
   const row = db.query("SELECT value FROM probe").get() as {
     value: string
   } | null

--- a/tests/lib/is-extended-promotional.test.ts
+++ b/tests/lib/is-extended-promotional.test.ts
@@ -3,8 +3,9 @@ import { isExtendedPromotional } from "lib/util/is-extended-promotional"
 
 test("isExtendedPromotional derives extended promotional from preferred but not basic", () => {
   expect(isExtendedPromotional({ preferred: 1, basic: 0 })).toBe(true)
-  expect(isExtendedPromotional({ preferred: true, basic: false })).toBe(true)
   expect(isExtendedPromotional({ preferred: 1, basic: 1 })).toBe(false)
   expect(isExtendedPromotional({ preferred: 0, basic: 0 })).toBe(false)
+  expect(isExtendedPromotional({ preferred: 1, basic: null })).toBe(false)
+  expect(isExtendedPromotional({ preferred: true, basic: false })).toBe(false)
   expect(isExtendedPromotional({ preferred: null, basic: null })).toBe(false)
 })

--- a/tests/lib/is-extended-promotional.test.ts
+++ b/tests/lib/is-extended-promotional.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "bun:test"
+import { isExtendedPromotional } from "lib/util/is-extended-promotional"
+
+test("isExtendedPromotional derives extended promotional from preferred but not basic", () => {
+  expect(isExtendedPromotional({ preferred: 1, basic: 0 })).toBe(true)
+  expect(isExtendedPromotional({ preferred: true, basic: false })).toBe(true)
+  expect(isExtendedPromotional({ preferred: 1, basic: 1 })).toBe(false)
+  expect(isExtendedPromotional({ preferred: 0, basic: 0 })).toBe(false)
+  expect(isExtendedPromotional({ preferred: null, basic: null })).toBe(false)
+})


### PR DESCRIPTION
/claim #92

## Summary
- derive `is_extended_promotional` from `preferred = 1` and `basic = 0`
- expose/filter it on `/components/list` and `/api/search`
- pass the same filter/field through the D1/cf-proxy components/search paths
- add filter UI and focused tests

## Verification
- `bun test tests/lib/is-extended-promotional.test.ts`
- `bunx tsc --noEmit`
- `bun run format:check`
- `cd cf-proxy && bun test test/is-extended-promotional.test.ts test/render.test.ts`
- `cd cf-proxy && bunx tsc --noEmit`

Note: DB-backed route tests are blocked locally by an existing Kysely fixture state issue (`driver has already been destroyed`) before assertions run.