### PR TITLE
feat: add is_extended_promotional column to components

### DIFF
--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -200,6 +200,7 @@ export interface Component {
   mfr: string;
   package: string;
   preferred: Generated<number>;
+  is_extended_promotional: Generated<number>;
   price: string;
   stock: number;
 }
@@ -809,6 +810,7 @@ export interface VComponent {
   mfr: string | null;
   package: string | null;
   preferred: number | null;
+  is_extended_promotional: number | null;
   price: string | null;
   stock: number | null;
   subcategory: string | null;

--- a/lib/db/optimizations/component-extended-promotional-column.ts
+++ b/lib/db/optimizations/component-extended-promotional-column.ts
@@ -1,0 +1,35 @@
+import { sql } from "kysely"
+import type { DbOptimizationSpec } from "./types"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+
+export const componentExtendedPromotionalColumn: DbOptimizationSpec = {
+  name: "add_components_extended_promotional_column",
+  description:
+    "Adds is_extended_promotional boolean column to components table derived from preferred = 1 AND basic = 0",
+
+  async checkIfAdded(db: KyselyDatabaseInstance) {
+    const {
+      rows: [ex],
+    } = await sql<any>`
+      SELECT * FROM components LIMIT 1
+    `.execute(db)
+
+    return "is_extended_promotional" in ex
+  },
+
+  async execute(db: KyselyDatabaseInstance) {
+    // Add the column
+    await sql`
+      ALTER TABLE components 
+      ADD COLUMN is_extended_promotional boolean 
+      GENERATED ALWAYS AS (preferred = 1 AND basic = 0)
+    `.execute(db)
+
+    // Create an index on the new column
+    await db.schema
+      .createIndex("idx_components_is_extended_promotional")
+      .on("components")
+      .column("is_extended_promotional")
+      .execute()
+  },
+}

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -50,6 +50,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -71,6 +72,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("is_extended_promotional", "=", 1)
   }
 
   const baseQuery = query
@@ -193,6 +197,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean((c as any).is_extended_promotional),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -35,6 +35,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -51,6 +52,8 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
+      "is_extended_promotional",
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -69,6 +72,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("is_extended_promotional", "=", 1)
   }
 
   if (req.query.search) {
@@ -111,6 +117,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.is_extended_promotional),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +159,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/scripts/setup-db-optimizations.ts
+++ b/scripts/setup-db-optimizations.ts
@@ -9,6 +9,7 @@ import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
 import { componentPackageIndex } from "lib/db/optimizations/component-indexes"
 import { componentBasicIndex } from "lib/db/optimizations/component-basic-index"
 import { componentPreferredIndex } from "lib/db/optimizations/component-preferred-index"
+import { componentExtendedPromotionalColumn } from "lib/db/optimizations/component-extended-promotional-column"
 
 const OPTIMIZATIONS: DbOptimizationSpec[] = [
   componentSearchFTS,
@@ -20,6 +21,7 @@ const OPTIMIZATIONS: DbOptimizationSpec[] = [
   componentInStockColumn,
   componentCategoryIndex,
   componentInStockCategoryIndex,
+  componentExtendedPromotionalColumn,
 ]
 
 async function main() {


### PR DESCRIPTION
## Summary

Adds the `is_extended_promotional` computed column to the components table as requested in #92.

### Changes:
- **DB Optimization**: Added `component-extended-promotional-column.ts` that creates a computed column (`preferred = 1 AND basic = 0`) with an index for query performance
- **Type Definitions**: Updated `kysely.ts` to include `is_extended_promotional` in Component and VComponent interfaces
- **API Search**: Added `is_extended_promotional` filter parameter and response field to `/api/search`
- **Components List**: Added `is_extended_promotional` filter parameter, response field, and UI checkbox to `/components/list`
- **Setup Script**: Registered the optimization in `setup-db-optimizations.ts`

### Logic:
- `is_extended_promotional` = `preferred = 1 AND basic = 0`
- Filterable via `?is_extended_promotional=true` on both endpoints
- Exposed in JSON response as boolean

/claim #92

ETH: `0x911d202f713Ee2ad139E8b8b8a0A712347eFE31f`