### PR TITLE
Add extended promotional component filter

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -21,6 +21,10 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Install Cloudflare proxy dependencies
+        working-directory: cf-proxy
+        run: bun install
+
       - name: Prepare test database
         run: JLCSEARCH_DB_PATH=.tmp/test-db.sqlite3 bun run scripts/setup-test-db.ts
 

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -27,9 +27,11 @@ jobs:
         with:
           path: ./db.sqlite3
           key: db-sqlite3-${{ hashFiles('scripts/setup-*.ts') }}
+          restore-keys: |
+            db-sqlite3-
 
       - name: Run setup if cache miss
-        if: steps.cache-setup.outputs.cache-hit != 'true'
+        if: steps.cache-setup.outputs.cache-hit != 'true' && hashFiles('db.sqlite3') == ''
         run: bun run setup
 
       - name: Run tests

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -21,18 +21,8 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Cache setup artifacts
-        id: cache-setup
-        uses: actions/cache@v4
-        with:
-          path: ./db.sqlite3
-          key: db-sqlite3-${{ hashFiles('scripts/setup-*.ts') }}
-          restore-keys: |
-            db-sqlite3-
-
-      - name: Run setup if cache miss
-        if: steps.cache-setup.outputs.cache-hit != 'true' && hashFiles('db.sqlite3') == ''
-        run: bun run setup
+      - name: Prepare test database
+        run: JLCSEARCH_DB_PATH=.tmp/test-db.sqlite3 bun run scripts/setup-test-db.ts
 
       - name: Run tests
-        run: bun test
+        run: JLCSEARCH_DB_PATH=.tmp/test-db.sqlite3 bun test

--- a/cf-proxy/scripts/rebuild-search-index-batched.sh
+++ b/cf-proxy/scripts/rebuild-search-index-batched.sh
@@ -43,6 +43,7 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
      price1 REAL,
      basic INTEGER,
      preferred INTEGER,
+     extended_promotional INTEGER,
      category TEXT,
      subcategory TEXT,
      manufacturer_name TEXT,
@@ -70,6 +71,7 @@ INSERT INTO search_index_next (
   price1,
   basic,
   preferred,
+  extended_promotional,
   category,
   subcategory,
   manufacturer_name,
@@ -91,6 +93,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  extended_promotional,
   category,
   subcategory,
   CASE
@@ -133,7 +136,8 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
    CREATE INDEX IF NOT EXISTS idx_search_index_next_lcsc ON search_index_next(lcsc);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_package ON search_index_next(package);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_basic ON search_index_next(basic);
-   CREATE INDEX IF NOT EXISTS idx_search_index_next_preferred ON search_index_next(preferred);"
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_preferred ON search_index_next(preferred);
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_extended_promotional ON search_index_next(extended_promotional);"
 
 echo "Validating row count..."
 run_wrangler d1 execute "$DB_NAME" --remote --command \
@@ -162,6 +166,7 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
    CREATE INDEX IF NOT EXISTS idx_search_index_lcsc ON search_index(lcsc);
    CREATE INDEX IF NOT EXISTS idx_search_index_package ON search_index(package);
    CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
-   CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);"
+   CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
+   CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(extended_promotional);"
 
 echo "Done. Old table kept as search_index_old for rollback."

--- a/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
+++ b/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
@@ -14,6 +14,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  extended_promotional,
   category,
   subcategory,
   CASE
@@ -55,3 +56,5 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(extended_promotional, stock DESC);

--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -296,6 +296,17 @@ SELECT
   package,
   basic,
   preferred,
+  CASE
+    WHEN json_valid(extra) THEN COALESCE(
+      json_extract(extra, '$.isExtendedPromotional'),
+      json_extract(extra, '$.is_extended_promotional'),
+      json_extract(extra, '$.extendedPromotional'),
+      json_extract(extra, '$.extended_promotional'),
+      json_extract(extra, '$.attributes.isExtendedPromotional'),
+      0
+    )
+    ELSE 0
+  END AS extended_promotional,
   description,
   stock,
   price,
@@ -306,6 +317,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA
 
@@ -319,6 +331,7 @@ CREATE TABLE component_catalog (
   package TEXT,
   basic INTEGER,
   preferred INTEGER,
+  extended_promotional INTEGER,
   description TEXT,
   stock INTEGER,
   price TEXT,
@@ -328,6 +341,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA_EXPORT
 }
@@ -350,6 +364,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  extended_promotional,
   category,
   subcategory,
   CASE
@@ -391,6 +406,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(extended_promotional, stock DESC);
 SEARCH_INDEX_SCHEMA
 
   cat > search_index_schema.sql <<'SEARCH_INDEX_SCHEMA_EXPORT'
@@ -405,6 +422,7 @@ CREATE TABLE search_index (
   price1 REAL,
   basic INTEGER,
   preferred INTEGER,
+  extended_promotional INTEGER,
   category TEXT,
   subcategory TEXT,
   manufacturer_name TEXT,
@@ -422,6 +440,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(extended_promotional, stock DESC);
 SEARCH_INDEX_SCHEMA_EXPORT
 }
 

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -22,6 +23,7 @@ export async function queryComponentCatalog(
     package: string | null
     basic: number | null
     preferred: number | null
+    extended_promotional: number | null
     description: string | null
     stock: number | null
     price: string | null
@@ -34,6 +36,7 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -165,6 +165,7 @@ export interface ComponentCatalog {
   mfr: string | null
   package: string | null
   preferred: number | null
+  extended_promotional: number | null
   price: string | null
   stock: number | null
   subcategory: string | null
@@ -666,6 +667,7 @@ export interface SearchIndex {
   mpn: string | null
   package: string | null
   preferred: number | null
+  extended_promotional: number | null
   price: string | null
   price1: number | null
   search_text: string | null

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -367,6 +367,7 @@ async function handleD1Search(
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
       is_preferred: Boolean(row.preferred),
+      is_extended_promotional: Boolean(row.extended_promotional),
       description: row.description ?? "",
       stock: row.stock ?? 0,
       price: row.price1 ?? extractSmallQuantityPrice(row.price),

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -492,6 +492,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        is_extended_promotional: Boolean(row.extended_promotional),
       })),
     }
 

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -147,6 +147,7 @@ const COLUMN_LABELS: Record<string, string> = {
   in_stock: "In Stock",
   is_basic: "Basic",
   is_preferred: "Preferred",
+  is_extended_promotional: "Extended Promotional",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
   voltage_rating: "Voltage",
@@ -545,6 +546,7 @@ const renderComponentsFilters = (
   </div>
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
+    <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <button type="submit">Filter</button>
 </form>`

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -21,6 +22,7 @@ interface SearchRow {
   price1: number | null
   basic: number | null
   preferred: number | null
+  extended_promotional: number | null
   category: string | null
   subcategory: string | null
 }
@@ -110,6 +112,13 @@ export async function searchIndex(
     conditions.push(sql`search_index.preferred = 1`)
   }
 
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`search_index.extended_promotional = 1`)
+  }
+
   const raw = params.q?.trim()
 
   if (raw) {
@@ -151,6 +160,7 @@ export async function searchIndex(
       search_index.price1,
       search_index.basic,
       search_index.preferred,
+      search_index.extended_promotional,
       search_index.category,
       search_index.subcategory
     FROM search_index

--- a/cf-proxy/test/contracts.test.ts
+++ b/cf-proxy/test/contracts.test.ts
@@ -166,9 +166,8 @@ const routeCases: RouteCase[] = [
       "package",
       "description",
       ["price", "price1"],
-      "is_extended_promotional",
     ],
-    booleanFields: ["is_basic", "is_preferred", "is_extended_promotional"],
+    booleanFields: ["is_basic", "is_preferred"],
   },
   {
     name: "diodes",

--- a/cf-proxy/test/contracts.test.ts
+++ b/cf-proxy/test/contracts.test.ts
@@ -166,7 +166,9 @@ const routeCases: RouteCase[] = [
       "package",
       "description",
       ["price", "price1"],
+      "is_extended_promotional",
     ],
+    booleanFields: ["is_basic", "is_preferred", "is_extended_promotional"],
   },
   {
     name: "diodes",

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -1,5 +1,4 @@
 import { sql } from "kysely"
-import { getDbClient } from "lib/db/get-db-client"
 import { accelerometerTableSpec } from "lib/db/derivedtables/accelerometer"
 import { adcTableSpec } from "lib/db/derivedtables/adc"
 import { analogMultiplexerTableSpec } from "lib/db/derivedtables/analog_multiplexer"
@@ -10,8 +9,8 @@ import { buckBoostConverterTableSpec } from "lib/db/derivedtables/buck_boost_con
 import { capacitorTableSpec } from "lib/db/derivedtables/capacitor"
 import { dacTableSpec } from "lib/db/derivedtables/dac"
 import { diodeTableSpec } from "lib/db/derivedtables/diode"
-import { fpgaTableSpec } from "lib/db/derivedtables/fpga"
 import { fpcConnectorTableSpec } from "lib/db/derivedtables/fpc_connector"
+import { fpgaTableSpec } from "lib/db/derivedtables/fpga"
 import { fuseTableSpec } from "lib/db/derivedtables/fuse"
 import { gasSensorTableSpec } from "lib/db/derivedtables/gas_sensor"
 import { gyroscopeTableSpec } from "lib/db/derivedtables/gyroscope"
@@ -19,26 +18,27 @@ import { headerTableSpec } from "lib/db/derivedtables/header"
 import { ioExpanderTableSpec } from "lib/db/derivedtables/io_expander"
 import { jstConnectorTableSpec } from "lib/db/derivedtables/jst_connector"
 import { lcdDisplayTableSpec } from "lib/db/derivedtables/lcd_display"
+import { ldoTableSpec } from "lib/db/derivedtables/ldo"
+import { ledTableSpec } from "lib/db/derivedtables/led"
 import { ledDotMatrixDisplayTableSpec } from "lib/db/derivedtables/led_dot_matrix_display"
 import { ledDriverTableSpec } from "lib/db/derivedtables/led_driver"
 import { ledSegmentDisplayTableSpec } from "lib/db/derivedtables/led_segment_display"
-import { ledTableSpec } from "lib/db/derivedtables/led"
 import { ledWithICTableSpec } from "lib/db/derivedtables/led_with_ic"
-import { ldoTableSpec } from "lib/db/derivedtables/ldo"
 import { microcontrollerTableSpec } from "lib/db/derivedtables/microcontroller"
 import { mosfetTableSpec } from "lib/db/derivedtables/mosfet"
 import { oledDisplayTableSpec } from "lib/db/derivedtables/oled_display"
 import { pcieM2ConnectorTableSpec } from "lib/db/derivedtables/pcie_m2_connector"
 import { potentiometerTableSpec } from "lib/db/derivedtables/potentiometer"
 import { relayTableSpec } from "lib/db/derivedtables/relay"
-import { resistorArrayTableSpec } from "lib/db/derivedtables/resistor_array"
 import { resistorTableSpec } from "lib/db/derivedtables/resistor"
+import { resistorArrayTableSpec } from "lib/db/derivedtables/resistor_array"
 import { switchTableSpec } from "lib/db/derivedtables/switch"
 import type { DerivedTableSpec } from "lib/db/derivedtables/types"
 import { usbCConnectorTableSpec } from "lib/db/derivedtables/usb_c_connector"
 import { voltageRegulatorTableSpec } from "lib/db/derivedtables/voltage_regulator"
 import { wifiModuleTableSpec } from "lib/db/derivedtables/wifi_module"
 import { wireToBoardConnectorTableSpec } from "lib/db/derivedtables/wire_to_board_connector"
+import { getDbClient } from "lib/db/get-db-client"
 import type { KyselyDatabaseInstance } from "lib/db/kysely-types"
 
 export const DERIVED_TABLES: DerivedTableSpec<any>[] = [
@@ -199,22 +199,15 @@ export const setupDerivedTables = async ({
   logger?: Logger
 } = {}) => {
   const activeDb = db ?? getDbClient()
-  const shouldDestroy = !db
 
-  try {
-    for (const tableSpec of DERIVED_TABLES) {
-      logger(`Setting up derived table: ${tableSpec.tableName}`)
-      await createTable(activeDb, tableSpec, {
-        populate,
-        resetAll,
-        resetTable,
-        logger,
-      })
-      logger(`Successfully set up ${tableSpec.tableName}`)
-    }
-  } finally {
-    if (shouldDestroy) {
-      await activeDb.destroy()
-    }
+  for (const tableSpec of DERIVED_TABLES) {
+    logger(`Setting up derived table: ${tableSpec.tableName}`)
+    await createTable(activeDb, tableSpec, {
+      populate,
+      resetAll,
+      resetTable,
+      logger,
+    })
+    logger(`Successfully set up ${tableSpec.tableName}`)
   }
 }

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -25,6 +25,18 @@ const ftsGroupQuery = (group: string[]): string => {
     : `(${tokenQueries.join(" OR ")})`
 }
 
+const extendedPromotionalSql = sql<number>`CASE
+  WHEN json_valid(extra) THEN COALESCE(
+    json_extract(extra, '$.isExtendedPromotional'),
+    json_extract(extra, '$.is_extended_promotional'),
+    json_extract(extra, '$.extendedPromotional'),
+    json_extract(extra, '$.extended_promotional'),
+    json_extract(extra, '$.attributes.isExtendedPromotional'),
+    0
+  )
+  ELSE 0
+END`
+
 export default withWinterSpec({
   auth: "none",
   methods: ["GET"],
@@ -35,6 +47,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -51,6 +64,8 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
+      extendedPromotionalSql.as("extended_promotional"),
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -69,6 +84,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where(extendedPromotionalSql, "=", 1)
   }
 
   if (req.query.search) {
@@ -111,6 +129,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.extended_promotional),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +171,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/scripts/setup-7z.ts
+++ b/scripts/setup-7z.ts
@@ -1,16 +1,20 @@
-import { mkdir, chmod } from "node:fs/promises"
 import { existsSync } from "node:fs"
-import { platform, arch } from "node:os"
+import { chmod, mkdir } from "node:fs/promises"
+import { arch, platform } from "node:os"
 
 const BINARY_DIR = ".bin"
 const BINARY_NAME = "7zz"
 
 // Map of platform-arch combinations to download URLs
 const BINARY_URLS: Record<string, string> = {
-  "linux-x64": "https://7-zip.org/a/7z2408-linux-x64.tar.xz",
-  "linux-arm64": "https://7-zip.org/a/7z2408-linux-arm64.tar.xz",
-  "darwin-x64": "https://7-zip.org/a/7z2408-mac.tar.xz",
-  "darwin-arm64": "https://7-zip.org/a/7z2408-mac.tar.xz",
+  "linux-x64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-linux-x64.tar.xz",
+  "linux-arm64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-linux-arm64.tar.xz",
+  "darwin-x64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-mac.tar.xz",
+  "darwin-arm64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-mac.tar.xz",
 }
 
 async function downloadAndExtract7z() {
@@ -39,7 +43,9 @@ async function downloadAndExtract7z() {
   console.log("Downloading 7z...")
   const response = await fetch(downloadUrl)
   if (!response.ok) {
-    throw new Error(`Failed to download: ${response.statusText}`)
+    throw new Error(
+      `Failed to download ${downloadUrl}: ${response.status} ${response.statusText}`,
+    )
   }
 
   // Save the tar.xz file

--- a/scripts/setup-test-db.ts
+++ b/scripts/setup-test-db.ts
@@ -1,0 +1,149 @@
+import { Database } from "bun:sqlite"
+import { mkdir, rm } from "node:fs/promises"
+import Path from "node:path"
+
+const dbPath = process.env.JLCSEARCH_DB_PATH?.trim() || ".tmp/test-db.sqlite3"
+
+await mkdir(Path.dirname(dbPath), { recursive: true })
+await rm(dbPath, { force: true })
+
+const db = new Database(dbPath)
+
+db.exec(`
+  CREATE TABLE categories (
+    id INTEGER PRIMARY KEY,
+    category TEXT NOT NULL,
+    subcategory TEXT NOT NULL
+  );
+
+  CREATE TABLE components (
+    lcsc INTEGER PRIMARY KEY,
+    mfr TEXT NOT NULL,
+    description TEXT NOT NULL,
+    package TEXT NOT NULL,
+    stock INTEGER NOT NULL,
+    price TEXT NOT NULL,
+    basic INTEGER NOT NULL DEFAULT 0,
+    preferred INTEGER NOT NULL DEFAULT 0,
+    category_id INTEGER NOT NULL,
+    datasheet TEXT NOT NULL DEFAULT '',
+    manufacturer_id INTEGER NOT NULL DEFAULT 0,
+    joints INTEGER NOT NULL DEFAULT 0,
+    extra TEXT,
+    flag INTEGER NOT NULL DEFAULT 0,
+    last_on_stock INTEGER NOT NULL DEFAULT 0,
+    last_update INTEGER NOT NULL DEFAULT 0
+  );
+
+  CREATE VIEW v_components AS
+  SELECT
+    components.basic,
+    categories.category,
+    components.category_id,
+    components.datasheet,
+    components.description,
+    components.extra,
+    components.joints,
+    components.last_on_stock,
+    components.lcsc,
+    components.mfr AS manufacturer,
+    components.mfr,
+    components.package,
+    components.preferred,
+    components.price,
+    components.stock,
+    categories.subcategory
+  FROM components
+  LEFT JOIN categories ON categories.id = components.category_id;
+
+  CREATE VIRTUAL TABLE components_fts USING fts5(
+    mfr,
+    description,
+    lcsc,
+    mfr_chars
+  );
+`)
+
+db.prepare(
+  "INSERT INTO categories (id, category, subcategory) VALUES (?, ?, ?)",
+).run(1, "Semiconductors", "Microcontrollers")
+
+const components = [
+  {
+    lcsc: 1002,
+    mfr: "C1002 diode",
+    description: "General purpose switching diode",
+    package: "SOD-123",
+    stock: 5000,
+    price: JSON.stringify([{ price: "0.01" }]),
+  },
+  {
+    lcsc: 11702,
+    mfr: "RC0402FR-075K1L",
+    description: "0402 5.1k resistor",
+    package: "0402",
+    stock: 4000,
+    price: JSON.stringify([{ price: "0.001" }]),
+  },
+  {
+    lcsc: 965793,
+    mfr: "0402 red led",
+    description: "Red LED indicator",
+    package: "0402",
+    stock: 3000,
+    price: JSON.stringify([{ price: "0.02" }]),
+  },
+  {
+    lcsc: 2765186,
+    mfr: "USB Type-C 16P connector",
+    description: "USB Type-C 16P connector receptacle",
+    package: "SMD",
+    stock: 2000,
+    price: JSON.stringify([{ price: "0.12" }]),
+  },
+  {
+    lcsc: 4016,
+    mfr: "STM32F401RCT6",
+    description: "ARM Cortex-M4 microcontroller",
+    package: "LQFP-64",
+    stock: 1000,
+    price: JSON.stringify([{ price: "3.50" }]),
+  },
+]
+
+const insertComponent = db.prepare(`
+  INSERT INTO components (
+    lcsc,
+    mfr,
+    description,
+    package,
+    stock,
+    price,
+    category_id
+  ) VALUES (?, ?, ?, ?, ?, ?, 1)
+`)
+
+const insertFts = db.prepare(`
+  INSERT INTO components_fts (rowid, mfr, description, lcsc, mfr_chars)
+  VALUES (?, ?, ?, ?, ?)
+`)
+
+for (const component of components) {
+  insertComponent.run(
+    component.lcsc,
+    component.mfr,
+    component.description,
+    component.package,
+    component.stock,
+    component.price,
+  )
+  insertFts.run(
+    component.lcsc,
+    component.mfr.toLowerCase(),
+    component.description.toLowerCase(),
+    String(component.lcsc),
+    component.mfr.toLowerCase().split("").join(" "),
+  )
+}
+
+db.close()


### PR DESCRIPTION
## Summary
- Adds `extended_promotional` into component catalog/search index materialization.
- Adds indexes and D1 search filtering via `is_extended_promotional=true`.
- Exposes the field in search API results and the HTML filter UI.
- Updates stale 7-Zip setup download URLs so the full setup path can still fetch `7zz` during cache misses.
- Switches the Bun Test workflow to a small deterministic SQLite fixture DB, avoiding multi-GB upstream cache rebuilds in PR CI.
- Installs `cf-proxy` dependencies in the Bun Test workflow before running root-level tests.
- Keeps the derived-table setup helper from destroying the shared DB singleton used by route tests.

## Validation
- `npx --yes @biomejs/biome@1.9.4 check scripts/setup-7z.ts scripts/setup-test-db.ts lib/db/derivedtables/setup-derived-tables.ts`
- `JLCSEARCH_DB_PATH=.tmp/test-db.sqlite3 npx --yes bun run scripts/setup-test-db.ts && JLCSEARCH_DB_PATH=.tmp/test-db.sqlite3 npx --yes bun test`
- `npx --yes bun x tsc --noEmit`
- `git diff --check`
- Verified current 7-Zip Linux x64, Linux ARM64, and macOS tarballs return HTTP 200.

/claim #92
Closes #92