### PR TITLE
feat: add is_extended_promotional column to components list

### DIFF
--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -51,6 +51,7 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "is_extended_promotional",
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -114,6 +115,7 @@ export default withWinterSpec({
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
+    is_extended_promotional: Boolean(c.is_extended_promotional),
   }))
 
   if (ctx.isApiRequest) {


### PR DESCRIPTION
This PR adds the `is_extended_promotional` column to the components list by:
1. Updating the SQL search index rebuild script to extract the field from the `extra` JSON column.
2. Adding the field to the component selection query and the mapped result object in `routes/components/list.tsx`.
3. The generic `Table` component will automatically render this new column.

This allows users to identify extended promotional components directly in the search results.