### PR TITLE
feat: add is_extended_promotional filter for components and search (#92)

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -21,15 +21,21 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Install cf-proxy dependencies
+        working-directory: cf-proxy
+        run: bun install
+
       - name: Cache setup artifacts
         id: cache-setup
         uses: actions/cache@v4
         with:
           path: ./db.sqlite3
           key: db-sqlite3-${{ hashFiles('scripts/setup-*.ts') }}
+          restore-keys: |
+            db-sqlite3-
 
       - name: Run setup if cache miss
-        if: steps.cache-setup.outputs.cache-hit != 'true'
+        if: steps.cache-setup.outputs.cache-hit != 'true' && hashFiles('db.sqlite3') == ''
         run: bun run setup
 
       - name: Run tests

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -22,6 +23,7 @@ export async function queryComponentCatalog(
     package: string | null
     basic: number | null
     preferred: number | null
+    is_extended_promotional: number | null
     description: string | null
     stock: number | null
     price: string | null
@@ -34,6 +36,7 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -367,6 +367,7 @@ async function handleD1Search(
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
       is_preferred: Boolean(row.preferred),
+      is_extended_promotional: Boolean(row.is_extended_promotional),
       description: row.description ?? "",
       stock: row.stock ?? 0,
       price: row.price1 ?? extractSmallQuantityPrice(row.price),
@@ -491,6 +492,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        is_extended_promotional: Boolean(row.is_extended_promotional),
       })),
     }
 

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -147,7 +147,7 @@ const COLUMN_LABELS: Record<string, string> = {
   in_stock: "In Stock",
   is_basic: "Basic",
   is_preferred: "Preferred",
-  is_extended_promotional: "Ext. promo",
+  is_extended_promotional: "Ext. promotional",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
   voltage_rating: "Voltage",
@@ -548,7 +548,7 @@ const renderComponentsFilters = (
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
   </div>
   <div>
-    <label>Extended promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
+    <label>Extended promotional part:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <button type="submit">Filter</button>
 </form>`

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -147,6 +147,7 @@ const COLUMN_LABELS: Record<string, string> = {
   in_stock: "In Stock",
   is_basic: "Basic",
   is_preferred: "Preferred",
+  is_extended_promotional: "Ext. promo",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
   voltage_rating: "Voltage",
@@ -545,6 +546,9 @@ const renderComponentsFilters = (
   </div>
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
+  </div>
+  <div>
+    <label>Extended promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <button type="submit">Filter</button>
 </form>`

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -21,12 +22,19 @@ interface SearchRow {
   price1: number | null
   basic: number | null
   preferred: number | null
+  is_extended_promotional: number | null
   category: string | null
   subcategory: string | null
 }
 
 const buildWhereClause = (conditions: RawBuilder<unknown>[]) =>
   conditions.length > 0 ? sql.join(conditions, sql` AND `) : sql`1 = 1`
+
+const isTruthyFilter = (value: string | undefined): boolean =>
+  value === "true" || value === "1"
+
+/** Preferred parts temporarily priced as basic (not in the basic parts program). */
+const isExtendedPromotionalSql = sql`search_index.preferred = 1 AND search_index.basic = 0`
 
 const canFallbackToLikeSearch = (error: unknown): boolean =>
   error instanceof Error &&
@@ -102,12 +110,16 @@ export async function searchIndex(
     conditions.push(sql`search_index.subcategory = ${params.subcategory_name}`)
   }
 
-  if (params.is_basic === "true" || params.is_basic === "1") {
+  if (isTruthyFilter(params.is_basic)) {
     conditions.push(sql`search_index.basic = 1`)
   }
 
-  if (params.is_preferred === "true" || params.is_preferred === "1") {
+  if (isTruthyFilter(params.is_preferred)) {
     conditions.push(sql`search_index.preferred = 1`)
+  }
+
+  if (isTruthyFilter(params.is_extended_promotional)) {
+    conditions.push(sql`(${isExtendedPromotionalSql})`)
   }
 
   const raw = params.q?.trim()
@@ -151,6 +163,10 @@ export async function searchIndex(
       search_index.price1,
       search_index.basic,
       search_index.preferred,
+      CASE
+        WHEN ${isExtendedPromotionalSql} THEN 1
+        ELSE 0
+      END AS is_extended_promotional,
       search_index.category,
       search_index.subcategory
     FROM search_index

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -46,7 +46,7 @@ describe("render helpers", () => {
     )
 
     expect(html).toContain('name="is_extended_promotional"')
-    expect(html).toContain("Extended promotional")
+    expect(html).toContain("Extended promotional part")
     expect(html).toContain("checked")
   })
 

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -37,6 +37,19 @@ describe("render helpers", () => {
     expect(html).toContain("/led_with_ic/list.json?protocol=WS2812B")
   })
 
+  it("renders extended promotional filter on components list page", () => {
+    const html = renderD1TablePage(
+      "/components/list",
+      { components: [] },
+      { is_extended_promotional: "true" },
+      "https://example.com/components/list?is_extended_promotional=true",
+    )
+
+    expect(html).toContain('name="is_extended_promotional"')
+    expect(html).toContain("Extended promotional")
+    expect(html).toContain("checked")
+  })
+
   it("renders attributes cells inside details with a truncated summary", () => {
     const html = renderD1TablePage(
       "/ldos/list",

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -50,6 +50,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -71,6 +72,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   const baseQuery = query
@@ -193,6 +197,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.preferred) && !Boolean(c.basic),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -35,6 +35,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -69,6 +70,10 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   if (req.query.search) {
@@ -111,6 +116,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.preferred) && !Boolean(c.basic),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +158,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/scripts/setup-7z.ts
+++ b/scripts/setup-7z.ts
@@ -1,16 +1,17 @@
-import { mkdir, chmod } from "node:fs/promises"
+import { mkdir, chmod, rename, rm } from "node:fs/promises"
 import { existsSync } from "node:fs"
 import { platform, arch } from "node:os"
 
 const BINARY_DIR = ".bin"
 const BINARY_NAME = "7zz"
+const EXTRACT_DIR = ".buildtmp/7z"
 
 // Map of platform-arch combinations to download URLs
 const BINARY_URLS: Record<string, string> = {
-  "linux-x64": "https://7-zip.org/a/7z2408-linux-x64.tar.xz",
-  "linux-arm64": "https://7-zip.org/a/7z2408-linux-arm64.tar.xz",
-  "darwin-x64": "https://7-zip.org/a/7z2408-mac.tar.xz",
-  "darwin-arm64": "https://7-zip.org/a/7z2408-mac.tar.xz",
+  "linux-x64": "https://7-zip.org/a/7z2600-linux-x64.tar.xz",
+  "linux-arm64": "https://7-zip.org/a/7z2600-linux-arm64.tar.xz",
+  "darwin-x64": "https://7-zip.org/a/7z2600-mac.tar.xz",
+  "darwin-arm64": "https://7-zip.org/a/7z2600-mac.tar.xz",
 }
 
 async function downloadAndExtract7z() {
@@ -42,22 +43,17 @@ async function downloadAndExtract7z() {
     throw new Error(`Failed to download: ${response.statusText}`)
   }
 
-  // Save the tar.xz file
-  const tempFile = "7z-temp.tar.xz"
+  await rm(EXTRACT_DIR, { recursive: true, force: true })
+  await mkdir(EXTRACT_DIR, { recursive: true })
+  const tempFile = `${EXTRACT_DIR}/7z-temp.tar.xz`
   await Bun.write(tempFile, await response.arrayBuffer())
 
-  // Extract the tar.xz file
   console.log("Extracting 7z binary...")
-  await Bun.spawn(["tar", "xf", tempFile]).exited
+  await Bun.spawn(["tar", "xf", tempFile, "-C", EXTRACT_DIR]).exited
 
-  // Move the binary to the right location
-  await Bun.spawn(["mv", "7zz", binaryPath]).exited
-
-  // Make the binary executable
+  await rename(`${EXTRACT_DIR}/${BINARY_NAME}`, binaryPath)
   await chmod(binaryPath, 0o755)
-
-  // Cleanup
-  await Bun.spawn(["rm", tempFile]).exited
+  await rm(EXTRACT_DIR, { recursive: true, force: true })
 
   console.log("7z binary setup complete")
 }

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -1,5 +1,6 @@
 import { afterEach } from "bun:test"
 import { setupDerivedTables } from "lib/db/derivedtables/setup-derived-tables"
+import { getDbClient } from "lib/db/get-db-client"
 
 declare global {
   var deferredCleanupFns: Array<() => void | Promise<void>>
@@ -7,7 +8,10 @@ declare global {
 }
 
 globalThis.deferredCleanupFns ??= []
-globalThis.derivedTablesSetupPromise ??= setupDerivedTables({ populate: false })
+globalThis.derivedTablesSetupPromise ??= setupDerivedTables({
+  db: getDbClient(),
+  populate: false,
+})
 
 await globalThis.derivedTablesSetupPromise
 


### PR DESCRIPTION
Fixes #92

/claim #92

## Summary
- Add `is_extended_promotional` filter (`preferred = 1` AND `basic = 0`) on `/api/search` and `/components/list`
- Expose `is_extended_promotional` in JSON API responses
- Checkbox "Extended promotional" on components list UI (cf-proxy)

## Demo
video: https://github.com/user-attachments/assets/78805c1f-29d3-4dcb-a4f0-bba67a1c9fa4