### PR TITLE
Add extended promotional component filter

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -21,6 +21,10 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Install cf-proxy dependencies
+        working-directory: cf-proxy
+        run: bun install
+
       - name: Cache setup artifacts
         id: cache-setup
         uses: actions/cache@v4

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -34,6 +35,7 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -1,7 +1,8 @@
 import { CacheService, addCorsHeaders, addVaryHeader } from "./cache-service"
 import { queryComponentCatalog } from "./components"
-import { getD1Client } from "./db/get-d1-client"
 import { getD1Handler } from "./d1-routes"
+import { getD1Client } from "./db/get-d1-client"
+import { isExtendedPromotional } from "./is-extended-promotional"
 import { renderD1TablePage, renderHomePage } from "./render"
 import { searchIndex } from "./search"
 
@@ -367,6 +368,7 @@ async function handleD1Search(
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
       is_preferred: Boolean(row.preferred),
+      is_extended_promotional: isExtendedPromotional(row),
       description: row.description ?? "",
       stock: row.stock ?? 0,
       price: row.price1 ?? extractSmallQuantityPrice(row.price),
@@ -491,6 +493,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        is_extended_promotional: isExtendedPromotional(row),
       })),
     }
 

--- a/cf-proxy/src/is-extended-promotional.ts
+++ b/cf-proxy/src/is-extended-promotional.ts
@@ -1,0 +1,8 @@
+export interface ComponentPromotionFlags {
+  basic?: unknown
+  preferred?: unknown
+}
+
+export const isExtendedPromotional = (
+  component: ComponentPromotionFlags,
+): boolean => Boolean(component.preferred) && !component.basic

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -1,9 +1,9 @@
 import {
+  type FilterOptions,
+  type QueryParams,
   ROUTE_TO_TABLE,
   TABLE_CONFIGS,
   TABLE_RESPONSE_KEY,
-  type QueryParams,
-  type FilterOptions,
 } from "./handlers"
 
 const escapeHtml = (value: unknown): string =>
@@ -147,6 +147,7 @@ const COLUMN_LABELS: Record<string, string> = {
   in_stock: "In Stock",
   is_basic: "Basic",
   is_preferred: "Preferred",
+  is_extended_promotional: "Extended Promotional",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
   voltage_rating: "Voltage",
@@ -545,6 +546,9 @@ const renderComponentsFilters = (
   </div>
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
+  </div>
+  <div>
+    <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <button type="submit">Filter</button>
 </form>`

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -1,4 +1,4 @@
-import { sql, type Kysely, type RawBuilder } from "kysely"
+import { type Kysely, type RawBuilder, sql } from "kysely"
 import type { DB } from "./db/types"
 import { buildSearchTokenGroups } from "./search-query"
 
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -35,6 +36,12 @@ const canFallbackToLikeSearch = (error: unknown): boolean =>
 const isMissingFtsReadinessTable = (error: unknown): boolean =>
   error instanceof Error &&
   /no such table: search_index_fts_meta/i.test(error.message)
+
+const isTruthyParam = (value?: string): boolean =>
+  value === "true" || value === "1"
+
+const isFalseyParam = (value?: string): boolean =>
+  value === "false" || value === "0"
 
 async function isFtsSearchReady(db: Kysely<DB>): Promise<boolean> {
   try {
@@ -108,6 +115,16 @@ export async function searchIndex(
 
   if (params.is_preferred === "true" || params.is_preferred === "1") {
     conditions.push(sql`search_index.preferred = 1`)
+  }
+
+  if (isTruthyParam(params.is_extended_promotional)) {
+    conditions.push(
+      sql`COALESCE(search_index.preferred, 0) = 1 AND COALESCE(search_index.basic, 0) = 0`,
+    )
+  } else if (isFalseyParam(params.is_extended_promotional)) {
+    conditions.push(
+      sql`NOT (COALESCE(search_index.preferred, 0) = 1 AND COALESCE(search_index.basic, 0) = 0)`,
+    )
   }
 
   const raw = params.q?.trim()

--- a/cf-proxy/test/is-extended-promotional.test.ts
+++ b/cf-proxy/test/is-extended-promotional.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest"
+import { isExtendedPromotional } from "../src/is-extended-promotional"
+
+describe("isExtendedPromotional", () => {
+  it("derives preferred non-basic components", () => {
+    expect(isExtendedPromotional({ preferred: 1, basic: 0 })).toBe(true)
+    expect(isExtendedPromotional({ preferred: true, basic: false })).toBe(true)
+    expect(isExtendedPromotional({ preferred: 1, basic: null })).toBe(true)
+
+    expect(isExtendedPromotional({ preferred: 1, basic: 1 })).toBe(false)
+    expect(isExtendedPromotional({ preferred: 0, basic: 0 })).toBe(false)
+    expect(isExtendedPromotional({ preferred: null, basic: 0 })).toBe(false)
+  })
+})

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -59,4 +59,27 @@ describe("render helpers", () => {
       "Feature&quot;:&quot;Overcurrent Protection(OCP)&quot;",
     )
   })
+
+  it("renders the components extended promotional filter and label", () => {
+    const html = renderD1TablePage(
+      "/components/list",
+      {
+        components: [
+          {
+            lcsc: 123,
+            mfr: "ABC",
+            is_extended_promotional: true,
+          },
+        ],
+      },
+      { is_extended_promotional: "true" },
+      "https://example.com/components/list?is_extended_promotional=true",
+    )
+
+    expect(html).toContain('name="is_extended_promotional"')
+    expect(html).toContain(
+      'name="is_extended_promotional" value="true" checked',
+    )
+    expect(html).toContain("Extended Promotional")
+  })
 })

--- a/lib/util/is-extended-promotional.ts
+++ b/lib/util/is-extended-promotional.ts
@@ -1,0 +1,8 @@
+export interface ComponentPromotionFlags {
+  basic?: unknown
+  preferred?: unknown
+}
+
+export const isExtendedPromotional = (
+  component: ComponentPromotionFlags,
+): boolean => Boolean(component.preferred) && !component.basic

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@tscircuit/footprinter": "^0.0.143",
     "kysely-bun-sqlite": "^0.3.2",
+    "kysely-d1": "^0.4.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "redaxios": "^0.5.1"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   "dependencies": {
     "@tscircuit/footprinter": "^0.0.143",
     "kysely-bun-sqlite": "^0.3.2",
-    "kysely-d1": "^0.4.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "redaxios": "^0.5.1"

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -1,7 +1,8 @@
 import { sql } from "kysely"
+import { isExtendedPromotional } from "lib/util/is-extended-promotional"
 import {
-  buildSearchTokenGroups,
   type SearchTokenGroup,
+  buildSearchTokenGroups,
   tokenizeSearchTerm,
 } from "lib/util/search-token-groups"
 import { withWinterSpec } from "lib/with-winter-spec"
@@ -50,6 +51,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -71,6 +73,15 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional === true) {
+    query = query.where(
+      sql<boolean>`COALESCE(preferred, 0) = 1 AND COALESCE(basic, 0) = 0`,
+    )
+  } else if (req.query.is_extended_promotional === false) {
+    query = query.where(
+      sql<boolean>`NOT (COALESCE(preferred, 0) = 1 AND COALESCE(basic, 0) = 0)`,
+    )
   }
 
   const baseQuery = query
@@ -193,6 +204,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: isExtendedPromotional(c),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -1,6 +1,6 @@
 import { sql } from "kysely"
 import { Table } from "lib/ui/Table"
-import { ExpressionBuilder } from "kysely"
+import { isExtendedPromotional } from "lib/util/is-extended-promotional"
 import { buildSearchTokenGroups } from "lib/util/search-token-groups"
 import { withWinterSpec } from "lib/with-winter-spec"
 import { z } from "zod"
@@ -35,6 +35,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -51,6 +52,7 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -69,6 +71,15 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional === true) {
+    query = query.where(
+      sql<boolean>`COALESCE(preferred, 0) = 1 AND COALESCE(basic, 0) = 0`,
+    )
+  } else if (req.query.is_extended_promotional === false) {
+    query = query.where(
+      sql<boolean>`NOT (COALESCE(preferred, 0) = 1 AND COALESCE(basic, 0) = 0)`,
+    )
   }
 
   if (req.query.search) {
@@ -111,6 +122,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: isExtendedPromotional(c),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +164,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/routes/microphones/list.tsx
+++ b/routes/microphones/list.tsx
@@ -42,15 +42,6 @@ export default withWinterSpec({
 
   const microphones = await query.execute()
 
-  const packages = await ctx.db
-    .selectFrom("v_components")
-    .select("package")
-    .distinct()
-    .where("subcategory", "in", [...MICROPHONE_SUBCATEGORIES])
-    .where("package", "is not", null)
-    .orderBy("package")
-    .execute()
-
   const normalizedMicrophones = microphones
     .map((m) => ({
       lcsc: m.lcsc ?? 0,
@@ -66,6 +57,15 @@ export default withWinterSpec({
   if (ctx.isApiRequest) {
     return ctx.json({ microphones: normalizedMicrophones })
   }
+
+  const packages = await ctx.db
+    .selectFrom("v_components")
+    .select("package")
+    .distinct()
+    .where("subcategory", "in", [...MICROPHONE_SUBCATEGORIES])
+    .where("package", "is not", null)
+    .orderBy("package")
+    .execute()
 
   return ctx.react(
     <div>

--- a/scripts/download-cache-fragments.ts
+++ b/scripts/download-cache-fragments.ts
@@ -1,8 +1,9 @@
-import { mkdir } from "node:fs/promises"
 import { existsSync } from "node:fs"
+import { mkdir } from "node:fs/promises"
 
 const BASE_URL = "https://yaqwsx.github.io/jlcparts/data"
 const OUTPUT_DIR = ".buildtmp"
+const FRAGMENT_DOWNLOAD_CONCURRENCY = 6
 
 async function downloadFile(url: string, outputPath: string): Promise<boolean> {
   try {
@@ -33,20 +34,33 @@ async function main() {
   // Download initial cache.zip
   await downloadFile(`${BASE_URL}/cache.zip`, `${OUTPUT_DIR}/cache.zip`)
 
-  // Download fragments until we get a 404
+  // Download fragments until we get a 404. These are 50MB parts, so
+  // bounded parallelism keeps CI setup under the workflow timeout.
   let index = 1
   while (true) {
-    const paddedIndex = index.toString().padStart(2, "0")
-    const success = await downloadFile(
-      `${BASE_URL}/cache.z${paddedIndex}`,
-      `${OUTPUT_DIR}/cache.z${paddedIndex}`,
+    const fragmentIndexes = Array.from(
+      { length: FRAGMENT_DOWNLOAD_CONCURRENCY },
+      (_, offset) => index + offset,
     )
+    const results = await Promise.all(
+      fragmentIndexes.map((fragmentIndex) => {
+        const paddedIndex = fragmentIndex.toString().padStart(2, "0")
+        return downloadFile(
+          `${BASE_URL}/cache.z${paddedIndex}`,
+          `${OUTPUT_DIR}/cache.z${paddedIndex}`,
+        )
+      }),
+    )
+    const firstMissingIndex = results.findIndex((success) => !success)
 
-    if (!success) {
-      console.log(`Stopped at index ${paddedIndex} (404 encountered)`)
+    if (firstMissingIndex !== -1) {
+      const missingFragmentIndex = fragmentIndexes[firstMissingIndex]
+        .toString()
+        .padStart(2, "0")
+      console.log(`Stopped at index ${missingFragmentIndex} (404 encountered)`)
       break
     }
-    index++
+    index += FRAGMENT_DOWNLOAD_CONCURRENCY
   }
 }
 

--- a/scripts/setup-7z.ts
+++ b/scripts/setup-7z.ts
@@ -1,16 +1,16 @@
-import { mkdir, chmod } from "node:fs/promises"
 import { existsSync } from "node:fs"
-import { platform, arch } from "node:os"
+import { chmod, mkdir } from "node:fs/promises"
+import { arch, platform } from "node:os"
 
 const BINARY_DIR = ".bin"
 const BINARY_NAME = "7zz"
 
 // Map of platform-arch combinations to download URLs
 const BINARY_URLS: Record<string, string> = {
-  "linux-x64": "https://7-zip.org/a/7z2408-linux-x64.tar.xz",
-  "linux-arm64": "https://7-zip.org/a/7z2408-linux-arm64.tar.xz",
-  "darwin-x64": "https://7-zip.org/a/7z2408-mac.tar.xz",
-  "darwin-arm64": "https://7-zip.org/a/7z2408-mac.tar.xz",
+  "linux-x64": "https://7-zip.org/a/7z2501-linux-x64.tar.xz",
+  "linux-arm64": "https://7-zip.org/a/7z2501-linux-arm64.tar.xz",
+  "darwin-x64": "https://7-zip.org/a/7z2501-mac.tar.xz",
+  "darwin-arm64": "https://7-zip.org/a/7z2501-mac.tar.xz",
 }
 
 async function downloadAndExtract7z() {

--- a/tests/lib/is-extended-promotional.test.ts
+++ b/tests/lib/is-extended-promotional.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test"
+import { isExtendedPromotional } from "lib/util/is-extended-promotional"
+
+test("isExtendedPromotional derives preferred non-basic components", () => {
+  expect(isExtendedPromotional({ preferred: 1, basic: 0 })).toBe(true)
+  expect(isExtendedPromotional({ preferred: true, basic: false })).toBe(true)
+  expect(isExtendedPromotional({ preferred: 1, basic: null })).toBe(true)
+
+  expect(isExtendedPromotional({ preferred: 1, basic: 1 })).toBe(false)
+  expect(isExtendedPromotional({ preferred: 0, basic: 0 })).toBe(false)
+  expect(isExtendedPromotional({ preferred: null, basic: 0 })).toBe(false)
+})

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -1,5 +1,6 @@
 import { afterEach } from "bun:test"
 import { setupDerivedTables } from "lib/db/derivedtables/setup-derived-tables"
+import { getDbClient } from "lib/db/get-db-client"
 
 declare global {
   var deferredCleanupFns: Array<() => void | Promise<void>>
@@ -7,7 +8,10 @@ declare global {
 }
 
 globalThis.deferredCleanupFns ??= []
-globalThis.derivedTablesSetupPromise ??= setupDerivedTables({ populate: false })
+globalThis.derivedTablesSetupPromise ??= setupDerivedTables({
+  db: getDbClient(),
+  populate: false,
+})
 
 await globalThis.derivedTablesSetupPromise
 

--- a/tests/routes/api/search.test.ts
+++ b/tests/routes/api/search.test.ts
@@ -16,8 +16,29 @@ test("GET /api/search with search query 'STM32F401RCT6' returns expected compone
   expect(component).toHaveProperty("mfr")
   expect(component.mfr).toContain("STM32F401RCT6") // More specific check
   expect(component).toHaveProperty("package")
+  expect(component).toHaveProperty("is_basic")
+  expect(component).toHaveProperty("is_preferred")
+  expect(component).toHaveProperty("is_extended_promotional")
+  expect(component.is_extended_promotional).toBe(
+    component.is_preferred && !component.is_basic,
+  )
   expect(component).toHaveProperty("price")
   expect(component).toHaveProperty("stock")
+})
+
+test("GET /api/search can filter extended promotional components", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get(
+    "/api/search?limit=10&is_extended_promotional=true",
+  )
+
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+  for (const component of res.data.components) {
+    expect(component.is_extended_promotional).toBe(true)
+    expect(component.is_preferred).toBe(true)
+    expect(component.is_basic).toBe(false)
+  }
 })
 
 test("GET /api/search with search query '555 Timer' returns expected components", async () => {

--- a/tests/routes/components/list.test.ts
+++ b/tests/routes/components/list.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
 import { getTestServer } from "tests/fixtures/get-test-server"
 
 test("GET /components/list with json param returns component data", async () => {
@@ -6,4 +6,28 @@ test("GET /components/list with json param returns component data", async () => 
   const res = await axios.get("/components/list?json=true")
   expect(res.data).toHaveProperty("components")
   expect(Array.isArray(res.data.components)).toBe(true)
+  if (res.data.components.length > 0) {
+    const component = res.data.components[0]
+    expect(component).toHaveProperty("is_basic")
+    expect(component).toHaveProperty("is_preferred")
+    expect(component).toHaveProperty("is_extended_promotional")
+    expect(component.is_extended_promotional).toBe(
+      component.is_preferred && !component.is_basic,
+    )
+  }
+})
+
+test("GET /components/list can filter extended promotional components", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get(
+    "/components/list?json=true&is_extended_promotional=true",
+  )
+
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+  for (const component of res.data.components) {
+    expect(component.is_extended_promotional).toBe(true)
+    expect(component.is_preferred).toBe(true)
+    expect(component.is_basic).toBe(false)
+  }
 })

--- a/tests/routes/microphones/list.test.ts
+++ b/tests/routes/microphones/list.test.ts
@@ -26,4 +26,4 @@ test("GET /microphones/list.json returns microphone data", async () => {
     expect(typeof microphone.stock).toBe("number")
     expect(typeof microphone.price1).toBe("number")
   }
-})
+}, 60_000)


### PR DESCRIPTION
/claim #92

## Summary
- Derive `is_extended_promotional` from existing JLC flags as `preferred && !basic`.
- Expose the field in origin `/api/search` and `/components/list` responses, plus D1 proxy search/list responses.
- Add `is_extended_promotional=true|false` filtering in origin and D1 search paths, and wire the HTML filter/column label.
- Add focused helper/render coverage plus route assertions for the derived field/filter.
- Keep CI usable on cache miss by updating the 7-Zip setup URL, downloading database cache fragments with bounded parallelism, extending the test timeout for the first uncached 28GB database setup, keeping the preload DB client alive, and installing `cf-proxy` dependencies before root `bun test` imports proxy code.
- Avoid a flaky JSON route timeout by skipping the microphone package-dropdown lookup for JSON responses and giving that route test a route-appropriate timeout.

## Validation
- GitHub CI on `9b176a8`: Format Check, Type Check, and Bun Test all pass.
- `npx --yes @biomejs/biome@1.9.4 check routes/components/list.tsx routes/api/search.tsx lib/util/is-extended-promotional.ts tests/lib/is-extended-promotional.test.ts tests/routes/api/search.test.ts tests/routes/components/list.test.ts cf-proxy/src/components.ts cf-proxy/src/index.ts cf-proxy/src/render.ts cf-proxy/src/search.ts cf-proxy/src/is-extended-promotional.ts cf-proxy/test/is-extended-promotional.test.ts cf-proxy/test/render.test.ts`
- `npm test` in `cf-proxy` - 127 passed
- `npx --yes bun test tests/lib/is-extended-promotional.test.ts`
- `npx --yes bun test cf-proxy/test/worker.test.ts cf-proxy/test/cache-service.test.ts`
- `git diff --check`

Note: I also tried the origin DB-backed route tests locally with `npx --yes bun test tests/routes/api/search.test.ts tests/routes/components/list.test.ts`; this Windows workspace does not have the seeded SQLite tables, so those route tests stop at `no such table: components/v_components`. The full seeded DB route suite passes in GitHub CI.