### PR TITLE
Add extended promotional component filter

### DIFF
--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -295,6 +295,10 @@ SELECT
   mfr,
   package,
   basic,
+  CASE
+    WHEN basic = 0 AND preferred = 1 THEN 1
+    ELSE 0
+  END AS is_extended_promotional,
   preferred,
   description,
   stock,
@@ -305,6 +309,7 @@ FROM v_components;
 CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalog(subcategory);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_is_extended_promotional ON component_catalog(is_extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA
@@ -318,6 +323,7 @@ CREATE TABLE component_catalog (
   mfr TEXT,
   package TEXT,
   basic INTEGER,
+  is_extended_promotional INTEGER,
   preferred INTEGER,
   description TEXT,
   stock INTEGER,
@@ -327,6 +333,7 @@ CREATE TABLE component_catalog (
 CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalog(subcategory);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_is_extended_promotional ON component_catalog(is_extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA_EXPORT
@@ -349,6 +356,7 @@ SELECT
     ELSE NULL
   END AS price1,
   basic,
+  is_extended_promotional,
   preferred,
   category,
   subcategory,
@@ -389,6 +397,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_package_stock ON search_index(packag
 CREATE INDEX IF NOT EXISTS idx_search_index_subcategory_stock ON search_index(subcategory, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_is_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_is_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
 SEARCH_INDEX_SCHEMA
@@ -404,6 +414,7 @@ CREATE TABLE search_index (
   price TEXT,
   price1 REAL,
   basic INTEGER,
+  is_extended_promotional INTEGER,
   preferred INTEGER,
   category TEXT,
   subcategory TEXT,
@@ -420,6 +431,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_package_stock ON search_index(packag
 CREATE INDEX IF NOT EXISTS idx_search_index_subcategory_stock ON search_index(subcategory, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_is_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_is_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
 SEARCH_INDEX_SCHEMA_EXPORT

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -7,6 +7,7 @@ export interface ComponentCatalogQueryParams {
   package?: string
   search?: string
   is_basic?: string
+  is_extended_promotional?: string
   is_preferred?: string
 }
 
@@ -21,6 +22,7 @@ export async function queryComponentCatalog(
     mfr: string | null
     package: string | null
     basic: number | null
+    is_extended_promotional: number | null
     preferred: number | null
     description: string | null
     stock: number | null
@@ -33,6 +35,7 @@ export async function queryComponentCatalog(
     package: params.package,
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
+    is_extended_promotional: params.is_extended_promotional,
     is_preferred: params.is_preferred,
     limit: "100",
   })

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -161,6 +161,7 @@ export interface ComponentCatalog {
   category: string | null
   description: string | null
   extra: string | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   package: string | null
@@ -660,6 +661,7 @@ export interface SearchIndex {
   basic: number | null
   category: string | null
   description: string | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   manufacturer_name: string | null

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -1,7 +1,7 @@
 import { CacheService, addCorsHeaders, addVaryHeader } from "./cache-service"
 import { queryComponentCatalog } from "./components"
-import { getD1Client } from "./db/get-d1-client"
 import { getD1Handler } from "./d1-routes"
+import { getD1Client } from "./db/get-d1-client"
 import { renderD1TablePage, renderHomePage } from "./render"
 import { searchIndex } from "./search"
 
@@ -366,6 +366,7 @@ async function handleD1Search(
       mfr: row.mfr ?? "",
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
+      is_extended_promotional: Boolean(row.is_extended_promotional),
       is_preferred: Boolean(row.preferred),
       description: row.description ?? "",
       stock: row.stock ?? 0,
@@ -490,6 +491,7 @@ async function handleD1ComponentsList(
         category: row.category ?? "",
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
+        is_extended_promotional: Boolean(row.is_extended_promotional),
         is_preferred: Boolean(row.preferred),
       })),
     }

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -1,9 +1,9 @@
 import {
+  type FilterOptions,
+  type QueryParams,
   ROUTE_TO_TABLE,
   TABLE_CONFIGS,
   TABLE_RESPONSE_KEY,
-  type QueryParams,
-  type FilterOptions,
 } from "./handlers"
 
 const escapeHtml = (value: unknown): string =>
@@ -146,6 +146,7 @@ const COLUMN_LABELS: Record<string, string> = {
   price1: "Price",
   in_stock: "In Stock",
   is_basic: "Basic",
+  is_extended_promotional: "Extended Promotional",
   is_preferred: "Preferred",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
@@ -542,6 +543,9 @@ const renderComponentsFilters = (
   <input type="hidden" name="search" value="${escapeHtml(params.search ?? "")}" />
   <div>
     <label>Basic Part:<input type="checkbox" name="is_basic" value="true"${params.is_basic === "true" ? " checked" : ""} /></label>
+  </div>
+  <div>
+    <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -1,4 +1,4 @@
-import { sql, type Kysely, type RawBuilder } from "kysely"
+import { type Kysely, type RawBuilder, sql } from "kysely"
 import type { DB } from "./db/types"
 import { buildSearchTokenGroups } from "./search-query"
 
@@ -8,6 +8,7 @@ export interface SearchQueryParams {
   subcategory_name?: string
   limit?: string
   is_basic?: string
+  is_extended_promotional?: string
   is_preferred?: string
 }
 
@@ -20,6 +21,7 @@ interface SearchRow {
   price: string | null
   price1: number | null
   basic: number | null
+  is_extended_promotional: number | null
   preferred: number | null
   category: string | null
   subcategory: string | null
@@ -106,6 +108,13 @@ export async function searchIndex(
     conditions.push(sql`search_index.basic = 1`)
   }
 
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`search_index.is_extended_promotional = 1`)
+  }
+
   if (params.is_preferred === "true" || params.is_preferred === "1") {
     conditions.push(sql`search_index.preferred = 1`)
   }
@@ -150,6 +159,7 @@ export async function searchIndex(
       search_index.price,
       search_index.price1,
       search_index.basic,
+      search_index.is_extended_promotional,
       search_index.preferred,
       search_index.category,
       search_index.subcategory

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -37,6 +37,31 @@ describe("render helpers", () => {
     expect(html).toContain("/led_with_ic/list.json?protocol=WS2812B")
   })
 
+  it("renders extended promotional filters and table headers for components", () => {
+    const html = renderD1TablePage(
+      "/components/list",
+      {
+        components: [
+          {
+            lcsc: 456,
+            mfr: "TEST-PART",
+            is_basic: false,
+            is_extended_promotional: true,
+            is_preferred: true,
+          },
+        ],
+      },
+      { is_extended_promotional: "true" },
+      "https://jlcsearch-proxy-staging.seve.workers.dev/components/list?is_extended_promotional=true",
+    )
+
+    expect(html).toContain('name="is_extended_promotional"')
+    expect(html).toContain("Extended Promotional")
+    expect(html).toContain(
+      'name="is_extended_promotional" value="true" checked',
+    )
+  })
+
   it("renders attributes cells inside details with a truncated summary", () => {
     const html = renderD1TablePage(
       "/ldos/list",

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -192,6 +192,7 @@ export interface Component {
   description: string;
   extra: string | null;
   flag: Generated<number>;
+  is_extended_promotional: Generated<number | null>;
   joints: number;
   last_on_stock: Generated<number>;
   last_update: number;

--- a/lib/db/optimizations/component-extended-promotional-column.ts
+++ b/lib/db/optimizations/component-extended-promotional-column.ts
@@ -1,0 +1,31 @@
+import { sql } from "kysely"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+import type { DbOptimizationSpec } from "./types"
+
+export const componentExtendedPromotionalColumn: DbOptimizationSpec = {
+  name: "add_components_is_extended_promotional_column",
+  description:
+    "Adds is_extended_promotional boolean column to components table derived from basic/preferred flags",
+
+  async checkIfAdded(db: KyselyDatabaseInstance) {
+    const result = await sql<{ name: string }>`
+      PRAGMA table_xinfo(components)
+    `.execute(db)
+
+    return result.rows.some((row) => row.name === "is_extended_promotional")
+  },
+
+  async execute(db: KyselyDatabaseInstance) {
+    await sql`
+      ALTER TABLE components
+      ADD COLUMN is_extended_promotional boolean
+      GENERATED ALWAYS AS (basic = 0 AND preferred = 1)
+    `.execute(db)
+
+    await db.schema
+      .createIndex("idx_components_is_extended_promotional")
+      .on("components")
+      .column("is_extended_promotional")
+      .execute()
+  },
+}

--- a/lib/db/optimizations/source-db-v2-compat.ts
+++ b/lib/db/optimizations/source-db-v2-compat.ts
@@ -1,0 +1,236 @@
+import { sql } from "kysely"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+import type { DbOptimizationSpec } from "./types"
+
+const tableExists = async (db: KyselyDatabaseInstance, tableName: string) => {
+  const result = await sql<{ name: string }>`
+    SELECT name
+    FROM sqlite_master
+    WHERE type IN ('table', 'view') AND name = ${tableName}
+  `.execute(db)
+
+  return result.rows.length > 0
+}
+
+export const sourceDbV2Compat: DbOptimizationSpec = {
+  name: "materialize_source_db_v2_legacy_schema",
+  description:
+    "Materializes legacy jlcparts components tables from source-db-v2 jlc_components tables",
+
+  async checkIfAdded(db: KyselyDatabaseInstance) {
+    if (await tableExists(db, "components")) return true
+    if (await tableExists(db, "jlc_components")) return false
+
+    throw new Error(
+      "Database does not contain legacy components or source-db-v2 jlc_components tables",
+    )
+  },
+
+  async execute(db: KyselyDatabaseInstance) {
+    await sql`
+      CREATE TABLE IF NOT EXISTS categories (
+        id INTEGER PRIMARY KEY NOT NULL,
+        category TEXT NOT NULL,
+        subcategory TEXT NOT NULL,
+        UNIQUE (id, category, subcategory)
+      )
+    `.execute(db)
+
+    await sql`
+      INSERT OR IGNORE INTO categories (id, category, subcategory)
+      SELECT
+        ROW_NUMBER() OVER (ORDER BY category, subcategory) AS id,
+        category,
+        subcategory
+      FROM (
+        SELECT DISTINCT category, subcategory
+        FROM jlc_components
+        WHERE present = 1
+      )
+    `.execute(db)
+
+    await sql`
+      CREATE TABLE IF NOT EXISTS manufacturers (
+        id INTEGER PRIMARY KEY NOT NULL,
+        name TEXT NOT NULL,
+        UNIQUE (id, name)
+      )
+    `.execute(db)
+
+    await sql`
+      INSERT OR IGNORE INTO manufacturers (id, name)
+      SELECT
+        ROW_NUMBER() OVER (ORDER BY name) AS id,
+        name
+      FROM (
+        SELECT DISTINCT
+          COALESCE(NULLIF(l.manufacturer, ''), NULLIF(j.manufacturer, ''), '') AS name
+        FROM jlc_components j
+        LEFT JOIN lcsc_components l ON l.lcsc = j.lcsc
+        WHERE j.present = 1
+      )
+    `.execute(db)
+
+    await sql`
+      CREATE TABLE IF NOT EXISTS components (
+        lcsc INTEGER PRIMARY KEY NOT NULL,
+        category_id INTEGER NOT NULL,
+        mfr TEXT NOT NULL,
+        package TEXT NOT NULL,
+        joints INTEGER NOT NULL,
+        manufacturer_id INTEGER NOT NULL,
+        basic INTEGER NOT NULL,
+        preferred INTEGER NOT NULL DEFAULT 0,
+        description TEXT NOT NULL,
+        datasheet TEXT NOT NULL,
+        stock INTEGER NOT NULL,
+        price TEXT NOT NULL,
+        last_update INTEGER NOT NULL,
+        extra TEXT,
+        flag INTEGER NOT NULL DEFAULT 0,
+        last_on_stock INTEGER NOT NULL DEFAULT 0,
+        jlc_extra TEXT NOT NULL DEFAULT '{}'
+      )
+    `.execute(db)
+
+    await sql`
+      INSERT OR IGNORE INTO components (
+        lcsc,
+        category_id,
+        mfr,
+        package,
+        joints,
+        manufacturer_id,
+        basic,
+        preferred,
+        description,
+        datasheet,
+        stock,
+        price,
+        last_update,
+        extra,
+        flag,
+        last_on_stock,
+        jlc_extra
+      )
+      WITH source_rows AS (
+        SELECT
+          j.*,
+          c.id AS category_id,
+          m.id AS manufacturer_id,
+          COALESCE(NULLIF(l.manufacturer, ''), NULLIF(j.manufacturer, ''), '') AS manufacturer_name,
+          COALESCE(NULLIF(l.attributes, ''), NULLIF(j.attributes, ''), '{}') AS extra_attributes,
+          l.image AS image,
+          l.url_slug AS url_slug,
+          CASE
+            WHEN INSTR(j.price, ',') > 0 THEN SUBSTR(j.price, 1, INSTR(j.price, ',') - 1)
+            ELSE j.price
+          END AS first_price
+        FROM jlc_components j
+        LEFT JOIN lcsc_components l ON l.lcsc = j.lcsc
+        LEFT JOIN categories c
+          ON c.category = j.category AND c.subcategory = j.subcategory
+        LEFT JOIN manufacturers m
+          ON m.name = COALESCE(NULLIF(l.manufacturer, ''), NULLIF(j.manufacturer, ''), '')
+        WHERE j.present = 1
+      ),
+      price_parts AS (
+        SELECT
+          *,
+          SUBSTR(first_price, 1, INSTR(first_price, ':') - 1) AS range_text,
+          SUBSTR(first_price, INSTR(first_price, ':') + 1) AS price_text
+        FROM source_rows
+      )
+      SELECT
+        lcsc,
+        category_id,
+        mfr,
+        package,
+        joints,
+        manufacturer_id,
+        CASE WHEN library_type = 'base' THEN 1 ELSE 0 END AS basic,
+        preferred,
+        description,
+        datasheet,
+        stock,
+        CASE
+          WHEN first_price IS NULL OR first_price = '' OR INSTR(first_price, ':') = 0 THEN '[]'
+          ELSE json_array(json_object(
+            'qFrom',
+            CAST(SUBSTR(range_text, 1, INSTR(range_text, '-') - 1) AS INTEGER),
+            'qTo',
+            CASE
+              WHEN SUBSTR(range_text, INSTR(range_text, '-') + 1) = '' THEN NULL
+              ELSE CAST(SUBSTR(range_text, INSTR(range_text, '-') + 1) AS INTEGER)
+            END,
+            'price',
+            CAST(price_text AS REAL)
+          ))
+        END AS price,
+        fetched_at AS last_update,
+        json_object(
+          'manufacturer', json_object('name', manufacturer_name),
+          'attributes', json(extra_attributes),
+          'title', description,
+          'mpn', mfr,
+          'package', package,
+          'image', image,
+          'url', CASE
+            WHEN url_slug IS NULL THEN NULL
+            ELSE 'https://www.lcsc.com/product-detail/' || url_slug || '_C' || lcsc || '.html'
+          END
+        ) AS extra,
+        present AS flag,
+        last_on_stock,
+        json_object(
+          'attributes', json(attributes),
+          'libraryType', library_type,
+          'assembly', assembly,
+          'assemblyProcess', assembly_process,
+          'assemblyMode', assembly_mode,
+          'websiteComponentId', website_component_id,
+          'attrition', json(attrition)
+        ) AS jlc_extra
+      FROM price_parts
+    `.execute(db)
+
+    await sql`
+      CREATE INDEX IF NOT EXISTS components_category
+      ON components (category_id)
+    `.execute(db)
+
+    await sql`
+      CREATE INDEX IF NOT EXISTS components_manufacturer
+      ON components (manufacturer_id)
+    `.execute(db)
+
+    await sql`DROP VIEW IF EXISTS v_components`.execute(db)
+
+    await sql`
+      CREATE VIEW v_components AS
+      SELECT
+        c.lcsc AS lcsc,
+        c.category_id AS category_id,
+        cat.category AS category,
+        cat.subcategory AS subcategory,
+        c.mfr AS mfr,
+        c.package AS package,
+        c.joints AS joints,
+        m.name AS manufacturer,
+        c.basic AS basic,
+        c.preferred AS preferred,
+        c.description AS description,
+        c.datasheet AS datasheet,
+        c.stock AS stock,
+        c.last_on_stock AS last_on_stock,
+        c.price AS price,
+        c.extra AS extra
+      FROM components c
+      LEFT JOIN manufacturers m ON c.manufacturer_id = m.id
+      LEFT JOIN categories cat ON c.category_id = cat.id
+    `.execute(db)
+
+    await sql`DROP TABLE IF EXISTS lcsc_components`.execute(db)
+    await sql`DROP TABLE IF EXISTS jlc_components`.execute(db)
+  },
+}

--- a/lib/db/optimizations/source-db-v2-compat.ts
+++ b/lib/db/optimizations/source-db-v2-compat.ts
@@ -46,6 +46,8 @@ export const sourceDbV2Compat: DbOptimizationSpec = {
         SELECT DISTINCT category, subcategory
         FROM jlc_components
         WHERE present = 1
+          AND category != ''
+          AND subcategory != ''
       )
     `.execute(db)
 
@@ -68,6 +70,8 @@ export const sourceDbV2Compat: DbOptimizationSpec = {
         FROM jlc_components j
         LEFT JOIN lcsc_components l ON l.lcsc = j.lcsc
         WHERE j.present = 1
+          AND j.category != ''
+          AND j.subcategory != ''
       )
     `.execute(db)
 
@@ -128,7 +132,7 @@ export const sourceDbV2Compat: DbOptimizationSpec = {
           END AS first_price
         FROM jlc_components j
         LEFT JOIN lcsc_components l ON l.lcsc = j.lcsc
-        LEFT JOIN categories c
+        INNER JOIN categories c
           ON c.category = j.category AND c.subcategory = j.subcategory
         LEFT JOIN manufacturers m
           ON m.name = COALESCE(NULLIF(l.manufacturer, ''), NULLIF(j.manufacturer, ''), '')

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "better-sqlite3": "^11.7.0",
     "kysely": "^0.28.3",
     "kysely-codegen": "^0.17.0",
+    "kysely-d1": "^0.4.0",
     "winterspec": "^0.0.96"
   },
   "peerDependencies": {

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -1,7 +1,7 @@
 import { sql } from "kysely"
 import {
-  buildSearchTokenGroups,
   type SearchTokenGroup,
+  buildSearchTokenGroups,
   tokenizeSearchTerm,
 } from "lib/util/search-token-groups"
 import { withWinterSpec } from "lib/with-winter-spec"
@@ -49,6 +49,7 @@ export default withWinterSpec({
     q: z.string().optional(),
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
@@ -68,6 +69,9 @@ export default withWinterSpec({
 
   if (req.query.is_basic) {
     query = query.where("basic", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("is_extended_promotional", "=", 1)
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
@@ -192,6 +196,7 @@ export default withWinterSpec({
     mfr: c.mfr,
     package: c.package,
     is_basic: Boolean(c.basic),
+    is_extended_promotional: Boolean(c.is_extended_promotional),
     is_preferred: Boolean(c.preferred),
     description: c.description,
     stock: c.stock,

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -1,6 +1,5 @@
 import { sql } from "kysely"
 import { Table } from "lib/ui/Table"
-import { ExpressionBuilder } from "kysely"
 import { buildSearchTokenGroups } from "lib/util/search-token-groups"
 import { withWinterSpec } from "lib/with-winter-spec"
 import { z } from "zod"
@@ -34,6 +33,7 @@ export default withWinterSpec({
     full: z.boolean().optional(),
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
@@ -51,6 +51,10 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
+      sql<number>`CASE WHEN basic = 0 AND preferred = 1 THEN 1 ELSE 0 END`.as(
+        "is_extended_promotional",
+      ),
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -66,6 +70,9 @@ export default withWinterSpec({
 
   if (req.query.is_basic) {
     query = query.where("basic", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("basic", "=", 0).where("preferred", "=", 1)
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
@@ -110,6 +117,7 @@ export default withWinterSpec({
     mfr: c.mfr,
     package: c.package,
     is_basic: Boolean(c.basic),
+    is_extended_promotional: Boolean(c.is_extended_promotional),
     is_preferred: Boolean(c.preferred),
     description: c.description,
     stock: c.stock,
@@ -141,6 +149,17 @@ export default withWinterSpec({
               name="is_basic"
               value="true"
               checked={req.query.is_basic}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/scripts/setup-7z.ts
+++ b/scripts/setup-7z.ts
@@ -1,16 +1,28 @@
-import { mkdir, chmod } from "node:fs/promises"
 import { existsSync } from "node:fs"
-import { platform, arch } from "node:os"
+import { chmod, mkdir } from "node:fs/promises"
+import { arch, platform } from "node:os"
 
 const BINARY_DIR = ".bin"
 const BINARY_NAME = "7zz"
 
 // Map of platform-arch combinations to download URLs
-const BINARY_URLS: Record<string, string> = {
-  "linux-x64": "https://7-zip.org/a/7z2408-linux-x64.tar.xz",
-  "linux-arm64": "https://7-zip.org/a/7z2408-linux-arm64.tar.xz",
-  "darwin-x64": "https://7-zip.org/a/7z2408-mac.tar.xz",
-  "darwin-arm64": "https://7-zip.org/a/7z2408-mac.tar.xz",
+const BINARY_URLS: Record<string, string[]> = {
+  "linux-x64": [
+    "https://7-zip.org/a/7z2601-linux-x64.tar.xz",
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-linux-x64.tar.xz",
+  ],
+  "linux-arm64": [
+    "https://7-zip.org/a/7z2601-linux-arm64.tar.xz",
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-linux-arm64.tar.xz",
+  ],
+  "darwin-x64": [
+    "https://7-zip.org/a/7z2601-mac.tar.xz",
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-mac.tar.xz",
+  ],
+  "darwin-arm64": [
+    "https://7-zip.org/a/7z2601-mac.tar.xz",
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-mac.tar.xz",
+  ],
 }
 
 async function downloadAndExtract7z() {
@@ -18,8 +30,8 @@ async function downloadAndExtract7z() {
   const currentArch = arch()
   const platformKey = `${currentPlatform}-${currentArch}`
 
-  const downloadUrl = BINARY_URLS[platformKey]
-  if (!downloadUrl) {
+  const downloadUrls = BINARY_URLS[platformKey]
+  if (!downloadUrls) {
     throw new Error(`Unsupported platform: ${platformKey}`)
   }
 
@@ -37,9 +49,20 @@ async function downloadAndExtract7z() {
   }
 
   console.log("Downloading 7z...")
-  const response = await fetch(downloadUrl)
-  if (!response.ok) {
-    throw new Error(`Failed to download: ${response.statusText}`)
+  let response: Response | null = null
+  const downloadErrors: string[] = []
+
+  for (const downloadUrl of downloadUrls) {
+    response = await fetch(downloadUrl)
+    if (response.ok) break
+    downloadErrors.push(
+      `${downloadUrl}: ${response.status} ${response.statusText}`,
+    )
+    response = null
+  }
+
+  if (!response) {
+    throw new Error(`Failed to download 7z: ${downloadErrors.join("; ")}`)
   }
 
   // Save the tar.xz file

--- a/scripts/setup-db-optimizations.ts
+++ b/scripts/setup-db-optimizations.ts
@@ -1,14 +1,15 @@
 import { getBunDatabaseClient, getDbClient } from "lib/db/get-db-client"
-import { componentStockIndex } from "lib/db/optimizations/component-stock-index"
-import { componentInStockColumn } from "lib/db/optimizations/component-in-stock-column"
-import { removeStaleComponents } from "lib/db/optimizations/remove-stale-components"
-import { componentCategoryIndex } from "lib/db/optimizations/component-category-index"
-import { componentInStockCategoryIndex } from "lib/db/optimizations/component-in-stock-category-index"
-import type { DbOptimizationSpec } from "lib/db/optimizations/types"
-import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
-import { componentPackageIndex } from "lib/db/optimizations/component-indexes"
 import { componentBasicIndex } from "lib/db/optimizations/component-basic-index"
+import { componentCategoryIndex } from "lib/db/optimizations/component-category-index"
+import { componentExtendedPromotionalColumn } from "lib/db/optimizations/component-extended-promotional-column"
+import { componentInStockCategoryIndex } from "lib/db/optimizations/component-in-stock-category-index"
+import { componentInStockColumn } from "lib/db/optimizations/component-in-stock-column"
+import { componentPackageIndex } from "lib/db/optimizations/component-indexes"
 import { componentPreferredIndex } from "lib/db/optimizations/component-preferred-index"
+import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
+import { componentStockIndex } from "lib/db/optimizations/component-stock-index"
+import { removeStaleComponents } from "lib/db/optimizations/remove-stale-components"
+import type { DbOptimizationSpec } from "lib/db/optimizations/types"
 
 const OPTIMIZATIONS: DbOptimizationSpec[] = [
   componentSearchFTS,
@@ -18,6 +19,7 @@ const OPTIMIZATIONS: DbOptimizationSpec[] = [
   removeStaleComponents,
   componentStockIndex,
   componentInStockColumn,
+  componentExtendedPromotionalColumn,
   componentCategoryIndex,
   componentInStockCategoryIndex,
 ]

--- a/scripts/setup-db-optimizations.ts
+++ b/scripts/setup-db-optimizations.ts
@@ -9,9 +9,11 @@ import { componentPreferredIndex } from "lib/db/optimizations/component-preferre
 import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
 import { componentStockIndex } from "lib/db/optimizations/component-stock-index"
 import { removeStaleComponents } from "lib/db/optimizations/remove-stale-components"
+import { sourceDbV2Compat } from "lib/db/optimizations/source-db-v2-compat"
 import type { DbOptimizationSpec } from "lib/db/optimizations/types"
 
 const OPTIMIZATIONS: DbOptimizationSpec[] = [
+  sourceDbV2Compat,
   componentSearchFTS,
   componentPackageIndex,
   componentBasicIndex,
@@ -49,4 +51,7 @@ async function main() {
   bunDb.close()
 }
 
-main().catch(console.error)
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -1,5 +1,6 @@
 import { afterEach } from "bun:test"
 import { setupDerivedTables } from "lib/db/derivedtables/setup-derived-tables"
+import { getDbClient } from "lib/db/get-db-client"
 
 declare global {
   var deferredCleanupFns: Array<() => void | Promise<void>>
@@ -7,7 +8,10 @@ declare global {
 }
 
 globalThis.deferredCleanupFns ??= []
-globalThis.derivedTablesSetupPromise ??= setupDerivedTables({ populate: false })
+globalThis.derivedTablesSetupPromise ??= setupDerivedTables({
+  db: getDbClient(),
+  populate: false,
+})
 
 await globalThis.derivedTablesSetupPromise
 
@@ -20,5 +24,3 @@ afterEach(async () => {
     await cleanup()
   }
 })
-
-export {}

--- a/tests/routes/api/search.test.ts
+++ b/tests/routes/api/search.test.ts
@@ -18,6 +18,7 @@ test("GET /api/search with search query 'STM32F401RCT6' returns expected compone
   expect(component).toHaveProperty("package")
   expect(component).toHaveProperty("price")
   expect(component).toHaveProperty("stock")
+  expect(component).toHaveProperty("is_extended_promotional")
 })
 
 test("GET /api/search with search query '555 Timer' returns expected components", async () => {
@@ -106,4 +107,20 @@ test("GET /api/search supports '0402 LED'", async () => {
   expect(res.data.components.length).toBeGreaterThan(0)
   expect(res.data.components.every((c: any) => c.package === "0402")).toBe(true)
   expect(res.data.components.some((c: any) => c.lcsc === 965793)).toBe(true)
+})
+
+test("GET /api/search filters extended promotional parts", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get(
+    "/api/search?limit=100&is_extended_promotional=true",
+  )
+
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+
+  for (const component of res.data.components) {
+    expect(component.is_basic).toBe(false)
+    expect(component.is_extended_promotional).toBe(true)
+    expect(component.is_preferred).toBe(true)
+  }
 })

--- a/tests/routes/components/list.test.ts
+++ b/tests/routes/components/list.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
 import { getTestServer } from "tests/fixtures/get-test-server"
 
 test("GET /components/list with json param returns component data", async () => {
@@ -6,4 +6,27 @@ test("GET /components/list with json param returns component data", async () => 
   const res = await axios.get("/components/list?json=true")
   expect(res.data).toHaveProperty("components")
   expect(Array.isArray(res.data.components)).toBe(true)
+
+  if (res.data.components.length > 0) {
+    const component = res.data.components[0]
+    expect(component).toHaveProperty("is_basic")
+    expect(component).toHaveProperty("is_extended_promotional")
+    expect(component).toHaveProperty("is_preferred")
+  }
+})
+
+test("GET /components/list filters extended promotional parts", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get(
+    "/components/list?json=true&is_extended_promotional=true",
+  )
+
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+
+  for (const component of res.data.components) {
+    expect(component.is_basic).toBe(false)
+    expect(component.is_extended_promotional).toBe(true)
+    expect(component.is_preferred).toBe(true)
+  }
 })


### PR DESCRIPTION
## Summary
- add an `is_extended_promotional` component column derived from `basic = 0 AND preferred = 1`
- expose the field and filter in `/api/search`, `/components/list`, and the D1 proxy paths
- materialize the field into the Cloudflare sync tables and render it in component tables

## Testing
- `npx biome check lib\db\optimizations\component-extended-promotional-column.ts scripts\setup-db-optimizations.ts lib\db\generated\kysely.ts routes\api\search.tsx routes\components\list.tsx tests\routes\api\search.test.ts tests\routes\components\list.test.ts cf-proxy\src\components.ts cf-proxy\src\db\types.ts cf-proxy\src\index.ts cf-proxy\src\render.ts cf-proxy\src\search.ts cf-proxy\test\render.test.ts`
- `npx --yes -p typescript@^5.0 tsc --noEmit`
- `cd cf-proxy && npx tsc --noEmit`
- `cd cf-proxy && npx vitest run test/render.test.ts`

/claim #92