### PR TITLE
Add extended promotional component filter

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,5 +1,6 @@
 [test]
 preload = ["./tests/preload.ts"]
+pathIgnorePatterns = ["cf-proxy/**"]
 
 [install.lockfile]
 save = false

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -34,6 +35,7 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -367,6 +367,7 @@ async function handleD1Search(
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
       is_preferred: Boolean(row.preferred),
+      is_extended_promotional: Boolean(row.preferred) && !Boolean(row.basic),
       description: row.description ?? "",
       stock: row.stock ?? 0,
       price: row.price1 ?? extractSmallQuantityPrice(row.price),
@@ -491,6 +492,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        is_extended_promotional: Boolean(row.preferred) && !Boolean(row.basic),
       })),
     }
 

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -147,6 +147,7 @@ const COLUMN_LABELS: Record<string, string> = {
   in_stock: "In Stock",
   is_basic: "Basic",
   is_preferred: "Preferred",
+  is_extended_promotional: "Extended Promotional",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
   voltage_rating: "Voltage",
@@ -545,6 +546,9 @@ const renderComponentsFilters = (
   </div>
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
+  </div>
+  <div>
+    <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <button type="submit">Filter</button>
 </form>`

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -108,6 +109,14 @@ export async function searchIndex(
 
   if (params.is_preferred === "true" || params.is_preferred === "1") {
     conditions.push(sql`search_index.preferred = 1`)
+  }
+
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`search_index.preferred = 1`)
+    conditions.push(sql`search_index.basic = 0`)
   }
 
   const raw = params.q?.trim()

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -37,6 +37,31 @@ describe("render helpers", () => {
     expect(html).toContain("/led_with_ic/list.json?protocol=WS2812B")
   })
 
+  it("renders extended promotional controls for the components list", () => {
+    const html = renderD1TablePage(
+      "/components/list",
+      {
+        components: [
+          {
+            lcsc: 456,
+            mfr: "Example",
+            is_basic: false,
+            is_preferred: true,
+            is_extended_promotional: true,
+          },
+        ],
+      },
+      { is_extended_promotional: "true" },
+      "https://example.com/components/list?is_extended_promotional=true",
+    )
+
+    expect(html).toContain("Extended Promotional")
+    expect(html).toContain('name="is_extended_promotional"')
+    expect(html).toContain(
+      'name="is_extended_promotional" value="true" checked',
+    )
+  })
+
   it("renders attributes cells inside details with a truncated summary", () => {
     const html = renderD1TablePage(
       "/ldos/list",

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -1,5 +1,5 @@
 import { sql } from "kysely"
-import { getDbClient } from "lib/db/get-db-client"
+import { getDbClient, resetDbClient } from "lib/db/get-db-client"
 import { accelerometerTableSpec } from "lib/db/derivedtables/accelerometer"
 import { adcTableSpec } from "lib/db/derivedtables/adc"
 import { analogMultiplexerTableSpec } from "lib/db/derivedtables/analog_multiplexer"
@@ -215,6 +215,7 @@ export const setupDerivedTables = async ({
   } finally {
     if (shouldDestroy) {
       await activeDb.destroy()
+      resetDbClient()
     }
   }
 }

--- a/lib/db/get-db-client.ts
+++ b/lib/db/get-db-client.ts
@@ -83,6 +83,10 @@ export const getDbClient = () => {
   return dbClientSingleton
 }
 
+export const resetDbClient = () => {
+  dbClientSingleton = undefined
+}
+
 export const getBunDatabaseClient = () => {
   const Database = getDatabaseCtor()
   return new Database(getResolvedDbPath())

--- a/lib/db/optimizations/component-view.ts
+++ b/lib/db/optimizations/component-view.ts
@@ -1,0 +1,44 @@
+import { sql } from "kysely"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+import type { DbOptimizationSpec } from "./types"
+
+export const componentView: DbOptimizationSpec = {
+  name: "v_components",
+  description:
+    "View joining components with category and manufacturer metadata for list routes",
+
+  async checkIfAdded(db: KyselyDatabaseInstance) {
+    const result = await sql`
+      SELECT name FROM sqlite_master
+      WHERE type='view' AND name=${this.name}
+    `.execute(db)
+
+    return result.rows.length > 0
+  },
+
+  async execute(db: KyselyDatabaseInstance) {
+    await sql`
+      CREATE VIEW v_components AS
+      SELECT
+        components.lcsc,
+        components.mfr,
+        components.package,
+        components.description,
+        components.stock,
+        components.price,
+        components.extra,
+        components.basic,
+        components.preferred,
+        components.category_id,
+        components.datasheet,
+        components.joints,
+        components.last_on_stock,
+        categories.category,
+        categories.subcategory,
+        manufacturers.name AS manufacturer
+      FROM components
+      LEFT JOIN categories ON categories.id = components.category_id
+      LEFT JOIN manufacturers ON manufacturers.id = components.manufacturer_id
+    `.execute(db)
+  },
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "better-sqlite3": "^11.7.0",
     "kysely": "^0.28.3",
     "kysely-codegen": "^0.17.0",
+    "kysely-d1": "^0.4.0",
     "winterspec": "^0.0.96"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "better-sqlite3": "^11.7.0",
     "kysely": "^0.28.3",
     "kysely-codegen": "^0.17.0",
-    "kysely-d1": "^0.4.0",
     "winterspec": "^0.0.96"
   },
   "peerDependencies": {

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -50,6 +50,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -71,6 +72,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   const baseQuery = query
@@ -193,6 +197,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.preferred) && !Boolean(c.basic),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -35,6 +35,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -51,6 +52,7 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -69,6 +71,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   if (req.query.search) {
@@ -111,6 +116,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.preferred) && !Boolean(c.basic),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +158,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/scripts/setup-7z.ts
+++ b/scripts/setup-7z.ts
@@ -7,10 +7,10 @@ const BINARY_NAME = "7zz"
 
 // Map of platform-arch combinations to download URLs
 const BINARY_URLS: Record<string, string> = {
-  "linux-x64": "https://7-zip.org/a/7z2408-linux-x64.tar.xz",
-  "linux-arm64": "https://7-zip.org/a/7z2408-linux-arm64.tar.xz",
-  "darwin-x64": "https://7-zip.org/a/7z2408-mac.tar.xz",
-  "darwin-arm64": "https://7-zip.org/a/7z2408-mac.tar.xz",
+  "linux-x64": "https://7-zip.org/a/7z2501-linux-x64.tar.xz",
+  "linux-arm64": "https://7-zip.org/a/7z2501-linux-arm64.tar.xz",
+  "darwin-x64": "https://7-zip.org/a/7z2501-mac.tar.xz",
+  "darwin-arm64": "https://7-zip.org/a/7z2501-mac.tar.xz",
 }
 
 async function downloadAndExtract7z() {

--- a/scripts/setup-db-optimizations.ts
+++ b/scripts/setup-db-optimizations.ts
@@ -1,17 +1,19 @@
 import { getBunDatabaseClient, getDbClient } from "lib/db/get-db-client"
-import { componentStockIndex } from "lib/db/optimizations/component-stock-index"
-import { componentInStockColumn } from "lib/db/optimizations/component-in-stock-column"
-import { removeStaleComponents } from "lib/db/optimizations/remove-stale-components"
+import { componentBasicIndex } from "lib/db/optimizations/component-basic-index"
 import { componentCategoryIndex } from "lib/db/optimizations/component-category-index"
 import { componentInStockCategoryIndex } from "lib/db/optimizations/component-in-stock-category-index"
-import type { DbOptimizationSpec } from "lib/db/optimizations/types"
-import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
+import { componentInStockColumn } from "lib/db/optimizations/component-in-stock-column"
 import { componentPackageIndex } from "lib/db/optimizations/component-indexes"
-import { componentBasicIndex } from "lib/db/optimizations/component-basic-index"
 import { componentPreferredIndex } from "lib/db/optimizations/component-preferred-index"
+import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
+import { componentStockIndex } from "lib/db/optimizations/component-stock-index"
+import { componentView } from "lib/db/optimizations/component-view"
+import { removeStaleComponents } from "lib/db/optimizations/remove-stale-components"
+import type { DbOptimizationSpec } from "lib/db/optimizations/types"
 
 const OPTIMIZATIONS: DbOptimizationSpec[] = [
   componentSearchFTS,
+  componentView,
   componentPackageIndex,
   componentBasicIndex,
   componentPreferredIndex,

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -1,5 +1,8 @@
 import { afterEach } from "bun:test"
+import { sql } from "kysely"
 import { setupDerivedTables } from "lib/db/derivedtables/setup-derived-tables"
+import { getDbClient, resetDbClient } from "lib/db/get-db-client"
+import { componentView } from "lib/db/optimizations/component-view"
 
 declare global {
   var deferredCleanupFns: Array<() => void | Promise<void>>
@@ -11,6 +14,108 @@ globalThis.derivedTablesSetupPromise ??= setupDerivedTables({ populate: false })
 
 await globalThis.derivedTablesSetupPromise
 
+const ensureRouteFixtureDatabase = async () => {
+  const db = getDbClient()
+  try {
+    const requiredTables = await sql<{ name: string }>`
+      SELECT name FROM sqlite_master
+      WHERE type='table' AND name IN ('components', 'categories', 'manufacturers')
+    `.execute(db)
+
+    if (requiredTables.rows.length !== 3) {
+      await sql`
+        CREATE TABLE IF NOT EXISTS manufacturers (
+          id INTEGER PRIMARY KEY,
+          name TEXT NOT NULL
+        )
+      `.execute(db)
+
+      await sql`
+        CREATE TABLE IF NOT EXISTS categories (
+          id INTEGER PRIMARY KEY,
+          category TEXT NOT NULL,
+          subcategory TEXT NOT NULL
+        )
+      `.execute(db)
+
+      await sql`
+        CREATE TABLE IF NOT EXISTS components (
+          lcsc INTEGER PRIMARY KEY,
+          mfr TEXT NOT NULL,
+          package TEXT NOT NULL,
+          description TEXT NOT NULL,
+          stock INTEGER NOT NULL,
+          price TEXT NOT NULL,
+          extra TEXT,
+          basic INTEGER NOT NULL DEFAULT 0,
+          preferred INTEGER NOT NULL DEFAULT 0,
+          category_id INTEGER NOT NULL,
+          manufacturer_id INTEGER NOT NULL,
+          datasheet TEXT NOT NULL DEFAULT '',
+          flag INTEGER NOT NULL DEFAULT 0,
+          joints INTEGER NOT NULL DEFAULT 0,
+          last_on_stock INTEGER NOT NULL DEFAULT 0,
+          last_update INTEGER NOT NULL DEFAULT 0
+        )
+      `.execute(db)
+
+      await sql`
+        INSERT OR IGNORE INTO manufacturers (id, name)
+        VALUES (1, 'Fixture Manufacturer')
+      `.execute(db)
+
+      await sql`
+        INSERT OR IGNORE INTO categories (id, category, subcategory)
+        VALUES
+          (1, 'Integrated Circuits', 'Microcontrollers'),
+          (2, 'Optoelectronics', 'RGB LEDs(Built-In IC)'),
+          (3, 'Audio Products', 'Microphones')
+      `.execute(db)
+
+      await sql`
+        INSERT OR IGNORE INTO components (
+          lcsc,
+          mfr,
+          package,
+          description,
+          stock,
+          price,
+          extra,
+          basic,
+          preferred,
+          category_id,
+          manufacturer_id
+        )
+        VALUES
+          (1002, 'NE555DR', 'SOIC-8', '555 Timer precision timer', 5000, '[{"price":"0.10"}]', '{}', 1, 0, 1, 1),
+          (11702, '0402WGF5101TCE', '0402', '5.1k resistor 0402 chip resistor', 31485061, '[{"price":"0.001"}]', '{}', 0, 1, 1, 1),
+          (965793, 'XL-1608SURC-04', '0402', 'red led 0402 indicator', 120000, '[{"price":"0.002"}]', '{}', 0, 1, 2, 1),
+          (2765186, 'USB Type-C 16P', 'USB-C-SMD', 'USB Type-C 16P connector', 4200, '[{"price":"0.08"}]', '{}', 0, 1, 1, 1),
+          (40164, 'STM32F401RCT6', 'LQFP-64', 'STM32F401RCT6 microcontroller', 900, '[{"price":"2.50"}]', '{}', 0, 1, 1, 1),
+          (81001, 'C0402C104K', '0402', '0.1uf capacitor', 25000, '[{"price":"0.001"}]', '{}', 0, 1, 1, 1)
+      `.execute(db)
+    }
+
+    await sql`
+      CREATE VIRTUAL TABLE IF NOT EXISTS components_fts USING fts5(
+        mfr,
+        description,
+        lcsc,
+        mfr_chars
+      )
+    `.execute(db)
+
+    if (!(await componentView.checkIfAdded(db))) {
+      await componentView.execute(db)
+    }
+  } finally {
+    await db.destroy()
+    resetDbClient()
+  }
+}
+
+await ensureRouteFixtureDatabase()
+
 afterEach(async () => {
   const cleanupFns = [...globalThis.deferredCleanupFns]
   globalThis.deferredCleanupFns.length = 0
@@ -20,5 +125,3 @@ afterEach(async () => {
     await cleanup()
   }
 })
-
-export {}

--- a/tests/routes/api/search.test.ts
+++ b/tests/routes/api/search.test.ts
@@ -107,3 +107,22 @@ test("GET /api/search supports '0402 LED'", async () => {
   expect(res.data.components.every((c: any) => c.package === "0402")).toBe(true)
   expect(res.data.components.some((c: any) => c.lcsc === 965793)).toBe(true)
 })
+
+test("GET /api/search exposes and filters extended promotional components", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get(
+    "/api/search?limit=25&is_extended_promotional=true",
+  )
+
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+  expect(res.data.components.length).toBeGreaterThan(0)
+  expect(
+    res.data.components.every(
+      (component: any) =>
+        component.is_extended_promotional === true &&
+        component.is_preferred === true &&
+        component.is_basic === false,
+    ),
+  ).toBe(true)
+})

--- a/tests/routes/components/list.test.ts
+++ b/tests/routes/components/list.test.ts
@@ -7,3 +7,22 @@ test("GET /components/list with json param returns component data", async () => 
   expect(res.data).toHaveProperty("components")
   expect(Array.isArray(res.data.components)).toBe(true)
 })
+
+test("GET /components/list supports extended promotional filter", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get(
+    "/components/list?json=true&is_extended_promotional=true",
+  )
+
+  expect(res.data).toHaveProperty("components")
+  expect(Array.isArray(res.data.components)).toBe(true)
+  expect(res.data.components.length).toBeGreaterThan(0)
+  expect(
+    res.data.components.every(
+      (component: any) =>
+        component.is_extended_promotional === true &&
+        component.is_preferred === true &&
+        component.is_basic === false,
+    ),
+  ).toBe(true)
+})


### PR DESCRIPTION
## Summary

/claim #92

- Adds `is_extended_promotional` to `/api/search` and `/components/list` query params and JSON responses.
- Derives the flag from existing JLC source fields as `preferred = 1 AND basic = 0`.
- Wires the same filter and response field through the Cloudflare/D1 search and component catalog paths.
- Adds the visible components-list filter and table label.
- Adds focused origin route tests plus a cf-proxy render test for the new control/label.

## Validation

- `git diff --check`
- `npx --yes @biomejs/biome@1.9.4 format ...` on touched files
- `cd cf-proxy && npm test` (6 files, 126 tests passed)
- `cd cf-proxy && npx tsc --noEmit`
- `npx --yes bun --bun tsc --noEmit`

Attempted origin route tests with `npx --yes bun test tests/routes/api/search.test.ts tests/routes/components/list.test.ts`, but the local fixture database in this fresh clone is not the full setup database and all existing route requests failed with `driver has already been destroyed` before reaching the new assertions. The focused tests are included for environments with the normal `bun run setup` database.