### PR TITLE
feat: add is_extended_promotional filterable column to components

### DIFF
--- a/lib/db/derivedtables/capacitor.ts
+++ b/lib/db/derivedtables/capacitor.ts
@@ -34,6 +34,7 @@ export const capacitorTableSpec: DerivedTableSpec<Capacitor> = {
     { name: "capacitor_type", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -115,6 +116,7 @@ export const capacitorTableSpec: DerivedTableSpec<Capacitor> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: c.basic === 2,
         capacitance_farads: capacitance,
         tolerance_fraction: tolerance,
         voltage_rating: voltage,

--- a/lib/db/derivedtables/component-base.ts
+++ b/lib/db/derivedtables/component-base.ts
@@ -7,5 +7,6 @@ export interface BaseComponent {
   in_stock: boolean
   is_basic: boolean
   is_preferred: boolean
+  is_extended_promotional: boolean
   attributes: Record<string, string>
 }

--- a/lib/db/derivedtables/resistor.ts
+++ b/lib/db/derivedtables/resistor.ts
@@ -31,6 +31,7 @@ export const resistorTableSpec: DerivedTableSpec<Resistor> = {
     { name: "is_multi_resistor_chip", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -82,6 +83,7 @@ export const resistorTableSpec: DerivedTableSpec<Resistor> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: c.basic === 2,
         resistance: resistance,
         tolerance_fraction: tolerance,
         power_watts,

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -164,6 +164,7 @@ export interface Capacitor {
   esr_ohms: number | null;
   in_stock: number | null;
   is_basic: number | null;
+  is_extended_promotional: number | null;
   is_polarized: number | null;
   is_preferred: number | null;
   is_surface_mount: number | null;
@@ -712,6 +713,7 @@ export interface Resistor {
   description: string | null;
   in_stock: number | null;
   is_basic: number | null;
+  is_extended_promotional: number | null;
   is_multi_resistor_chip: number | null;
   is_potentiometer: number | null;
   is_preferred: number | null;

--- a/routes/capacitors/list.tsx
+++ b/routes/capacitors/list.tsx
@@ -13,6 +13,7 @@ export default withWinterSpec({
     package: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
     capacitance: z
       .string()
       .optional()
@@ -32,6 +33,7 @@ export default withWinterSpec({
           package: z.string(),
           is_basic: z.boolean(),
           is_preferred: z.boolean(),
+          is_extended_promotional: z.boolean(),
           capacitance: z.number(),
           voltage: z.number().optional(),
           type: z.string().optional(),
@@ -62,6 +64,9 @@ export default withWinterSpec({
   if (params.is_preferred) {
     query = query.where("is_preferred", "=", 1)
   }
+  if (params.is_extended_promotional) {
+    query = query.where("is_extended_promotional", "=", 1)
+  }
 
   // Apply capacitance filter with a small tolerance for rounding errors
   if (params.capacitance != null) {
@@ -89,6 +94,7 @@ export default withWinterSpec({
           package: c.package ?? "",
           is_basic: Boolean(c.is_basic),
           is_preferred: Boolean(c.is_preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           capacitance: c.capacitance_farads ?? 0,
           voltage: c.voltage_rating ?? undefined,
           type: c.capacitor_type ?? undefined,
@@ -145,6 +151,18 @@ export default withWinterSpec({
         </div>
 
         <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={params.is_extended_promotional}
+            />
+          </label>
+        </div>
+
+        <div>
           <label>Capacitance:</label>
           <input
             type="text"
@@ -164,6 +182,7 @@ export default withWinterSpec({
           package: c.package,
           is_basic: c.is_basic ? "✓" : "",
           is_preferred: c.is_preferred ? "✓" : "",
+          is_extended_promotional: c.is_extended_promotional ? "✓" : "",
           capacitance: (
             <span className="tabular-nums">
               {formatSiUnit(c.capacitance_farads)}F

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -35,6 +35,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -69,6 +70,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("basic", "=", 2)
   }
 
   if (req.query.search) {
@@ -111,6 +115,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: c.basic === 2,
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +157,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/routes/resistors/list.tsx
+++ b/routes/resistors/list.tsx
@@ -13,6 +13,7 @@ export default withWinterSpec({
     package: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
     resistance: z
       .string()
       .optional()
@@ -32,6 +33,7 @@ export default withWinterSpec({
           package: z.string(),
           is_basic: z.boolean(),
           is_preferred: z.boolean(),
+          is_extended_promotional: z.boolean(),
           resistance: z.number(),
           tolerance_fraction: z.number().optional(),
           power_watts: z.number().optional(),
@@ -62,6 +64,9 @@ export default withWinterSpec({
   if (params.is_preferred) {
     query = query.where("is_preferred", "=", 1)
   }
+  if (params.is_extended_promotional) {
+    query = query.where("is_extended_promotional", "=", 1)
+  }
 
   // Apply resistance filter with a small tolerance for rounding errors
   if (params.resistance != null) {
@@ -88,6 +93,7 @@ export default withWinterSpec({
           package: r.package ?? "",
           is_basic: Boolean(r.is_basic),
           is_preferred: Boolean(r.is_preferred),
+          is_extended_promotional: Boolean(r.is_extended_promotional),
           resistance: r.resistance ?? 0,
           tolerance_fraction: r.tolerance_fraction ?? undefined,
           power_watts: r.power_watts ?? undefined,
@@ -144,6 +150,18 @@ export default withWinterSpec({
         </div>
 
         <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={params.is_extended_promotional}
+            />
+          </label>
+        </div>
+
+        <div>
           <label>Resistance:</label>
           <input
             type="text"
@@ -163,6 +181,7 @@ export default withWinterSpec({
           package: r.package,
           is_basic: r.is_basic ? "✓" : "",
           is_preferred: r.is_preferred ? "✓" : "",
+          is_extended_promotional: r.is_extended_promotional ? "✓" : "",
           resistance: (
             <span className="tabular-nums">{formatSiUnit(r.resistance)}Ω</span>
           ),

--- a/tests/lib/extended-promotional.test.ts
+++ b/tests/lib/extended-promotional.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "bun:test"
+import { resistorTableSpec } from "lib/db/derivedtables/resistor"
+import { capacitorTableSpec } from "lib/db/derivedtables/capacitor"
+
+const makeResistor = (overrides: Record<string, unknown> = {}) =>
+  ({
+    lcsc: 100,
+    mfr: "TEST-RES",
+    description: "10kΩ Resistor",
+    stock: 1000,
+    basic: 0,
+    preferred: 0,
+    price: JSON.stringify([{ qFrom: 1, qTo: null, price: 0.01 }]),
+    package: "0402",
+    extra: JSON.stringify({
+      attributes: {
+        Resistance: "10kΩ",
+        Tolerance: "±1%",
+        "Power(Watts)": "0.1W",
+      },
+    }),
+    ...overrides,
+  }) as any
+
+const makeCapacitor = (overrides: Record<string, unknown> = {}) =>
+  ({
+    lcsc: 200,
+    mfr: "TEST-CAP",
+    description: "100nF Ceramic Capacitor",
+    stock: 5000,
+    basic: 0,
+    preferred: 0,
+    price: JSON.stringify([{ qFrom: 1, qTo: null, price: 0.005 }]),
+    package: "0402",
+    extra: JSON.stringify({
+      attributes: {
+        Capacitance: "100nF",
+        Tolerance: "±10%",
+        "Rated Voltage": "50V",
+      },
+    }),
+    ...overrides,
+  }) as any
+
+test("resistor with basic=0 has is_extended_promotional=false", () => {
+  const [resistor] = resistorTableSpec.mapToTable([makeResistor({ basic: 0 })])
+  expect(resistor?.is_extended_promotional).toBe(false)
+})
+
+test("resistor with basic=1 has is_extended_promotional=false", () => {
+  const [resistor] = resistorTableSpec.mapToTable([makeResistor({ basic: 1 })])
+  expect(resistor?.is_extended_promotional).toBe(false)
+})
+
+test("resistor with basic=2 has is_extended_promotional=true", () => {
+  const [resistor] = resistorTableSpec.mapToTable([makeResistor({ basic: 2 })])
+  expect(resistor?.is_extended_promotional).toBe(true)
+})
+
+test("resistor with basic=2 still has is_basic=true (acts as basic)", () => {
+  const [resistor] = resistorTableSpec.mapToTable([makeResistor({ basic: 2 })])
+  expect(resistor?.is_basic).toBe(true)
+})
+
+test("resistor with basic=1 has is_basic=true and is_extended_promotional=false", () => {
+  const [resistor] = resistorTableSpec.mapToTable([makeResistor({ basic: 1 })])
+  expect(resistor?.is_basic).toBe(true)
+  expect(resistor?.is_extended_promotional).toBe(false)
+})
+
+test("capacitor with basic=0 has is_extended_promotional=false", () => {
+  const [cap] = capacitorTableSpec.mapToTable([makeCapacitor({ basic: 0 })])
+  expect(cap?.is_extended_promotional).toBe(false)
+})
+
+test("capacitor with basic=2 has is_extended_promotional=true", () => {
+  const [cap] = capacitorTableSpec.mapToTable([makeCapacitor({ basic: 2 })])
+  expect(cap?.is_extended_promotional).toBe(true)
+})
+
+test("capacitor with basic=2 still has is_basic=true (acts as basic)", () => {
+  const [cap] = capacitorTableSpec.mapToTable([makeCapacitor({ basic: 2 })])
+  expect(cap?.is_basic).toBe(true)
+})

--- a/tests/routes/resistors/list.test.ts
+++ b/tests/routes/resistors/list.test.ts
@@ -16,7 +16,24 @@ test("GET /resistors/list with json param returns resistor data", async () => {
     expect(resistor).toHaveProperty("mfr")
     expect(resistor).toHaveProperty("package")
     expect(resistor).toHaveProperty("resistance")
+    expect(resistor).toHaveProperty("is_extended_promotional")
     expect(typeof resistor.lcsc).toBe("number")
+    expect(typeof resistor.is_extended_promotional).toBe("boolean")
+  }
+})
+
+test("GET /resistors/list with is_extended_promotional filter returns only extended promotional parts", async () => {
+  const { axios } = await getTestServer()
+
+  const res = await axios.get(
+    "/resistors/list?json=true&is_extended_promotional=true",
+  )
+
+  expect(res.data).toHaveProperty("resistors")
+  expect(Array.isArray(res.data.resistors)).toBe(true)
+
+  for (const resistor of res.data.resistors) {
+    expect(resistor.is_extended_promotional).toBe(true)
   }
 })
 


### PR DESCRIPTION
## Summary

Closes #92

Extended promotional parts on JLCPCB temporarily act as basic parts (no assembly surcharge), but currently the data has no way to identify them separately from permanent basic parts. The source database encodes this with `basic = 2` (vs `basic = 1` for regular basic, `basic = 0` for extended).

This PR adds `is_extended_promotional` as a filterable boolean column to the component search API and UI.

## Changes

- **`lib/db/derivedtables/component-base.ts`** — adds `is_extended_promotional: boolean` to `BaseComponent` interface
- **`lib/db/derivedtables/resistor.ts`** — adds `is_extended_promotional` to `extraColumns` and maps `c.basic === 2`
- **`lib/db/derivedtables/capacitor.ts`** — same as resistor
- **`lib/db/generated/kysely.ts`** — adds `is_extended_promotional` to generated `Resistor` and `Capacitor` interfaces (run `bun run generate:db-types` after rebuilding derived tables)
- **`routes/resistors/list.tsx`** — adds `is_extended_promotional` query param, filter, JSON field, and UI checkbox
- **`routes/capacitors/list.tsx`** — same as resistors route
- **`routes/components/list.tsx`** — adds `is_extended_promotional` filter (`basic = 2`) and JSON field

## Acceptance Criteria

- [x] `is_extended_promotional` is available as a filterable column in resistor and capacitor search routes
- [x] `is_extended_promotional` is available in the generic `/components/list` route
- [x] Existing `is_basic` behavior is unchanged (extended promotional parts with `basic=2` still appear when filtering `is_basic=true`)
- [x] UI checkboxes added to resistor, capacitor, and components list pages
- [x] JSON API responses include `is_extended_promotional` field

## Testing

- Added `tests/lib/extended-promotional.test.ts` with 8 unit tests covering:
  - `basic=0` → `is_extended_promotional=false`
  - `basic=1` → `is_extended_promotional=false`
  - `basic=2` → `is_extended_promotional=true`
  - `basic=2` still gives `is_basic=true` (acts as basic per issue description)
  - Tests cover both resistor and capacitor table specs
- Extended route test in `tests/routes/resistors/list.test.ts` to verify `is_extended_promotional` field appears in API response and filter works

All 18 existing lib tests pass. All 8 new tests pass.

## Notes for other derived tables

The same 3-line pattern (add to `extraColumns`, set `is_extended_promotional: c.basic === 2` in `mapToTable`, update route) can be applied to all remaining derived table specs (leds, microcontrollers, etc.) following the same pattern established here.

---
*This PR was created with AI assistance (Claude).*