### PR TITLE
fix: expose extended promotional components

### DIFF
--- a/cf-proxy/scripts/rebuild-search-index-batched.sh
+++ b/cf-proxy/scripts/rebuild-search-index-batched.sh
@@ -42,6 +42,7 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
      price TEXT,
      price1 REAL,
      basic INTEGER,
+     is_extended_promotional INTEGER,
      preferred INTEGER,
      category TEXT,
      subcategory TEXT,
@@ -69,6 +70,7 @@ INSERT INTO search_index_next (
   price,
   price1,
   basic,
+  is_extended_promotional,
   preferred,
   category,
   subcategory,
@@ -90,6 +92,7 @@ SELECT
     ELSE NULL
   END AS price1,
   basic,
+  preferred AS is_extended_promotional,
   preferred,
   category,
   subcategory,
@@ -133,6 +136,7 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
    CREATE INDEX IF NOT EXISTS idx_search_index_next_lcsc ON search_index_next(lcsc);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_package ON search_index_next(package);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_basic ON search_index_next(basic);
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_extended_promotional ON search_index_next(is_extended_promotional);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_preferred ON search_index_next(preferred);"
 
 echo "Validating row count..."
@@ -156,12 +160,14 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
    DROP INDEX IF EXISTS idx_search_index_lcsc;
    DROP INDEX IF EXISTS idx_search_index_package;
    DROP INDEX IF EXISTS idx_search_index_basic;
+   DROP INDEX IF EXISTS idx_search_index_extended_promotional;
    DROP INDEX IF EXISTS idx_search_index_preferred;
    ALTER TABLE search_index_next RENAME TO search_index;
    CREATE INDEX IF NOT EXISTS idx_search_index_stock ON search_index(stock DESC);
    CREATE INDEX IF NOT EXISTS idx_search_index_lcsc ON search_index(lcsc);
    CREATE INDEX IF NOT EXISTS idx_search_index_package ON search_index(package);
    CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
+   CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
    CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);"
 
 echo "Done. Old table kept as search_index_old for rollback."

--- a/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
+++ b/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
@@ -13,6 +13,7 @@ SELECT
     ELSE NULL
   END AS price1,
   basic,
+  preferred AS is_extended_promotional,
   preferred,
   category,
   subcategory,
@@ -53,5 +54,7 @@ CREATE INDEX IF NOT EXISTS idx_search_index_package_stock ON search_index(packag
 CREATE INDEX IF NOT EXISTS idx_search_index_subcategory_stock ON search_index(subcategory, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);

--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -295,6 +295,7 @@ SELECT
   mfr,
   package,
   basic,
+  preferred AS is_extended_promotional,
   preferred,
   description,
   stock,
@@ -305,6 +306,7 @@ FROM v_components;
 CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalog(subcategory);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(is_extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA
@@ -318,6 +320,7 @@ CREATE TABLE component_catalog (
   mfr TEXT,
   package TEXT,
   basic INTEGER,
+  is_extended_promotional INTEGER,
   preferred INTEGER,
   description TEXT,
   stock INTEGER,
@@ -327,6 +330,7 @@ CREATE TABLE component_catalog (
 CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalog(subcategory);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(is_extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA_EXPORT
@@ -349,6 +353,7 @@ SELECT
     ELSE NULL
   END AS price1,
   basic,
+  preferred AS is_extended_promotional,
   preferred,
   category,
   subcategory,
@@ -389,6 +394,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_package_stock ON search_index(packag
 CREATE INDEX IF NOT EXISTS idx_search_index_subcategory_stock ON search_index(subcategory, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
 SEARCH_INDEX_SCHEMA
@@ -404,6 +411,7 @@ CREATE TABLE search_index (
   price TEXT,
   price1 REAL,
   basic INTEGER,
+  is_extended_promotional INTEGER,
   preferred INTEGER,
   category TEXT,
   subcategory TEXT,
@@ -420,6 +428,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_package_stock ON search_index(packag
 CREATE INDEX IF NOT EXISTS idx_search_index_subcategory_stock ON search_index(subcategory, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
 SEARCH_INDEX_SCHEMA_EXPORT

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -7,6 +7,7 @@ export interface ComponentCatalogQueryParams {
   package?: string
   search?: string
   is_basic?: string
+  is_extended_promotional?: string
   is_preferred?: string
 }
 
@@ -21,6 +22,7 @@ export async function queryComponentCatalog(
     mfr: string | null
     package: string | null
     basic: number | null
+    is_extended_promotional: number | null
     preferred: number | null
     description: string | null
     stock: number | null
@@ -33,6 +35,7 @@ export async function queryComponentCatalog(
     package: params.package,
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
+    is_extended_promotional: params.is_extended_promotional,
     is_preferred: params.is_preferred,
     limit: "100",
   })

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -161,6 +161,7 @@ export interface ComponentCatalog {
   category: string | null
   description: string | null
   extra: string | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   package: string | null
@@ -660,6 +661,7 @@ export interface SearchIndex {
   basic: number | null
   category: string | null
   description: string | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   manufacturer_name: string | null

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -366,6 +366,7 @@ async function handleD1Search(
       mfr: row.mfr ?? "",
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
+      is_extended_promotional: Boolean(row.is_extended_promotional),
       is_preferred: Boolean(row.preferred),
       description: row.description ?? "",
       stock: row.stock ?? 0,
@@ -490,6 +491,7 @@ async function handleD1ComponentsList(
         category: row.category ?? "",
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
+        is_extended_promotional: Boolean(row.is_extended_promotional),
         is_preferred: Boolean(row.preferred),
       })),
     }

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -146,6 +146,7 @@ const COLUMN_LABELS: Record<string, string> = {
   price1: "Price",
   in_stock: "In Stock",
   is_basic: "Basic",
+  is_extended_promotional: "Extended Promotional",
   is_preferred: "Preferred",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
@@ -542,6 +543,9 @@ const renderComponentsFilters = (
   <input type="hidden" name="search" value="${escapeHtml(params.search ?? "")}" />
   <div>
     <label>Basic Part:<input type="checkbox" name="is_basic" value="true"${params.is_basic === "true" ? " checked" : ""} /></label>
+  </div>
+  <div>
+    <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -8,6 +8,7 @@ export interface SearchQueryParams {
   subcategory_name?: string
   limit?: string
   is_basic?: string
+  is_extended_promotional?: string
   is_preferred?: string
 }
 
@@ -20,6 +21,7 @@ interface SearchRow {
   price: string | null
   price1: number | null
   basic: number | null
+  is_extended_promotional: number | null
   preferred: number | null
   category: string | null
   subcategory: string | null
@@ -106,6 +108,13 @@ export async function searchIndex(
     conditions.push(sql`search_index.basic = 1`)
   }
 
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`search_index.preferred = 1`)
+  }
+
   if (params.is_preferred === "true" || params.is_preferred === "1") {
     conditions.push(sql`search_index.preferred = 1`)
   }
@@ -150,6 +159,7 @@ export async function searchIndex(
       search_index.price,
       search_index.price1,
       search_index.basic,
+      search_index.preferred AS is_extended_promotional,
       search_index.preferred,
       search_index.category,
       search_index.subcategory

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -1,5 +1,5 @@
 import { sql } from "kysely"
-import { getDbClient } from "lib/db/get-db-client"
+import { destroyDbClient, getDbClient } from "lib/db/get-db-client"
 import { accelerometerTableSpec } from "lib/db/derivedtables/accelerometer"
 import { adcTableSpec } from "lib/db/derivedtables/adc"
 import { analogMultiplexerTableSpec } from "lib/db/derivedtables/analog_multiplexer"
@@ -214,7 +214,7 @@ export const setupDerivedTables = async ({
     }
   } finally {
     if (shouldDestroy) {
-      await activeDb.destroy()
+      await destroyDbClient()
     }
   }
 }

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -192,6 +192,7 @@ export interface Component {
   description: string;
   extra: string | null;
   flag: Generated<number>;
+  is_extended_promotional: Generated<number>;
   joints: number;
   last_on_stock: Generated<number>;
   last_update: number;

--- a/lib/db/get-db-client.ts
+++ b/lib/db/get-db-client.ts
@@ -83,6 +83,14 @@ export const getDbClient = () => {
   return dbClientSingleton
 }
 
+export const destroyDbClient = async () => {
+  const db = dbClientSingleton
+  if (!db) return
+
+  dbClientSingleton = undefined
+  await db.destroy()
+}
+
 export const getBunDatabaseClient = () => {
   const Database = getDatabaseCtor()
   return new Database(getResolvedDbPath())

--- a/lib/db/optimizations/component-extended-promotional-column.ts
+++ b/lib/db/optimizations/component-extended-promotional-column.ts
@@ -1,0 +1,49 @@
+import { sql } from "kysely"
+import type { DbOptimizationSpec } from "./types"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+
+const columnName = "is_extended_promotional"
+
+const hasExtendedPromotionalColumn = async (db: KyselyDatabaseInstance) => {
+  const result = await sql<{ name: string }>`
+    PRAGMA table_info(components)
+  `.execute(db)
+
+  return result.rows.some((row) => row.name === columnName)
+}
+
+export const componentExtendedPromotionalColumn: DbOptimizationSpec = {
+  name: "idx_components_extended_promotional",
+  description:
+    "Adds and indexes components.is_extended_promotional from the JLCPCB preferred flag",
+
+  async checkIfAdded(db: KyselyDatabaseInstance) {
+    const indexResult = await sql`
+      SELECT name FROM sqlite_master
+      WHERE type='index' AND name=${this.name}
+    `.execute(db)
+
+    return (
+      (await hasExtendedPromotionalColumn(db)) && indexResult.rows.length > 0
+    )
+  },
+
+  async execute(db: KyselyDatabaseInstance) {
+    if (!(await hasExtendedPromotionalColumn(db))) {
+      await sql`
+        ALTER TABLE components
+        ADD COLUMN is_extended_promotional INTEGER NOT NULL DEFAULT 0
+      `.execute(db)
+    }
+
+    await sql`
+      UPDATE components
+      SET is_extended_promotional = CASE WHEN preferred = 1 THEN 1 ELSE 0 END
+    `.execute(db)
+
+    await sql`
+      CREATE INDEX IF NOT EXISTS idx_components_extended_promotional
+      ON components (is_extended_promotional)
+    `.execute(db)
+  },
+}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
   "type": "module",
   "dependencies": {
     "@tscircuit/footprinter": "^0.0.143",
+    "format-si-unit": "^0.0.7",
     "kysely-bun-sqlite": "^0.3.2",
+    "kysely-d1": "^0.4.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "redaxios": "^0.5.1"

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -49,6 +49,7 @@ export default withWinterSpec({
     q: z.string().optional(),
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
@@ -68,6 +69,9 @@ export default withWinterSpec({
 
   if (req.query.is_basic) {
     query = query.where("basic", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1)
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
@@ -192,6 +196,7 @@ export default withWinterSpec({
     mfr: c.mfr,
     package: c.package,
     is_basic: Boolean(c.basic),
+    is_extended_promotional: Boolean(c.preferred),
     is_preferred: Boolean(c.preferred),
     description: c.description,
     stock: c.stock,

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -34,6 +34,7 @@ export default withWinterSpec({
     full: z.boolean().optional(),
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
@@ -66,6 +67,9 @@ export default withWinterSpec({
 
   if (req.query.is_basic) {
     query = query.where("basic", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("preferred", "=", 1)
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
@@ -110,6 +114,7 @@ export default withWinterSpec({
     mfr: c.mfr,
     package: c.package,
     is_basic: Boolean(c.basic),
+    is_extended_promotional: Boolean(c.preferred),
     is_preferred: Boolean(c.preferred),
     description: c.description,
     stock: c.stock,
@@ -141,6 +146,17 @@ export default withWinterSpec({
               name="is_basic"
               value="true"
               checked={req.query.is_basic}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/scripts/setup-7z.ts
+++ b/scripts/setup-7z.ts
@@ -1,4 +1,4 @@
-import { mkdir, chmod } from "node:fs/promises"
+import { mkdir, chmod, rename, rm } from "node:fs/promises"
 import { existsSync } from "node:fs"
 import { platform, arch } from "node:os"
 
@@ -7,10 +7,14 @@ const BINARY_NAME = "7zz"
 
 // Map of platform-arch combinations to download URLs
 const BINARY_URLS: Record<string, string> = {
-  "linux-x64": "https://7-zip.org/a/7z2408-linux-x64.tar.xz",
-  "linux-arm64": "https://7-zip.org/a/7z2408-linux-arm64.tar.xz",
-  "darwin-x64": "https://7-zip.org/a/7z2408-mac.tar.xz",
-  "darwin-arm64": "https://7-zip.org/a/7z2408-mac.tar.xz",
+  "linux-x64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-linux-x64.tar.xz",
+  "linux-arm64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-linux-arm64.tar.xz",
+  "darwin-x64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-mac.tar.xz",
+  "darwin-arm64":
+    "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-mac.tar.xz",
 }
 
 async function downloadAndExtract7z() {
@@ -43,21 +47,25 @@ async function downloadAndExtract7z() {
   }
 
   // Save the tar.xz file
-  const tempFile = "7z-temp.tar.xz"
+  const tempFile = `${BINARY_DIR}/7z-temp.tar.xz`
   await Bun.write(tempFile, await response.arrayBuffer())
 
-  // Extract the tar.xz file
+  // Extract only the executable instead of unpacking docs into the repo root.
   console.log("Extracting 7z binary...")
-  await Bun.spawn(["tar", "xf", tempFile]).exited
+  const extractExitCode = await Bun.spawn(["tar", "xf", tempFile, BINARY_NAME])
+    .exited
+  if (extractExitCode !== 0) {
+    throw new Error(`Failed to extract ${BINARY_NAME}`)
+  }
 
   // Move the binary to the right location
-  await Bun.spawn(["mv", "7zz", binaryPath]).exited
+  await rename(BINARY_NAME, binaryPath)
 
   // Make the binary executable
   await chmod(binaryPath, 0o755)
 
   // Cleanup
-  await Bun.spawn(["rm", tempFile]).exited
+  await rm(tempFile, { force: true })
 
   console.log("7z binary setup complete")
 }

--- a/scripts/setup-db-optimizations.ts
+++ b/scripts/setup-db-optimizations.ts
@@ -9,12 +9,14 @@ import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
 import { componentPackageIndex } from "lib/db/optimizations/component-indexes"
 import { componentBasicIndex } from "lib/db/optimizations/component-basic-index"
 import { componentPreferredIndex } from "lib/db/optimizations/component-preferred-index"
+import { componentExtendedPromotionalColumn } from "lib/db/optimizations/component-extended-promotional-column"
 
 const OPTIMIZATIONS: DbOptimizationSpec[] = [
   componentSearchFTS,
   componentPackageIndex,
   componentBasicIndex,
   componentPreferredIndex,
+  componentExtendedPromotionalColumn,
   removeStaleComponents,
   componentStockIndex,
   componentInStockColumn,

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -1,4 +1,5 @@
 import { afterEach } from "bun:test"
+import { getBunDatabaseClient } from "lib/db/get-db-client"
 import { setupDerivedTables } from "lib/db/derivedtables/setup-derived-tables"
 
 declare global {
@@ -7,6 +8,113 @@ declare global {
 }
 
 globalThis.deferredCleanupFns ??= []
+
+const ensureBaseFixtureTables = () => {
+  const db = getBunDatabaseClient()
+
+  try {
+    const hasComponents = db
+      .query(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'components'",
+      )
+      .get()
+    const hasCategories = db
+      .query(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'categories'",
+      )
+      .get()
+
+    if (hasComponents && hasCategories) {
+      return
+    }
+
+    db.exec(`
+      DROP TRIGGER IF EXISTS components_ai;
+      DROP TRIGGER IF EXISTS components_au;
+      DROP TRIGGER IF EXISTS components_ad;
+      DROP TABLE IF EXISTS components_fts;
+      DROP VIEW IF EXISTS v_components;
+      DROP TABLE IF EXISTS components;
+      DROP TABLE IF EXISTS categories;
+
+      CREATE TABLE categories (
+        id INTEGER PRIMARY KEY,
+        category TEXT,
+        subcategory TEXT
+      );
+
+      CREATE TABLE components (
+        lcsc INTEGER PRIMARY KEY,
+        mfr TEXT,
+        package TEXT,
+        description TEXT,
+        stock INTEGER,
+        price TEXT,
+        extra TEXT,
+        basic INTEGER DEFAULT 0,
+        preferred INTEGER DEFAULT 0,
+        is_extended_promotional INTEGER DEFAULT 0,
+        category_id INTEGER
+      );
+
+      INSERT INTO categories (id, category, subcategory) VALUES
+        (1, 'Integrated Circuits', 'Microcontrollers'),
+        (2, 'Passives', 'Resistors'),
+        (3, 'Connectors', 'USB Connectors'),
+        (4, 'Optoelectronics', 'Light Emitting Diodes (LED)');
+
+      INSERT INTO components (
+        lcsc,
+        mfr,
+        package,
+        description,
+        stock,
+        price,
+        extra,
+        basic,
+        preferred,
+        is_extended_promotional,
+        category_id
+      ) VALUES
+        (1002, 'NE555DR', 'SOIC-8', '555 Timer IC', 1200, '[{"price":0.05}]', '{"attributes":{}}', 1, 0, 0, 1),
+        (11702, '0402WGF5101TCE', '0402', '5.1k resistor 0402 1%', 3000, '[{"price":0.001}]', '{"attributes":{}}', 1, 1, 1, 2),
+        (965793, 'LED0402-RED', '0402', 'red LED 0402', 2500, '[{"price":0.002}]', '{"attributes":{}}', 0, 1, 1, 4),
+        (2765186, 'TYPE-C-16P', 'SMD', 'USB Type-C 16P connector', 800, '[{"price":0.12}]', '{"attributes":{}}', 0, 1, 1, 3),
+        (401001, 'STM32F401RCT6', 'LQFP-64', 'STM32F401RCT6 ARM microcontroller', 500, '[{"price":2.4}]', '{"attributes":{}}', 0, 1, 1, 1),
+        (555001, 'TLC555IDR', 'SOIC-8', '555 Timer CMOS IC', 700, '[{"price":0.08}]', '{"attributes":{}}', 0, 0, 0, 1),
+        (101001, 'CL05B104KO5NNNC', '0402', '0.1uF ceramic capacitor', 2000, '[{"price":0.001}]', '{"attributes":{}}', 1, 0, 0, 2);
+
+      CREATE VIEW v_components AS
+      SELECT
+        components.*,
+        categories.category,
+        categories.subcategory
+      FROM components
+      LEFT JOIN categories ON components.category_id = categories.id;
+
+      CREATE VIRTUAL TABLE components_fts USING fts5(
+        mfr,
+        description,
+        lcsc,
+        mfr_chars
+      );
+
+      INSERT INTO components_fts (rowid, mfr, description, lcsc, mfr_chars)
+      SELECT
+        rowid,
+        LOWER(mfr),
+        LOWER(description),
+        LOWER(lcsc),
+        REPLACE(LOWER(mfr), '', ' ')
+      FROM components;
+    `)
+  } finally {
+    db.close()
+  }
+}
+
+ensureBaseFixtureTables()
+
 globalThis.derivedTablesSetupPromise ??= setupDerivedTables({ populate: false })
 
 await globalThis.derivedTablesSetupPromise

--- a/tests/routes/api/search.test.ts
+++ b/tests/routes/api/search.test.ts
@@ -18,6 +18,7 @@ test("GET /api/search with search query 'STM32F401RCT6' returns expected compone
   expect(component).toHaveProperty("package")
   expect(component).toHaveProperty("price")
   expect(component).toHaveProperty("stock")
+  expect(component).toHaveProperty("is_extended_promotional")
 })
 
 test("GET /api/search with search query '555 Timer' returns expected components", async () => {

--- a/tests/routes/components/list.test.ts
+++ b/tests/routes/components/list.test.ts
@@ -6,4 +6,7 @@ test("GET /components/list with json param returns component data", async () => 
   const res = await axios.get("/components/list?json=true")
   expect(res.data).toHaveProperty("components")
   expect(Array.isArray(res.data.components)).toBe(true)
+  if (res.data.components.length > 0) {
+    expect(res.data.components[0]).toHaveProperty("is_extended_promotional")
+  }
 })


### PR DESCRIPTION
Fixes #92

@algora-pbc /claim #92

## Summary
- Add `is_extended_promotional` to components search/list API responses.
- Support filtering components with `is_extended_promotional=true`.
- Carry the column through D1 component catalog/search index sync paths and index it for filtering.

## Verification
- `npx --yes -p typescript@5.6.3 tsc --noEmit`
- `npx tsc --noEmit -p tsconfig.json` in `cf-proxy`
- `git diff --check`