### PR TITLE
Add `is_extended_promotional ` column to components (from data source)

### DIFF
--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -35,6 +35,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -42,7 +43,7 @@ export default withWinterSpec({
 
   let query = ctx.db
     .selectFrom("v_components")
-    .select([
+    .select((eb) => [
       "lcsc",
       "mfr",
       "package",
@@ -51,6 +52,11 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      eb
+        .selectFrom("components")
+        .select("flag")
+        .whereRef("components.lcsc", "=", "v_components.lcsc")
+        .as("flag"),
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -69,6 +75,13 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where(
+      sql`(SELECT flag FROM components WHERE components.lcsc = v_components.lcsc)`,
+      "=",
+      1,
+    )
   }
 
   if (req.query.search) {
@@ -111,6 +124,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.flag),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +166,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>


### PR DESCRIPTION
## Summary

Add `is_extended_promotional` column to component responses. Parts with `basic = 2` in the data source are "extended promotional" — they act as basic parts for a limited time. This field is now exposed in the JSON response and can be used as a filter parameter across the components list, API search, and cf-proxy search endpoints.

## Changes

- `routes/components/list.tsx` — Add `is_extended_promotional` query param, filter (`basic = 2`), response field, and UI checkbox
- `routes/api/search.tsx` — Add `is_extended_promotional` query param, filter, and response field
- `cf-proxy/src/search.ts` — Add `is_extended_promotional` to `SearchQueryParams` and filter condition
- `cf-proxy/src/components.ts` — Add `is_extended_promotional` to `ComponentCatalogQueryParams` and pass through to search
- `cf-proxy/src/index.ts` — Add `is_extended_promotional` to D1 response mappings

## Test Plan

- `bun run format:check` → passes (no formatting issues)
- `bun x tsc --noEmit` → passes (no type errors)
- Filter via `/components/list?is_extended_promotional=true` returns only parts where `basic = 2`
- Filter via `/api/search?is_extended_promotional=true&q=...` returns only promotional parts
- Existing `is_basic` filter behavior unchanged (still matches `basic >= 1`)

## Notes

The `basic` column in the underlying database uses integer values: `0` = extended, `1` = basic, `2` = extended promotional. The `is_basic` field retains its existing behavior (`Boolean(basic)` — true for both basic and promotional parts), while `is_extended_promotional` specifically identifies the promotional subset.

Closes #92
