### PR TITLE
Add extended promotional component filter

### DIFF
--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -34,6 +35,7 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -2,6 +2,7 @@ import { CacheService, addCorsHeaders, addVaryHeader } from "./cache-service"
 import { queryComponentCatalog } from "./components"
 import { getD1Client } from "./db/get-d1-client"
 import { getD1Handler } from "./d1-routes"
+import { isExtendedPromotional } from "./is-extended-promotional"
 import { renderD1TablePage, renderHomePage } from "./render"
 import { searchIndex } from "./search"
 
@@ -367,6 +368,7 @@ async function handleD1Search(
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
       is_preferred: Boolean(row.preferred),
+      is_extended_promotional: isExtendedPromotional(row),
       description: row.description ?? "",
       stock: row.stock ?? 0,
       price: row.price1 ?? extractSmallQuantityPrice(row.price),
@@ -491,6 +493,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        is_extended_promotional: isExtendedPromotional(row),
       })),
     }
 

--- a/cf-proxy/src/is-extended-promotional.ts
+++ b/cf-proxy/src/is-extended-promotional.ts
@@ -1,0 +1,4 @@
+export const isExtendedPromotional = (component: {
+  basic?: number | boolean | null
+  preferred?: number | boolean | null
+}): boolean => Boolean(component.preferred) && !Boolean(component.basic)

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -147,6 +147,7 @@ const COLUMN_LABELS: Record<string, string> = {
   in_stock: "In Stock",
   is_basic: "Basic",
   is_preferred: "Preferred",
+  is_extended_promotional: "Extended Promotional",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
   voltage_rating: "Voltage",
@@ -545,6 +546,9 @@ const renderComponentsFilters = (
   </div>
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
+  </div>
+  <div>
+    <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <button type="submit">Filter</button>
 </form>`

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -108,6 +109,14 @@ export async function searchIndex(
 
   if (params.is_preferred === "true" || params.is_preferred === "1") {
     conditions.push(sql`search_index.preferred = 1`)
+  }
+
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`search_index.preferred = 1`)
+    conditions.push(sql`search_index.basic = 0`)
   }
 
   const raw = params.q?.trim()

--- a/cf-proxy/test/is-extended-promotional.test.ts
+++ b/cf-proxy/test/is-extended-promotional.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest"
+import { isExtendedPromotional } from "../src/is-extended-promotional"
+
+describe("isExtendedPromotional", () => {
+  it("derives the flag from preferred non-basic parts", () => {
+    expect(isExtendedPromotional({ preferred: 1, basic: 0 })).toBe(true)
+    expect(isExtendedPromotional({ preferred: 1, basic: 1 })).toBe(false)
+    expect(isExtendedPromotional({ preferred: 0, basic: 0 })).toBe(false)
+  })
+})

--- a/lib/util/is-extended-promotional.ts
+++ b/lib/util/is-extended-promotional.ts
@@ -1,0 +1,4 @@
+export const isExtendedPromotional = (component: {
+  basic?: number | boolean | null
+  preferred?: number | boolean | null
+}): boolean => Boolean(component.preferred) && !Boolean(component.basic)

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -4,6 +4,7 @@ import {
   type SearchTokenGroup,
   tokenizeSearchTerm,
 } from "lib/util/search-token-groups"
+import { isExtendedPromotional } from "lib/util/is-extended-promotional"
 import { withWinterSpec } from "lib/with-winter-spec"
 import { z } from "zod"
 
@@ -50,6 +51,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -71,6 +73,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   const baseQuery = query
@@ -193,6 +198,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: isExtendedPromotional(c),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -2,6 +2,7 @@ import { sql } from "kysely"
 import { Table } from "lib/ui/Table"
 import { ExpressionBuilder } from "kysely"
 import { buildSearchTokenGroups } from "lib/util/search-token-groups"
+import { isExtendedPromotional } from "lib/util/is-extended-promotional"
 import { withWinterSpec } from "lib/with-winter-spec"
 import { z } from "zod"
 
@@ -35,6 +36,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -51,6 +53,7 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -69,6 +72,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   if (req.query.search) {
@@ -111,6 +117,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: isExtendedPromotional(c),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +159,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/tests/lib/is-extended-promotional.test.ts
+++ b/tests/lib/is-extended-promotional.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "bun:test"
+import { isExtendedPromotional } from "lib/util/is-extended-promotional"
+
+test("isExtendedPromotional derives the flag from preferred non-basic parts", () => {
+  expect(isExtendedPromotional({ preferred: 1, basic: 0 })).toBe(true)
+  expect(isExtendedPromotional({ preferred: 1, basic: 1 })).toBe(false)
+  expect(isExtendedPromotional({ preferred: 0, basic: 0 })).toBe(false)
+})


### PR DESCRIPTION
/claim #92

## Summary
- derive `is_extended_promotional` from existing JLC flags as `preferred && !basic`
- expose the field and filter in `/components/list` and `/api/search`
- pass the same filter/field through the D1 Cloudflare proxy search and component list paths
- add HTML filter/column label wiring plus focused helper coverage for origin and proxy code

## Validation
- `git diff --check` passed
- `git diff --cached --check` passed before commit
- Local runtime tests were not run because this machine does not have `bun` installed and the system `node.exe` is blocked; I kept the patch small and added focused helper tests for the derived flag.