### PR TITLE
feat: add extended promotional component flag

### DIFF
--- a/cf-proxy/scripts/rebuild-search-index-batched.sh
+++ b/cf-proxy/scripts/rebuild-search-index-batched.sh
@@ -43,6 +43,7 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
      price1 REAL,
      basic INTEGER,
      preferred INTEGER,
+     extended_promotional INTEGER,
      category TEXT,
      subcategory TEXT,
      manufacturer_name TEXT,
@@ -70,6 +71,7 @@ INSERT INTO search_index_next (
   price1,
   basic,
   preferred,
+  extended_promotional,
   category,
   subcategory,
   manufacturer_name,
@@ -91,6 +93,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  extended_promotional,
   category,
   subcategory,
   CASE
@@ -133,7 +136,9 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
    CREATE INDEX IF NOT EXISTS idx_search_index_next_lcsc ON search_index_next(lcsc);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_package ON search_index_next(package);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_basic ON search_index_next(basic);
-   CREATE INDEX IF NOT EXISTS idx_search_index_next_preferred ON search_index_next(preferred);"
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_preferred ON search_index_next(preferred);
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_extended_promotional ON search_index_next(extended_promotional);
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_extended_promotional_stock ON search_index_next(extended_promotional, stock DESC);"
 
 echo "Validating row count..."
 run_wrangler d1 execute "$DB_NAME" --remote --command \
@@ -157,11 +162,15 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
    DROP INDEX IF EXISTS idx_search_index_package;
    DROP INDEX IF EXISTS idx_search_index_basic;
    DROP INDEX IF EXISTS idx_search_index_preferred;
+   DROP INDEX IF EXISTS idx_search_index_extended_promotional;
+   DROP INDEX IF EXISTS idx_search_index_extended_promotional_stock;
    ALTER TABLE search_index_next RENAME TO search_index;
    CREATE INDEX IF NOT EXISTS idx_search_index_stock ON search_index(stock DESC);
    CREATE INDEX IF NOT EXISTS idx_search_index_lcsc ON search_index(lcsc);
    CREATE INDEX IF NOT EXISTS idx_search_index_package ON search_index(package);
    CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
-   CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);"
+   CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
+   CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(extended_promotional);
+   CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(extended_promotional, stock DESC);"
 
 echo "Done. Old table kept as search_index_old for rollback."

--- a/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
+++ b/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
@@ -14,6 +14,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  extended_promotional,
   category,
   subcategory,
   CASE
@@ -55,3 +56,5 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(extended_promotional, stock DESC);

--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -296,6 +296,7 @@ SELECT
   package,
   basic,
   preferred,
+  extended_promotional,
   description,
   stock,
   price,
@@ -306,6 +307,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA
 
@@ -319,6 +321,7 @@ CREATE TABLE component_catalog (
   package TEXT,
   basic INTEGER,
   preferred INTEGER,
+  extended_promotional INTEGER,
   description TEXT,
   stock INTEGER,
   price TEXT,
@@ -328,6 +331,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA_EXPORT
 }
@@ -350,6 +354,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  extended_promotional,
   category,
   subcategory,
   CASE
@@ -391,6 +396,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(extended_promotional, stock DESC);
 SEARCH_INDEX_SCHEMA
 
   cat > search_index_schema.sql <<'SEARCH_INDEX_SCHEMA_EXPORT'
@@ -405,6 +412,7 @@ CREATE TABLE search_index (
   price1 REAL,
   basic INTEGER,
   preferred INTEGER,
+  extended_promotional INTEGER,
   category TEXT,
   subcategory TEXT,
   manufacturer_name TEXT,
@@ -422,6 +430,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(extended_promotional, stock DESC);
 SEARCH_INDEX_SCHEMA_EXPORT
 }
 

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -22,6 +23,7 @@ export async function queryComponentCatalog(
     package: string | null
     basic: number | null
     preferred: number | null
+    extended_promotional: number | null
     description: string | null
     stock: number | null
     price: string | null
@@ -34,6 +36,7 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -160,6 +160,7 @@ export interface ComponentCatalog {
   basic: number | null
   category: string | null
   description: string | null
+  extended_promotional: number | null
   extra: string | null
   lcsc: Generated<number | null>
   mfr: string | null
@@ -660,6 +661,7 @@ export interface SearchIndex {
   basic: number | null
   category: string | null
   description: string | null
+  extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   manufacturer_name: string | null

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -367,6 +367,7 @@ async function handleD1Search(
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
       is_preferred: Boolean(row.preferred),
+      is_extended_promotional: Boolean(row.extended_promotional),
       description: row.description ?? "",
       stock: row.stock ?? 0,
       price: row.price1 ?? extractSmallQuantityPrice(row.price),
@@ -491,6 +492,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        is_extended_promotional: Boolean(row.extended_promotional),
       })),
     }
 

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -147,6 +147,7 @@ const COLUMN_LABELS: Record<string, string> = {
   in_stock: "In Stock",
   is_basic: "Basic",
   is_preferred: "Preferred",
+  is_extended_promotional: "Extended Promotional",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
   voltage_rating: "Voltage",
@@ -545,6 +546,9 @@ const renderComponentsFilters = (
   </div>
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
+  </div>
+  <div>
+    <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <button type="submit">Filter</button>
 </form>`

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -21,6 +22,7 @@ interface SearchRow {
   price1: number | null
   basic: number | null
   preferred: number | null
+  extended_promotional: number | null
   category: string | null
   subcategory: string | null
 }
@@ -110,6 +112,13 @@ export async function searchIndex(
     conditions.push(sql`search_index.preferred = 1`)
   }
 
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`search_index.extended_promotional = 1`)
+  }
+
   const raw = params.q?.trim()
 
   if (raw) {
@@ -151,6 +160,7 @@ export async function searchIndex(
       search_index.price1,
       search_index.basic,
       search_index.preferred,
+      search_index.extended_promotional,
       search_index.category,
       search_index.subcategory
     FROM search_index

--- a/cf-proxy/test/contracts.test.ts
+++ b/cf-proxy/test/contracts.test.ts
@@ -166,6 +166,7 @@ const routeCases: RouteCase[] = [
       "package",
       "description",
       ["price", "price1"],
+      "is_extended_promotional",
     ],
   },
   {
@@ -382,6 +383,7 @@ describe("Cloudflare route contracts", () => {
       "description",
       ["price", "price1"],
       "stock",
+      "is_extended_promotional",
     ])
   })
 

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -190,6 +190,7 @@ export interface Component {
   category_id: number;
   datasheet: string;
   description: string;
+  extended_promotional: number | null;
   extra: string | null;
   flag: Generated<number>;
   joints: number;
@@ -801,6 +802,7 @@ export interface VComponent {
   category_id: number | null;
   datasheet: string | null;
   description: string | null;
+  extended_promotional: number | null;
   extra: string | null;
   joints: number | null;
   last_on_stock: number | null;

--- a/lib/db/optimizations/component-extended-promotional-column.ts
+++ b/lib/db/optimizations/component-extended-promotional-column.ts
@@ -1,0 +1,23 @@
+import { sql } from "kysely"
+import type { DbOptimizationSpec } from "./types"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+
+export const componentExtendedPromotionalColumn: DbOptimizationSpec = {
+  name: "add_components_extended_promotional_column",
+  description:
+    "Adds components.extended_promotional, populated from the JLCPCB extended promotional source sync script",
+
+  async checkIfAdded(db: KyselyDatabaseInstance) {
+    const result = await sql<{ name: string }>`
+      PRAGMA table_info(components)
+    `.execute(db)
+
+    return result.rows.some((row) => row.name === "extended_promotional")
+  },
+
+  async execute(db: KyselyDatabaseInstance) {
+    await sql`
+      ALTER TABLE components ADD COLUMN extended_promotional INTEGER
+    `.execute(db)
+  },
+}

--- a/lib/db/optimizations/component-extended-promotional-index.ts
+++ b/lib/db/optimizations/component-extended-promotional-index.ts
@@ -1,0 +1,26 @@
+import { sql } from "kysely"
+import type { DbOptimizationSpec } from "./types"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+
+export const componentExtendedPromotionalIndex: DbOptimizationSpec = {
+  name: "idx_components_extended_promotional",
+  description:
+    "Index on components.extended_promotional for faster extended promotional component queries",
+
+  async checkIfAdded(db: KyselyDatabaseInstance) {
+    const result = await sql`
+      SELECT name FROM sqlite_master
+      WHERE type='index' AND name=${this.name}
+    `.execute(db)
+
+    return result.rows.length > 0
+  },
+
+  async execute(db: KyselyDatabaseInstance) {
+    await db.schema
+      .createIndex(this.name)
+      .on("components")
+      .column("extended_promotional")
+      .execute()
+  },
+}

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -50,6 +50,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -71,6 +72,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("extended_promotional", "=", 1)
   }
 
   const baseQuery = query
@@ -193,6 +197,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.extended_promotional),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -35,6 +35,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -51,6 +52,8 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
+      "extended_promotional",
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -69,6 +72,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("extended_promotional", "=", 1)
   }
 
   if (req.query.search) {
@@ -114,6 +120,7 @@ export default withWinterSpec({
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
+    is_extended_promotional: Boolean(c.extended_promotional),
   }))
 
   if (ctx.isApiRequest) {
@@ -152,6 +159,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/scripts/pull-extended-promotional.ts
+++ b/scripts/pull-extended-promotional.ts
@@ -1,0 +1,161 @@
+/**
+ * Pull JLCPCB extended promotional LCSC codes.
+ *
+ * The JLCPCB "Basic/Promotional Extended Parts" page queries the SMT parts API
+ * with componentLibraryType="base" and preferredComponentFlag=true. Parts that
+ * appear in that result set with componentLibraryType="expand" are extended
+ * promotional parts. This script prints their LCSC codes, one per line.
+ */
+
+const API_URL =
+  "https://jlcpcb.com/api/overseas-pcb-order/v1/shoppingCart/smtGood/selectSmtComponentList/v2"
+const PAGE_SIZE = 500
+
+interface SmtComponent {
+  componentCode?: string
+  componentLibraryType?: string
+}
+
+interface ComponentPageInfo {
+  total?: number
+  list?: SmtComponent[]
+  pages?: number
+  hasNextPage?: boolean
+}
+
+interface JlcAuth {
+  xsrfToken: string
+  cookieHeader: string
+}
+
+const getCookieValue = (setCookieHeader: string, cookieName: string) => {
+  const match = setCookieHeader.match(new RegExp(`${cookieName}=([^;]+)`))
+  return match ? decodeURIComponent(match[1]!) : null
+}
+
+const getJlcAuth = async (): Promise<JlcAuth> => {
+  const response = await fetch(
+    "https://jlcpcb.com/api/overseas-pcb-order/v1/getAll",
+    {
+      headers: {
+        Referer: "https://jlcpcb.com/parts/basic_parts",
+        "User-Agent":
+          "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36",
+      },
+    },
+  )
+  const setCookie = response.headers.get("set-cookie") ?? ""
+  const token = getCookieValue(setCookie, "XSRF-TOKEN")
+
+  if (!token) {
+    throw new Error("Could not read XSRF-TOKEN from JLCPCB response")
+  }
+
+  const sessionId = getCookieValue(setCookie, "JLCPCB_SESSION_ID")
+  const cookieParts = [`XSRF-TOKEN=${encodeURIComponent(token)}`]
+  if (sessionId) {
+    cookieParts.push(`JLCPCB_SESSION_ID=${encodeURIComponent(sessionId)}`)
+  }
+
+  return {
+    xsrfToken: token,
+    cookieHeader: cookieParts.join("; "),
+  }
+}
+
+const fetchPage = async (
+  currentPage: number,
+  auth: JlcAuth,
+): Promise<ComponentPageInfo> => {
+  const response = await fetch(API_URL, {
+    method: "POST",
+    headers: {
+      Accept: "application/json, text/plain, */*",
+      "Content-Type": "application/json",
+      Cookie: auth.cookieHeader,
+      Origin: "https://jlcpcb.com",
+      Referer: "https://jlcpcb.com/parts/basic_parts",
+      "User-Agent":
+        "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36",
+      "X-XSRF-TOKEN": auth.xsrfToken,
+    },
+    body: JSON.stringify({
+      currentPage,
+      pageSize: PAGE_SIZE,
+      keyword: null,
+      componentLibraryType: "base",
+      preferredComponentFlag: true,
+      stockFlag: null,
+      stockSort: null,
+      firstSortName: null,
+      secondSortName: null,
+      componentBrand: null,
+      componentSpecification: null,
+      componentAttributes: [],
+      searchSource: "search",
+    }),
+  })
+
+  const responseText = await response.text()
+  const json = JSON.parse(responseText)
+  const pageInfo = json.componentPageInfo ?? json.data?.componentPageInfo
+
+  if (!pageInfo) {
+    throw new Error(
+      `JLCPCB API returned ${response.status} without componentPageInfo: ${responseText.slice(0, 500)}`,
+    )
+  }
+
+  return pageInfo
+}
+
+const main = async () => {
+  const auth = await getJlcAuth()
+  const codes = new Set<string>()
+  let currentPage = 1
+  let totalSeen = 0
+
+  while (true) {
+    const pageInfo = await fetchPage(currentPage, auth)
+    const parts = pageInfo.list ?? []
+
+    totalSeen += parts.length
+
+    for (const part of parts) {
+      if (
+        part.componentLibraryType === "expand" &&
+        part.componentCode?.trim()
+      ) {
+        codes.add(part.componentCode.trim())
+      }
+    }
+
+    console.error(
+      `page ${currentPage}: saw ${parts.length} parts (${totalSeen}/${pageInfo.total ?? "?"}), found ${codes.size} extended promotional`,
+    )
+
+    const hasMorePages =
+      pageInfo.pages != null
+        ? currentPage < pageInfo.pages
+        : pageInfo.total != null
+          ? totalSeen < pageInfo.total
+          : pageInfo.hasNextPage === true
+
+    if (!hasMorePages || parts.length === 0) break
+    currentPage += 1
+    await new Promise((resolve) => setTimeout(resolve, 300))
+  }
+
+  if (codes.size === 0) {
+    throw new Error("No extended promotional parts found from JLCPCB API")
+  }
+
+  for (const code of codes) {
+    console.log(code)
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})

--- a/scripts/setup-db-optimizations.ts
+++ b/scripts/setup-db-optimizations.ts
@@ -9,12 +9,16 @@ import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
 import { componentPackageIndex } from "lib/db/optimizations/component-indexes"
 import { componentBasicIndex } from "lib/db/optimizations/component-basic-index"
 import { componentPreferredIndex } from "lib/db/optimizations/component-preferred-index"
+import { componentExtendedPromotionalColumn } from "lib/db/optimizations/component-extended-promotional-column"
+import { componentExtendedPromotionalIndex } from "lib/db/optimizations/component-extended-promotional-index"
 
 const OPTIMIZATIONS: DbOptimizationSpec[] = [
   componentSearchFTS,
   componentPackageIndex,
   componentBasicIndex,
   componentPreferredIndex,
+  componentExtendedPromotionalColumn,
+  componentExtendedPromotionalIndex,
   removeStaleComponents,
   componentStockIndex,
   componentInStockColumn,

--- a/scripts/update-extended-promotional.ts
+++ b/scripts/update-extended-promotional.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs"
+import { getDbClient } from "lib/db/get-db-client"
+
+const parseLcscCodes = (input: string): number[] => {
+  const codes = new Set<number>()
+
+  for (const line of input.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+
+    const normalized = trimmed.toLowerCase().startsWith("c")
+      ? trimmed.slice(1)
+      : trimmed
+    const lcsc = Number.parseInt(normalized, 10)
+
+    if (!Number.isNaN(lcsc)) {
+      codes.add(lcsc)
+    }
+  }
+
+  return [...codes]
+}
+
+const readInput = async (path: string): Promise<string> => {
+  if (path === "-") {
+    return await Bun.stdin.text()
+  }
+
+  return readFileSync(path, "utf8")
+}
+
+const main = async () => {
+  const inputPath = process.argv[2]
+
+  if (!inputPath) {
+    console.error(
+      "Usage: bun run scripts/update-extended-promotional.ts <codes-file|->",
+    )
+    process.exit(1)
+  }
+
+  const codes = parseLcscCodes(await readInput(inputPath))
+
+  if (codes.length === 0) {
+    console.error(
+      "No extended promotional LCSC codes were provided; refusing to update the database with empty source data.",
+    )
+    process.exit(1)
+  }
+
+  const db = getDbClient()
+
+  try {
+    await db
+      .updateTable("components")
+      .set({ extended_promotional: 0 })
+      .execute()
+
+    const batchSize = 500
+    let updatedRows = 0
+
+    for (let index = 0; index < codes.length; index += batchSize) {
+      const batch = codes.slice(index, index + batchSize)
+      const result = await db
+        .updateTable("components")
+        .set({ extended_promotional: 1 })
+        .where("lcsc", "in", batch)
+        .executeTakeFirst()
+
+      updatedRows += Number(result.numUpdatedRows ?? 0)
+    }
+
+    if (updatedRows === 0) {
+      throw new Error(
+        "The source list was non-empty, but none of its LCSC codes matched local components.",
+      )
+    }
+
+    console.error(
+      `Marked ${updatedRows} components as extended promotional from ${codes.length} source codes.`,
+    )
+  } finally {
+    await db.destroy()
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})

--- a/tests/routes/api/search.test.ts
+++ b/tests/routes/api/search.test.ts
@@ -18,6 +18,8 @@ test("GET /api/search with search query 'STM32F401RCT6' returns expected compone
   expect(component).toHaveProperty("package")
   expect(component).toHaveProperty("price")
   expect(component).toHaveProperty("stock")
+  expect(component).toHaveProperty("is_extended_promotional")
+  expect(typeof component.is_extended_promotional).toBe("boolean")
 })
 
 test("GET /api/search with search query '555 Timer' returns expected components", async () => {
@@ -36,6 +38,22 @@ test("GET /api/search with search query '555 Timer' returns expected components"
     expect(component).toHaveProperty("price")
     expect(component).toHaveProperty("stock")
   }
+})
+
+test("GET /api/search supports is_extended_promotional filter", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get(
+    "/api/search?limit=10&is_extended_promotional=true",
+  )
+
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+  expect(res.data.components.length).toBeGreaterThan(0)
+  expect(
+    res.data.components.every(
+      (component: any) => component.is_extended_promotional === true,
+    ),
+  ).toBe(true)
 })
 
 test("GET /api/search with search query 'red led' returns expected components", async () => {

--- a/tests/routes/components/list.test.ts
+++ b/tests/routes/components/list.test.ts
@@ -6,4 +6,27 @@ test("GET /components/list with json param returns component data", async () => 
   const res = await axios.get("/components/list?json=true")
   expect(res.data).toHaveProperty("components")
   expect(Array.isArray(res.data.components)).toBe(true)
+
+  if (res.data.components.length > 0) {
+    expect(res.data.components[0]).toHaveProperty("is_extended_promotional")
+    expect(typeof res.data.components[0].is_extended_promotional).toBe(
+      "boolean",
+    )
+  }
+})
+
+test("GET /components/list supports is_extended_promotional filter", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get(
+    "/components/list?json=true&is_extended_promotional=true",
+  )
+
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+  expect(res.data.components.length).toBeGreaterThan(0)
+  expect(
+    res.data.components.every(
+      (component: any) => component.is_extended_promotional === true,
+    ),
+  ).toBe(true)
 })


### PR DESCRIPTION
/claim #92

Closes #92

Adds a source-backed `is_extended_promotional` flag/filter for components.

What changed:
- Adds `components.extended_promotional` plus an index through DB optimizations.
- Adds `scripts/pull-extended-promotional.ts` to fetch JLCPCB basic/preferred SMT results and classify returned `componentLibraryType="expand"` parts as extended promotional.
- Adds `scripts/update-extended-promotional.ts` to populate the local DB from the source LCSC list while refusing empty/non-matching source data.
- Exposes `is_extended_promotional` on origin `/api/search` and `/components/list`, D1 proxy search/list responses, filters, and render UI.
- Updates D1 component catalog/search index rebuild scripts and contract tests.

Verification:
- `npx.cmd --yes bun@1.3.1 x tsc --noEmit`
- `git diff --check`
- `npx.cmd --yes bun@1.3.1 run scripts/pull-extended-promotional.ts | Measure-Object -Line` returned 1235 source codes across 4 JLCPCB pages.

Note: the focused route tests currently fail before reaching these assertions with the existing shared test preload error `driver has already been destroyed`.