### PR TITLE
feat: add is_extended_promotional filter and column (fixes #92)

### DIFF
--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -192,6 +192,7 @@ export interface Component {
   description: string;
   extra: string | null;
   flag: Generated<number>;
+  is_extended_promotional: Generated<number | null>;
   joints: number;
   last_on_stock: Generated<number>;
   last_update: number;
@@ -802,6 +803,7 @@ export interface VComponent {
   datasheet: string | null;
   description: string | null;
   extra: string | null;
+  is_extended_promotional: number | null;
   joints: number | null;
   last_on_stock: number | null;
   lcsc: number | null;

--- a/lib/db/optimizations/component-extended-promotional-column.ts
+++ b/lib/db/optimizations/component-extended-promotional-column.ts
@@ -1,0 +1,47 @@
+import { sql } from "kysely"
+import type { DbOptimizationSpec } from "./types"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+
+/**
+ * Adds an `is_extended_promotional` generated boolean column to the components
+ * table.
+ *
+ * An "extended promotional" part is defined as a component that JLCPCB has
+ * designated as a preferred (promotional) part but that is NOT a basic part.
+ * In other words: preferred = 1 AND basic = 0.
+ *
+ * This follows the terminology used in the JLCPCB / EasyEDA component library
+ * where "extended" refers to non-basic parts that still carry a promotional
+ * discount/priority status.
+ */
+export const componentExtendedPromotionalColumn: DbOptimizationSpec = {
+  name: "add_components_is_extended_promotional_column",
+  description:
+    "Adds is_extended_promotional boolean column to components table (preferred=1 AND basic=0)",
+
+  async checkIfAdded(db: KyselyDatabaseInstance) {
+    const {
+      rows: [ex],
+    } = await sql<any>`
+      SELECT * FROM components LIMIT 1
+    `.execute(db)
+
+    return "is_extended_promotional" in ex
+  },
+
+  async execute(db: KyselyDatabaseInstance) {
+    // Add the generated column derived from existing preferred and basic flags
+    await sql`
+      ALTER TABLE components
+      ADD COLUMN is_extended_promotional boolean
+      GENERATED ALWAYS AS (preferred = 1 AND basic = 0)
+    `.execute(db)
+
+    // Index to make filtering by this column fast
+    await db.schema
+      .createIndex("idx_components_is_extended_promotional")
+      .on("components")
+      .column("is_extended_promotional")
+      .execute()
+  },
+}

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -50,6 +50,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -71,6 +72,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("is_extended_promotional", "=", 1)
   }
 
   const baseQuery = query
@@ -193,6 +197,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.is_extended_promotional),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -35,6 +35,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -69,6 +70,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("is_extended_promotional", "=", 1)
   }
 
   if (req.query.search) {
@@ -111,6 +115,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.is_extended_promotional),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +157,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/scripts/setup-db-optimizations.ts
+++ b/scripts/setup-db-optimizations.ts
@@ -9,6 +9,7 @@ import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
 import { componentPackageIndex } from "lib/db/optimizations/component-indexes"
 import { componentBasicIndex } from "lib/db/optimizations/component-basic-index"
 import { componentPreferredIndex } from "lib/db/optimizations/component-preferred-index"
+import { componentExtendedPromotionalColumn } from "lib/db/optimizations/component-extended-promotional-column"
 
 const OPTIMIZATIONS: DbOptimizationSpec[] = [
   componentSearchFTS,
@@ -18,6 +19,7 @@ const OPTIMIZATIONS: DbOptimizationSpec[] = [
   removeStaleComponents,
   componentStockIndex,
   componentInStockColumn,
+  componentExtendedPromotionalColumn,
   componentCategoryIndex,
   componentInStockCategoryIndex,
 ]

--- a/tests/routes/api/search.test.ts
+++ b/tests/routes/api/search.test.ts
@@ -107,3 +107,32 @@ test("GET /api/search supports '0402 LED'", async () => {
   expect(res.data.components.every((c: any) => c.package === "0402")).toBe(true)
   expect(res.data.components.some((c: any) => c.lcsc === 965793)).toBe(true)
 })
+
+test("GET /api/search returns is_extended_promotional field in each component", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/api/search?limit=10")
+
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+  expect(res.data.components.length).toBeGreaterThan(0)
+
+  for (const component of res.data.components) {
+    expect(component).toHaveProperty("is_extended_promotional")
+    expect(typeof component.is_extended_promotional).toBe("boolean")
+  }
+})
+
+test("GET /api/search with is_extended_promotional=true only returns extended promotional components", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/api/search?limit=50&is_extended_promotional=true")
+
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+
+  for (const component of res.data.components) {
+    // Extended promotional: preferred=true AND basic=false
+    expect(component.is_extended_promotional).toBe(true)
+    expect(component.is_basic).toBe(false)
+    expect(component.is_preferred).toBe(true)
+  }
+})


### PR DESCRIPTION
Closes #92

## Changes

Adds `is_extended_promotional` as a generated boolean column and API filter parameter.

**Definition:** A component is "extended promotional" when `preferred = 1 AND basic = 0`. This matches JLCPCB terminology where "extended" parts are non-basic components that carry preferred/promotional status.

### Database
- New `lib/db/optimizations/component-extended-promotional-column.ts`: adds the generated column via `ALTER TABLE ... ADD COLUMN is_extended_promotional GENERATED ALWAYS AS (preferred = 1 AND basic = 0)` with a supporting index `idx_components_is_extended_promotional`.
- Registered in `scripts/setup-db-optimizations.ts`.

### API (`GET /api/search`)
- New optional `is_extended_promotional` boolean query param.
- When `true`, only components with `preferred=1` and `basic=0` are returned.
- `is_extended_promotional` is now included in every component response object.

### UI (`/components/list`)
- New "Extended Promotional" checkbox filter in the filter form.

### Types
- `lib/db/generated/kysely.ts` updated for both `Component` and `VComponent` interfaces.

### Tests
- Two new tests in `tests/routes/api/search.test.ts`:
  - Verifies `is_extended_promotional` field is present and boolean in all responses.
  - Verifies that filtering by `is_extended_promotional=true` only returns components where `is_preferred=true` and `is_basic=false`.