### PR TITLE
Expose extended promotional component filter

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -21,16 +21,8 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Cache setup artifacts
-        id: cache-setup
-        uses: actions/cache@v4
-        with:
-          path: ./db.sqlite3
-          key: db-sqlite3-${{ hashFiles('scripts/setup-*.ts') }}
-
-      - name: Run setup if cache miss
-        if: steps.cache-setup.outputs.cache-hit != 'true'
-        run: bun run setup
+      - name: Install cf-proxy dependencies
+        run: cd cf-proxy && bun install
 
       - name: Run tests
         run: bun test

--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,7 @@ dist
 db.sqlite3
 .buildtmp
 .winterspec
+.tmp
 db.backup.sqlite3
 .bin
 .fly.toml.swp

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -34,6 +35,7 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -367,6 +367,7 @@ async function handleD1Search(
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
       is_preferred: Boolean(row.preferred),
+      is_extended_promotional: Boolean(row.preferred) && !Boolean(row.basic),
       description: row.description ?? "",
       stock: row.stock ?? 0,
       price: row.price1 ?? extractSmallQuantityPrice(row.price),
@@ -491,6 +492,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        is_extended_promotional: Boolean(row.preferred) && !Boolean(row.basic),
       })),
     }
 

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -546,6 +546,9 @@ const renderComponentsFilters = (
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
   </div>
+  <div>
+    <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
+  </div>
   <button type="submit">Filter</button>
 </form>`
 

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -108,6 +109,13 @@ export async function searchIndex(
 
   if (params.is_preferred === "true" || params.is_preferred === "1") {
     conditions.push(sql`search_index.preferred = 1`)
+  }
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`search_index.preferred = 1`)
+    conditions.push(sql`search_index.basic = 0`)
   }
 
   const raw = params.q?.trim()

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -59,4 +59,26 @@ describe("render helpers", () => {
       "Feature&quot;:&quot;Overcurrent Protection(OCP)&quot;",
     )
   })
+
+  it("renders the extended promotional components filter and column", () => {
+    const html = renderD1TablePage(
+      "/components/list",
+      {
+        components: [
+          {
+            lcsc: 123,
+            mfr: "ABC123",
+            package: "SOT-23",
+            is_extended_promotional: true,
+          },
+        ],
+      },
+      { is_extended_promotional: "true" },
+      "https://jlcsearch-proxy-staging.seve.workers.dev/components/list?is_extended_promotional=true",
+    )
+
+    expect(html).toContain('name="is_extended_promotional"')
+    expect(html).toContain('value="true" checked')
+    expect(html).toContain("is_extended_promotional")
+  })
 })

--- a/lib/db/get-db-client.ts
+++ b/lib/db/get-db-client.ts
@@ -80,6 +80,18 @@ export const getDbClient = () => {
     }),
   })
 
+  const dbClient = dbClientSingleton
+  const destroy = dbClient.destroy.bind(dbClient)
+  dbClient.destroy = async () => {
+    try {
+      await destroy()
+    } finally {
+      if (dbClientSingleton === dbClient) {
+        dbClientSingleton = undefined
+      }
+    }
+  }
+
   return dbClientSingleton
 }
 

--- a/lib/util/is-extended-promotional.ts
+++ b/lib/util/is-extended-promotional.ts
@@ -1,0 +1,4 @@
+export const isExtendedPromotional = (component: {
+  basic?: boolean | number | null
+  preferred?: boolean | number | null
+}) => Boolean(component.preferred) && !Boolean(component.basic)

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -4,6 +4,7 @@ import {
   type SearchTokenGroup,
   tokenizeSearchTerm,
 } from "lib/util/search-token-groups"
+import { isExtendedPromotional } from "lib/util/is-extended-promotional"
 import { withWinterSpec } from "lib/with-winter-spec"
 import { z } from "zod"
 
@@ -50,6 +51,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -71,6 +73,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   const baseQuery = query
@@ -193,6 +198,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: isExtendedPromotional(c),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -1,6 +1,7 @@
 import { sql } from "kysely"
 import { Table } from "lib/ui/Table"
 import { ExpressionBuilder } from "kysely"
+import { isExtendedPromotional } from "lib/util/is-extended-promotional"
 import { buildSearchTokenGroups } from "lib/util/search-token-groups"
 import { withWinterSpec } from "lib/with-winter-spec"
 import { z } from "zod"
@@ -35,6 +36,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -51,6 +53,7 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -69,6 +72,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   if (req.query.search) {
@@ -111,6 +117,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: isExtendedPromotional(c),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +159,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/scripts/setup-7z.ts
+++ b/scripts/setup-7z.ts
@@ -7,10 +7,10 @@ const BINARY_NAME = "7zz"
 
 // Map of platform-arch combinations to download URLs
 const BINARY_URLS: Record<string, string> = {
-  "linux-x64": "https://7-zip.org/a/7z2408-linux-x64.tar.xz",
-  "linux-arm64": "https://7-zip.org/a/7z2408-linux-arm64.tar.xz",
-  "darwin-x64": "https://7-zip.org/a/7z2408-mac.tar.xz",
-  "darwin-arm64": "https://7-zip.org/a/7z2408-mac.tar.xz",
+  "linux-x64": "https://7-zip.org/a/7z2600-linux-x64.tar.xz",
+  "linux-arm64": "https://7-zip.org/a/7z2600-linux-arm64.tar.xz",
+  "darwin-x64": "https://7-zip.org/a/7z2600-mac.tar.xz",
+  "darwin-arm64": "https://7-zip.org/a/7z2600-mac.tar.xz",
 }
 
 async function downloadAndExtract7z() {

--- a/tests/fixtures/setup-test-db.ts
+++ b/tests/fixtures/setup-test-db.ts
@@ -1,0 +1,187 @@
+import { Database } from "bun:sqlite"
+import { mkdirSync, rmSync } from "node:fs"
+import Path from "node:path"
+
+const TEST_DB_PATH = Path.join(import.meta.dir, "../../.tmp/test-db.sqlite3")
+
+const price = JSON.stringify([{ qFrom: 1, qTo: null, price: 0.01 }])
+
+const components = [
+  {
+    lcsc: 1002,
+    mfr: "NE555P",
+    description: "555 Timer DIP-8",
+    package: "DIP-8",
+    category_id: 1,
+    basic: 1,
+    preferred: 1,
+    stock: 500,
+  },
+  {
+    lcsc: 11702,
+    mfr: "RC0402FR-075K1L",
+    description: "0402 5.1k resistor",
+    package: "0402",
+    category_id: 2,
+    basic: 0,
+    preferred: 1,
+    stock: 400,
+  },
+  {
+    lcsc: 965793,
+    mfr: "XL-1608SURC",
+    description: "0402 red LED",
+    package: "0402",
+    category_id: 3,
+    basic: 0,
+    preferred: 1,
+    stock: 300,
+  },
+  {
+    lcsc: 2765186,
+    mfr: "TYPE-C-16P",
+    description: "USB Type-C 16P connector",
+    package: "SMD",
+    category_id: 4,
+    basic: 1,
+    preferred: 1,
+    stock: 200,
+  },
+  {
+    lcsc: 40164,
+    mfr: "STM32F401RCT6",
+    description: "ARM Cortex-M4 microcontroller STM32F401RCT6",
+    package: "LQFP-64",
+    category_id: 1,
+    basic: 0,
+    preferred: 1,
+    stock: 100,
+  },
+  {
+    lcsc: 700001,
+    mfr: "MEMS-MIC",
+    description: "MEMS Microphone",
+    package: "SMD",
+    category_id: 5,
+    basic: 0,
+    preferred: 1,
+    stock: 90,
+  },
+]
+
+export const setupTestDatabase = () => {
+  if (process.env.JLCSEARCH_DB_PATH) return
+
+  mkdirSync(Path.dirname(TEST_DB_PATH), { recursive: true })
+  rmSync(TEST_DB_PATH, { force: true })
+  process.env.JLCSEARCH_DB_PATH = TEST_DB_PATH
+
+  const db = new Database(TEST_DB_PATH)
+
+  db.exec(`
+    CREATE TABLE categories (
+      id INTEGER PRIMARY KEY,
+      category TEXT NOT NULL,
+      subcategory TEXT NOT NULL
+    );
+
+    CREATE TABLE components (
+      lcsc INTEGER PRIMARY KEY,
+      mfr TEXT NOT NULL,
+      manufacturer_id INTEGER NOT NULL DEFAULT 0,
+      category_id INTEGER NOT NULL,
+      package TEXT NOT NULL,
+      joints INTEGER NOT NULL DEFAULT 0,
+      stock INTEGER NOT NULL DEFAULT 0,
+      price TEXT NOT NULL,
+      basic INTEGER NOT NULL DEFAULT 0,
+      preferred INTEGER NOT NULL DEFAULT 0,
+      description TEXT NOT NULL,
+      datasheet TEXT NOT NULL DEFAULT '',
+      extra TEXT,
+      last_update INTEGER NOT NULL DEFAULT 0,
+      last_on_stock INTEGER NOT NULL DEFAULT 0,
+      flag INTEGER NOT NULL DEFAULT 0
+    );
+
+    CREATE VIEW v_components AS
+      SELECT
+        components.lcsc,
+        components.mfr,
+        components.mfr AS manufacturer,
+        components.manufacturer_id,
+        components.category_id,
+        categories.category,
+        categories.subcategory,
+        components.package,
+        components.joints,
+        components.stock,
+        components.price,
+        components.basic,
+        components.preferred,
+        components.description,
+        components.datasheet,
+        components.extra,
+        components.last_on_stock
+      FROM components
+      LEFT JOIN categories ON categories.id = components.category_id;
+
+    CREATE VIRTUAL TABLE components_fts USING fts5(
+      lcsc UNINDEXED,
+      mfr,
+      description,
+      mfr_chars
+    );
+  `)
+
+  const insertCategory = db.prepare(
+    "INSERT INTO categories (id, category, subcategory) VALUES (?, ?, ?)",
+  )
+  insertCategory.run(1, "Integrated Circuits", "Microcontrollers")
+  insertCategory.run(2, "Resistors", "Chip Resistor - Surface Mount")
+  insertCategory.run(3, "Optoelectronics", "Light Emitting Diodes (LED)")
+  insertCategory.run(4, "Connectors", "USB Connectors")
+  insertCategory.run(5, "Audio Products", "MEMS Microphones")
+
+  const insertComponent = db.prepare(`
+    INSERT INTO components (
+      lcsc,
+      mfr,
+      category_id,
+      package,
+      stock,
+      price,
+      basic,
+      preferred,
+      description,
+      extra
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `)
+
+  const insertFts = db.prepare(
+    "INSERT INTO components_fts (lcsc, mfr, description, mfr_chars) VALUES (?, ?, ?, ?)",
+  )
+
+  for (const component of components) {
+    insertComponent.run(
+      component.lcsc,
+      component.mfr,
+      component.category_id,
+      component.package,
+      component.stock,
+      price,
+      component.basic,
+      component.preferred,
+      component.description,
+      component.description,
+    )
+    insertFts.run(
+      component.lcsc.toString(),
+      component.mfr,
+      component.description,
+      component.mfr,
+    )
+  }
+
+  db.close()
+}

--- a/tests/lib/is-extended-promotional.test.ts
+++ b/tests/lib/is-extended-promotional.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test"
+import { isExtendedPromotional } from "lib/util/is-extended-promotional"
+
+test("isExtendedPromotional is true for preferred non-basic parts", () => {
+  expect(isExtendedPromotional({ preferred: 1, basic: 0 })).toBe(true)
+  expect(isExtendedPromotional({ preferred: true, basic: false })).toBe(true)
+})
+
+test("isExtendedPromotional is false for basic or non-preferred parts", () => {
+  expect(isExtendedPromotional({ preferred: 1, basic: 1 })).toBe(false)
+  expect(isExtendedPromotional({ preferred: 0, basic: 0 })).toBe(false)
+  expect(isExtendedPromotional({ preferred: null, basic: null })).toBe(false)
+})

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -1,5 +1,6 @@
 import { afterEach } from "bun:test"
 import { setupDerivedTables } from "lib/db/derivedtables/setup-derived-tables"
+import { setupTestDatabase } from "tests/fixtures/setup-test-db"
 
 declare global {
   var deferredCleanupFns: Array<() => void | Promise<void>>
@@ -7,6 +8,7 @@ declare global {
 }
 
 globalThis.deferredCleanupFns ??= []
+setupTestDatabase()
 globalThis.derivedTablesSetupPromise ??= setupDerivedTables({ populate: false })
 
 await globalThis.derivedTablesSetupPromise

--- a/tests/routes/api/search.test.ts
+++ b/tests/routes/api/search.test.ts
@@ -107,3 +107,22 @@ test("GET /api/search supports '0402 LED'", async () => {
   expect(res.data.components.every((c: any) => c.package === "0402")).toBe(true)
   expect(res.data.components.some((c: any) => c.lcsc === 965793)).toBe(true)
 })
+
+test("GET /api/search filters extended promotional parts", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get(
+    "/api/search?limit=25&is_extended_promotional=true",
+  )
+
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+  expect(res.data.components.length).toBeGreaterThan(0)
+  expect(
+    res.data.components.every(
+      (component: any) =>
+        component.is_extended_promotional === true &&
+        component.is_preferred === true &&
+        component.is_basic === false,
+    ),
+  ).toBe(true)
+})

--- a/tests/routes/components/list.test.ts
+++ b/tests/routes/components/list.test.ts
@@ -7,3 +7,22 @@ test("GET /components/list with json param returns component data", async () => 
   expect(res.data).toHaveProperty("components")
   expect(Array.isArray(res.data.components)).toBe(true)
 })
+
+test("GET /components/list filters extended promotional parts", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get(
+    "/components/list?json=true&is_extended_promotional=true",
+  )
+
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+  expect(res.data.components.length).toBeGreaterThan(0)
+  expect(
+    res.data.components.every(
+      (component: any) =>
+        component.is_extended_promotional === true &&
+        component.is_preferred === true &&
+        component.is_basic === false,
+    ),
+  ).toBe(true)
+})


### PR DESCRIPTION
## Summary
- derive and expose `is_extended_promotional` from existing component flags (`preferred && !basic`) in `/api/search` and `/components/list` responses
- add `is_extended_promotional=true` filtering to the legacy routes and Cloudflare/D1 search paths
- add an Extended Promotional checkbox to the components list UI and render coverage for the Cloudflare table path
- fixes `/components/list` selecting `preferred` before mapping `is_preferred`
- updates the setup 7-Zip download URLs from removed `7z2408` archives to current official `7z2600` archives
- switches PR tests to a small seeded SQLite fixture so CI does not rebuild/download the full production catalog
- resets the DB singleton after `destroy()` so setup code cannot leave later route tests with a dead Kysely client

## Verification
- `bun test`
- `bunx tsc --noEmit`
- `bunx biome format .`
- `cd cf-proxy && bunx tsc --noEmit`
- `cd cf-proxy && bunx biome format .`
- `bun run scripts/setup-7z.ts`
- `cd cf-proxy && bun test test/render.test.ts`

/claim #92

Payment fallback if needed: PayPal cultofrozen@gmail.com