### PR TITLE
add is_extended_promotional field to components endpoints

### DIFF
--- a/lib/db/derivedtables/component-base.ts
+++ b/lib/db/derivedtables/component-base.ts
@@ -7,5 +7,6 @@ export interface BaseComponent {
   in_stock: boolean
   is_basic: boolean
   is_preferred: boolean
+  is_extended_promotional?: boolean
   attributes: Record<string, string>
 }

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -50,6 +50,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -71,6 +72,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   const baseQuery = query
@@ -193,6 +197,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.preferred) && !Boolean(c.basic),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -35,6 +35,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -51,6 +52,7 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -69,6 +71,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1).where("basic", "=", 0)
   }
 
   if (req.query.search) {
@@ -111,6 +116,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.preferred) && !Boolean(c.basic),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +158,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/tests/routes/api/search.test.ts
+++ b/tests/routes/api/search.test.ts
@@ -120,7 +120,9 @@ test("GET /api/search response includes is_extended_promotional field", async ()
 
 test("GET /api/search with is_extended_promotional filter returns only promotional components", async () => {
   const { axios } = await getTestServer()
-  const res = await axios.get("/api/search?is_extended_promotional=true&limit=100")
+  const res = await axios.get(
+    "/api/search?is_extended_promotional=true&limit=100",
+  )
 
   expect(res.data).toHaveProperty("components")
   for (const c of res.data.components) {

--- a/tests/routes/api/search.test.ts
+++ b/tests/routes/api/search.test.ts
@@ -107,3 +107,24 @@ test("GET /api/search supports '0402 LED'", async () => {
   expect(res.data.components.every((c: any) => c.package === "0402")).toBe(true)
   expect(res.data.components.some((c: any) => c.lcsc === 965793)).toBe(true)
 })
+
+test("GET /api/search response includes is_extended_promotional field", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/api/search?q=STM32F401RCT6")
+
+  expect(res.data).toHaveProperty("components")
+  expect(res.data.components.length).toBeGreaterThan(0)
+  expect(res.data.components[0]).toHaveProperty("is_extended_promotional")
+  expect(typeof res.data.components[0].is_extended_promotional).toBe("boolean")
+})
+
+test("GET /api/search with is_extended_promotional filter returns only promotional components", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/api/search?is_extended_promotional=true&limit=100")
+
+  expect(res.data).toHaveProperty("components")
+  for (const c of res.data.components) {
+    expect(c.is_extended_promotional).toBe(true)
+    expect(c.is_basic).toBe(false)
+  }
+})

--- a/tests/routes/components/list.test.ts
+++ b/tests/routes/components/list.test.ts
@@ -20,7 +20,9 @@ test("GET /components/list response includes is_extended_promotional field", asy
 
 test("GET /components/list with is_extended_promotional filter returns only promotional components", async () => {
   const { axios } = await getTestServer()
-  const res = await axios.get("/components/list?json=true&is_extended_promotional=true")
+  const res = await axios.get(
+    "/components/list?json=true&is_extended_promotional=true",
+  )
 
   expect(res.data).toHaveProperty("components")
   for (const c of res.data.components) {

--- a/tests/routes/components/list.test.ts
+++ b/tests/routes/components/list.test.ts
@@ -7,3 +7,24 @@ test("GET /components/list with json param returns component data", async () => 
   expect(res.data).toHaveProperty("components")
   expect(Array.isArray(res.data.components)).toBe(true)
 })
+
+test("GET /components/list response includes is_extended_promotional field", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/components/list?json=true")
+
+  expect(res.data).toHaveProperty("components")
+  expect(res.data.components.length).toBeGreaterThan(0)
+  expect(res.data.components[0]).toHaveProperty("is_extended_promotional")
+  expect(typeof res.data.components[0].is_extended_promotional).toBe("boolean")
+})
+
+test("GET /components/list with is_extended_promotional filter returns only promotional components", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/components/list?json=true&is_extended_promotional=true")
+
+  expect(res.data).toHaveProperty("components")
+  for (const c of res.data.components) {
+    expect(c.is_extended_promotional).toBe(true)
+    expect(c.is_basic).toBe(false)
+  }
+})


### PR DESCRIPTION
## Summary

Adds `is_extended_promotional` to the `/components/list` and `/api/search` endpoints. A component is "extended promotional" when it is a preferred part (`preferred = 1`) but not a basic part (`basic = 0`), meaning JLCPCB is temporarily waiving the extended part fee for it.

## Changes

- `routes/components/list.tsx`: add `is_extended_promotional` query param, filter, and response field; add checkbox to the HTML UI; fix pre-existing bug where `preferred` column was missing from SELECT (making `is_preferred` always `false`)
- `routes/api/search.tsx`: same query param, filter, and response field
- `lib/db/derivedtables/component-base.ts`: add optional `is_extended_promotional?` to `BaseComponent`
- Tests for field presence and filter behavior in both endpoints

/claim #92
