### PR TITLE
feat: expose extended promotional components

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -13,6 +13,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Free runner disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          df -h
+
       - name: Setup bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -21,12 +21,18 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Install cf-proxy dependencies
+        run: bun install
+        working-directory: cf-proxy
+
       - name: Cache setup artifacts
         id: cache-setup
         uses: actions/cache@v4
         with:
           path: ./db.sqlite3
           key: db-sqlite3-${{ hashFiles('scripts/setup-*.ts') }}
+          restore-keys: |
+            db-sqlite3-
 
       - name: Run setup if cache miss
         if: steps.cache-setup.outputs.cache-hit != 'true'

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -22,6 +23,7 @@ export async function queryComponentCatalog(
     package: string | null
     basic: number | null
     preferred: number | null
+    is_extended_promotional: number | null
     description: string | null
     stock: number | null
     price: string | null
@@ -34,6 +36,7 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -370,6 +370,7 @@ async function handleD1Search(
       description: row.description ?? "",
       stock: row.stock ?? 0,
       price: row.price1 ?? extractSmallQuantityPrice(row.price),
+      is_extended_promotional: Boolean(row.is_extended_promotional),
     }))
 
     const headers = new Headers({
@@ -491,6 +492,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        is_extended_promotional: Boolean(row.is_extended_promotional),
       })),
     }
 

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -147,6 +147,7 @@ const COLUMN_LABELS: Record<string, string> = {
   in_stock: "In Stock",
   is_basic: "Basic",
   is_preferred: "Preferred",
+  is_extended_promotional: "Extended Promotional",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
   voltage_rating: "Voltage",
@@ -545,6 +546,9 @@ const renderComponentsFilters = (
   </div>
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
+  </div>
+  <div>
+    <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <button type="submit">Filter</button>
 </form>`

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -21,6 +22,7 @@ interface SearchRow {
   price1: number | null
   basic: number | null
   preferred: number | null
+  is_extended_promotional: number | null
   category: string | null
   subcategory: string | null
 }
@@ -35,6 +37,12 @@ const canFallbackToLikeSearch = (error: unknown): boolean =>
 const isMissingFtsReadinessTable = (error: unknown): boolean =>
   error instanceof Error &&
   /no such table: search_index_fts_meta/i.test(error.message)
+
+const parseBooleanFilter = (value: string | undefined): boolean | undefined => {
+  if (value === "true" || value === "1") return true
+  if (value === "false" || value === "0") return false
+  return undefined
+}
 
 async function isFtsSearchReady(db: Kysely<DB>): Promise<boolean> {
   try {
@@ -110,6 +118,18 @@ export async function searchIndex(
     conditions.push(sql`search_index.preferred = 1`)
   }
 
+  const isExtendedPromotional = parseBooleanFilter(
+    params.is_extended_promotional,
+  )
+  if (isExtendedPromotional === true) {
+    conditions.push(sql`search_index.preferred = 1`)
+    conditions.push(sql`search_index.basic = 0`)
+  } else if (isExtendedPromotional === false) {
+    conditions.push(
+      sql`NOT (search_index.preferred = 1 AND search_index.basic = 0)`,
+    )
+  }
+
   const raw = params.q?.trim()
 
   if (raw) {
@@ -151,6 +171,10 @@ export async function searchIndex(
       search_index.price1,
       search_index.basic,
       search_index.preferred,
+      CASE
+        WHEN search_index.preferred = 1 AND search_index.basic = 0 THEN 1
+        ELSE 0
+      END AS is_extended_promotional,
       search_index.category,
       search_index.subcategory
     FROM search_index

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -59,4 +59,27 @@ describe("render helpers", () => {
       "Feature&quot;:&quot;Overcurrent Protection(OCP)&quot;",
     )
   })
+
+  it("renders the components extended promotional filter", () => {
+    const html = renderD1TablePage(
+      "/components/list",
+      {
+        components: [
+          {
+            lcsc: 1,
+            mfr: "ABC123",
+            is_extended_promotional: true,
+          },
+        ],
+      },
+      { is_extended_promotional: "true" },
+      "https://example.com/components/list?is_extended_promotional=true",
+    )
+
+    expect(html).toContain('name="is_extended_promotional"')
+    expect(html).toContain("Extended Promotional")
+    expect(html).toContain(
+      'name="is_extended_promotional" value="true" checked',
+    )
+  })
 })

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -191,15 +191,17 @@ export const setupDerivedTables = async ({
   resetAll = false,
   resetTable = null,
   logger = () => {},
+  destroyOnComplete = false,
 }: {
   db?: KyselyDatabaseInstance
   populate?: boolean
   resetAll?: boolean
   resetTable?: string | null
   logger?: Logger
+  destroyOnComplete?: boolean
 } = {}) => {
   const activeDb = db ?? getDbClient()
-  const shouldDestroy = !db
+  const shouldDestroy = destroyOnComplete
 
   try {
     for (const tableSpec of DERIVED_TABLES) {

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -50,6 +50,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -71,6 +72,14 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (typeof req.query.is_extended_promotional === "boolean") {
+    query =
+      req.query.is_extended_promotional === true
+        ? query.where("preferred", "=", 1).where("basic", "=", 0)
+        : query.where((eb) =>
+            eb.or([eb("preferred", "!=", 1), eb("basic", "=", 1)]),
+          )
   }
 
   const baseQuery = query
@@ -193,6 +202,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.preferred) && !Boolean(c.basic),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -35,6 +35,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -51,6 +52,7 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -69,6 +71,14 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (typeof req.query.is_extended_promotional === "boolean") {
+    query =
+      req.query.is_extended_promotional === true
+        ? query.where("preferred", "=", 1).where("basic", "=", 0)
+        : query.where((eb) =>
+            eb.or([eb("preferred", "!=", 1), eb("basic", "=", 1)]),
+          )
   }
 
   if (req.query.search) {
@@ -111,6 +121,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.preferred) && !Boolean(c.basic),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +163,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/scripts/setup-7z.ts
+++ b/scripts/setup-7z.ts
@@ -7,10 +7,10 @@ const BINARY_NAME = "7zz"
 
 // Map of platform-arch combinations to download URLs
 const BINARY_URLS: Record<string, string> = {
-  "linux-x64": "https://7-zip.org/a/7z2408-linux-x64.tar.xz",
-  "linux-arm64": "https://7-zip.org/a/7z2408-linux-arm64.tar.xz",
-  "darwin-x64": "https://7-zip.org/a/7z2408-mac.tar.xz",
-  "darwin-arm64": "https://7-zip.org/a/7z2408-mac.tar.xz",
+  "linux-x64": "https://7-zip.org/a/7z2501-linux-x64.tar.xz",
+  "linux-arm64": "https://7-zip.org/a/7z2501-linux-arm64.tar.xz",
+  "darwin-x64": "https://7-zip.org/a/7z2501-mac.tar.xz",
+  "darwin-arm64": "https://7-zip.org/a/7z2501-mac.tar.xz",
 }
 
 async function downloadAndExtract7z() {

--- a/scripts/setup-7z.ts
+++ b/scripts/setup-7z.ts
@@ -7,10 +7,10 @@ const BINARY_NAME = "7zz"
 
 // Map of platform-arch combinations to download URLs
 const BINARY_URLS: Record<string, string> = {
-  "linux-x64": "https://7-zip.org/a/7z2501-linux-x64.tar.xz",
-  "linux-arm64": "https://7-zip.org/a/7z2501-linux-arm64.tar.xz",
-  "darwin-x64": "https://7-zip.org/a/7z2501-mac.tar.xz",
-  "darwin-arm64": "https://7-zip.org/a/7z2501-mac.tar.xz",
+  "linux-x64": "https://7-zip.org/a/7z2601-linux-x64.tar.xz",
+  "linux-arm64": "https://7-zip.org/a/7z2601-linux-arm64.tar.xz",
+  "darwin-x64": "https://7-zip.org/a/7z2601-mac.tar.xz",
+  "darwin-arm64": "https://7-zip.org/a/7z2601-mac.tar.xz",
 }
 
 async function downloadAndExtract7z() {

--- a/scripts/setup-derived-tables.ts
+++ b/scripts/setup-derived-tables.ts
@@ -9,6 +9,7 @@ async function main() {
     resetAll,
     resetTable,
     logger: console.log,
+    destroyOnComplete: true,
   })
 }
 


### PR DESCRIPTION
/claim #92

## Summary
- add an `is_extended_promotional` response field derived from existing JLC flags (`preferred = 1` and `basic = 0`)
- expose/filter the flag in origin `/components/list` and `/api/search`
- pass the same filter through D1 `/api/search` and `/components/list`, including HTML filter/column rendering
- add focused render coverage for the D1 components filter
- update the setup script from removed 7-Zip 24.08 download URLs to current 26.01 URLs so CI can fetch 7z and run tests
- stabilize the Bun test workflow by freeing runner disk, installing cf-proxy dependencies, allowing setup cache fallback, and giving fresh DB setup enough time to finish

## Notes
This keeps the feature change schema-light: the source tables already expose `basic` and `preferred`, so the extended-promotional value is computed consistently instead of requiring a new migration.

## Validation
- `git diff --check`
- `cd cf-proxy && npx tsc --noEmit`
- `cd cf-proxy && npx vitest run test/render.test.ts --config vitest.node.config.mts` with a temporary Node-only Vitest config for the pure render test: 4 tests passed
- `curl -I` checks confirmed the old `7z2408-linux-x64.tar.xz` URL returns 404 and the replacement `7z2601` Linux/macOS URLs return 200
- checked failed GitHub Actions annotation and addressed the runner `No space left on device` setup failure by freeing preinstalled toolchains before DB setup

The default cf-proxy Vitest worker config could not run locally because the Workers runtime failed to import `node:vm`; the focused render test passes under the Node pool. Root `tsc` is noisy on this repo without the Bun dependency environment, so CI remains the source of truth for the root Bun test.