### PR TITLE
feat: add IMU category route

### DIFF
--- a/cf-proxy/src/d1-routes.ts
+++ b/cf-proxy/src/d1-routes.ts
@@ -1,13 +1,13 @@
 import type { Kysely } from "kysely"
 import type { DB } from "./db/types"
 import {
-  queryFilterOptions,
-  queryTable,
+  type FilterOptions,
+  type QueryParams,
   ROUTE_TO_TABLE,
   TABLE_CONFIGS,
   TABLE_RESPONSE_KEY,
-  type FilterOptions,
-  type QueryParams,
+  queryFilterOptions,
+  queryTable,
 } from "./handlers"
 
 export interface D1QueryResult {
@@ -19,6 +19,7 @@ export interface D1QueryResult {
 type D1Handler = (db: Kysely<DB>, params: QueryParams) => Promise<D1QueryResult>
 
 const PROCESSOR_INTERFACES = ["uart", "i2c", "spi", "can", "usb"] as const
+const SENSOR_INTERFACES = ["spi", "i2c", "uart"] as const
 const MICROPHONE_SUBCATEGORIES = ["Microphones", "MEMS Microphones"] as const
 
 const parseFiniteNumber = (value: string | undefined): number | null => {
@@ -41,6 +42,40 @@ const getNonEmptyStrings = (
   rows: Array<Record<string, string | null>>,
   key: string,
 ): string[] => rows.map((row) => row[key]?.trim() ?? "").filter(Boolean)
+
+const applySensorInterfaceFilter = <T>(
+  query: T,
+  interfaceName: string | undefined,
+): T => {
+  switch (interfaceName) {
+    case "spi":
+      return (query as any).where("has_spi", "=", 1)
+    case "i2c":
+      return (query as any).where("has_i2c", "=", 1)
+    case "uart":
+      return (query as any).where("has_uart", "=", 1)
+    default:
+      return query
+  }
+}
+
+const normalizeImuRow = (
+  type: "accelerometer" | "gyroscope",
+  row: Record<string, any>,
+) => ({
+  type,
+  lcsc: row.lcsc ?? 0,
+  mfr: row.mfr ?? "",
+  package: row.package ?? "",
+  supply_voltage_min: row.supply_voltage_min ?? 0,
+  supply_voltage_max: row.supply_voltage_max ?? 0,
+  axes: row.axes ?? "",
+  has_i2c: Boolean(row.has_i2c),
+  has_spi: Boolean(row.has_spi),
+  has_uart: Boolean(row.has_uart),
+  stock: row.stock ?? 0,
+  price1: row.price1 ?? 0,
+})
 
 const getMicrocontrollerListHandler = (
   tableName: "arm_processor" | "risc_v_processor",
@@ -220,6 +255,88 @@ const SPECIAL_D1_HANDLERS: Record<string, D1Handler> = {
     "risc_v_processors",
     "RISC-V",
   ),
+  "/imus/list": async (db, params) => {
+    let accelerometerQuery = db
+      .selectFrom("accelerometer")
+      .selectAll()
+      .limit(100)
+      .orderBy("stock", "desc")
+    let gyroscopeQuery = db
+      .selectFrom("gyroscope")
+      .selectAll()
+      .limit(100)
+      .orderBy("stock", "desc")
+
+    if (params.package) {
+      accelerometerQuery = accelerometerQuery.where(
+        "package",
+        "=",
+        params.package,
+      )
+      gyroscopeQuery = gyroscopeQuery.where("package", "=", params.package)
+    }
+
+    accelerometerQuery = applySensorInterfaceFilter(
+      accelerometerQuery,
+      params.interface,
+    )
+    gyroscopeQuery = applySensorInterfaceFilter(
+      gyroscopeQuery,
+      params.interface,
+    )
+
+    const [
+      accelerometerPackages,
+      gyroscopePackages,
+      accelerometers,
+      gyroscopes,
+    ] = await Promise.all([
+      db
+        .selectFrom("accelerometer")
+        .select("package")
+        .distinct()
+        .where("package", "is not", null)
+        .orderBy("package")
+        .execute(),
+      db
+        .selectFrom("gyroscope")
+        .select("package")
+        .distinct()
+        .where("package", "is not", null)
+        .orderBy("package")
+        .execute(),
+      accelerometerQuery.execute(),
+      gyroscopeQuery.execute(),
+    ])
+
+    const imus = [
+      ...accelerometers.map((row) => normalizeImuRow("accelerometer", row)),
+      ...gyroscopes.map((row) => normalizeImuRow("gyroscope", row)),
+    ]
+      .filter((row) => row.lcsc !== 0 && row.package !== "")
+      .sort((a, b) => b.stock - a.stock)
+      .slice(0, 100)
+
+    return {
+      tableName: "imu",
+      filterOptions: {
+        package: Array.from(
+          new Set([
+            ...getNonEmptyStrings(
+              accelerometerPackages as Array<Record<string, string | null>>,
+              "package",
+            ),
+            ...getNonEmptyStrings(
+              gyroscopePackages as Array<Record<string, string | null>>,
+              "package",
+            ),
+          ]),
+        ).sort(),
+        interface: [...SENSOR_INTERFACES],
+      },
+      data: { imus },
+    }
+  },
   "/microphones/list": async (db, params) => {
     let query = db
       .selectFrom("component_catalog")
@@ -369,7 +486,7 @@ export function getD1Handler(pathname: string): D1Handler | null {
   if (!config) {
     return async (db, params) => {
       const results = await queryTable(db, tableName, params, { filters: {} })
-      const responseKey = TABLE_RESPONSE_KEY[tableName] || tableName + "s"
+      const responseKey = TABLE_RESPONSE_KEY[tableName] || `${tableName}s`
       return {
         data: { [responseKey]: results },
         tableName,
@@ -380,7 +497,7 @@ export function getD1Handler(pathname: string): D1Handler | null {
   return async (db, params) => {
     const results = await queryTable(db, tableName, params, config)
     const filterOptions = await queryFilterOptions(db, tableName, config)
-    const responseKey = TABLE_RESPONSE_KEY[tableName] || tableName + "s"
+    const responseKey = TABLE_RESPONSE_KEY[tableName] || `${tableName}s`
     return {
       data: { [responseKey]: results },
       tableName,

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -1,9 +1,9 @@
 import {
+  type FilterOptions,
+  type QueryParams,
   ROUTE_TO_TABLE,
   TABLE_CONFIGS,
   TABLE_RESPONSE_KEY,
-  type QueryParams,
-  type FilterOptions,
 } from "./handlers"
 
 const escapeHtml = (value: unknown): string =>
@@ -33,6 +33,7 @@ const routeLabels: Record<string, string> = {
   "/analog_multiplexers/list": "Analog Muxes",
   "/analog_switches/list": "Analog Switches",
   "/io_expanders/list": "I/O Expanders",
+  "/imus/list": "IMUs",
   "/gyroscopes/list": "Gyroscopes",
   "/accelerometers/list": "Accelerometers",
   "/gas_sensors/list": "Gas Sensors",

--- a/routes/imus/list.json.tsx
+++ b/routes/imus/list.json.tsx
@@ -1,0 +1,2 @@
+import list from "./list"
+export default list

--- a/routes/imus/list.tsx
+++ b/routes/imus/list.tsx
@@ -1,0 +1,186 @@
+import { Table } from "lib/ui/Table"
+import { formatPrice } from "lib/util/format-price"
+import { withWinterSpec } from "lib/with-winter-spec"
+import { z } from "zod"
+
+const INTERFACE_OPTIONS = ["spi", "i2c", "uart", ""] as const
+
+type SensorKind = "accelerometer" | "gyroscope"
+
+const applyInterfaceFilter = <T,>(
+  query: T,
+  interfaceName: (typeof INTERFACE_OPTIONS)[number] | undefined,
+): T => {
+  if (!interfaceName) return query
+
+  switch (interfaceName) {
+    case "spi":
+      return (query as any).where("has_spi", "=", 1)
+    case "i2c":
+      return (query as any).where("has_i2c", "=", 1)
+    case "uart":
+      return (query as any).where("has_uart", "=", 1)
+    default:
+      return query
+  }
+}
+
+const normalizeImu = (kind: SensorKind, sensor: any) => ({
+  type: kind,
+  lcsc: sensor.lcsc ?? 0,
+  mfr: sensor.mfr ?? "",
+  package: sensor.package ?? "",
+  supply_voltage_min: sensor.supply_voltage_min ?? undefined,
+  supply_voltage_max: sensor.supply_voltage_max ?? undefined,
+  axes: sensor.axes ?? undefined,
+  has_i2c: sensor.has_i2c === 1,
+  has_spi: sensor.has_spi === 1,
+  has_uart: sensor.has_uart === 1,
+  stock: sensor.stock ?? undefined,
+  price1: sensor.price1 ?? undefined,
+})
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET"],
+  queryParams: z.object({
+    package: z.string().optional(),
+    interface: z.enum(INTERFACE_OPTIONS).optional(),
+  }),
+  jsonResponse: z.any(),
+} as const)(async (req, ctx) => {
+  let accelerometerQuery = ctx.db
+    .selectFrom("accelerometer")
+    .selectAll()
+    .limit(100)
+    .orderBy("stock", "desc")
+  let gyroscopeQuery = ctx.db
+    .selectFrom("gyroscope")
+    .selectAll()
+    .limit(100)
+    .orderBy("stock", "desc")
+
+  if (req.query.package) {
+    accelerometerQuery = accelerometerQuery.where(
+      "package",
+      "=",
+      req.query.package,
+    )
+    gyroscopeQuery = gyroscopeQuery.where("package", "=", req.query.package)
+  }
+
+  accelerometerQuery = applyInterfaceFilter(
+    accelerometerQuery,
+    req.query.interface,
+  )
+  gyroscopeQuery = applyInterfaceFilter(gyroscopeQuery, req.query.interface)
+
+  const accelerometerPackages = await ctx.db
+    .selectFrom("accelerometer")
+    .select("package")
+    .distinct()
+    .where("package", "is not", null)
+    .orderBy("package")
+    .execute()
+  const gyroscopePackages = await ctx.db
+    .selectFrom("gyroscope")
+    .select("package")
+    .distinct()
+    .where("package", "is not", null)
+    .orderBy("package")
+    .execute()
+  const accelerometers = await accelerometerQuery.execute()
+  const gyroscopes = await gyroscopeQuery.execute()
+
+  const imus = [
+    ...accelerometers.map((sensor) => normalizeImu("accelerometer", sensor)),
+    ...gyroscopes.map((sensor) => normalizeImu("gyroscope", sensor)),
+  ]
+    .filter((sensor) => sensor.lcsc !== 0 && sensor.package !== "")
+    .sort((a, b) => (b.stock ?? 0) - (a.stock ?? 0))
+    .slice(0, 100)
+
+  if (ctx.isApiRequest) {
+    return ctx.json({ imus })
+  }
+
+  const packages = Array.from(
+    new Set(
+      [...accelerometerPackages, ...gyroscopePackages]
+        .map((row) => row.package?.trim() ?? "")
+        .filter(Boolean),
+    ),
+  ).sort()
+
+  return ctx.react(
+    <div>
+      <h2>IMUs</h2>
+
+      <form method="GET" className="flex flex-row gap-4">
+        <div>
+          <label>Package:</label>
+          <select name="package">
+            <option value="">All</option>
+            {packages.map((pkg) => (
+              <option
+                key={pkg}
+                value={pkg}
+                selected={pkg === req.query.package}
+              >
+                {pkg}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label>Interface:</label>
+          <select name="interface">
+            <option value="">All</option>
+            <option value="spi" selected={req.query.interface === "spi"}>
+              SPI
+            </option>
+            <option value="i2c" selected={req.query.interface === "i2c"}>
+              I2C
+            </option>
+            <option value="uart" selected={req.query.interface === "uart"}>
+              UART
+            </option>
+          </select>
+        </div>
+
+        <button type="submit">Filter</button>
+      </form>
+
+      <Table
+        rows={imus.map((sensor) => ({
+          type: sensor.type,
+          lcsc: sensor.lcsc,
+          mfr: sensor.mfr,
+          package: sensor.package,
+          voltage:
+            sensor.supply_voltage_min && sensor.supply_voltage_max ? (
+              <span className="tabular-nums">
+                {sensor.supply_voltage_min}V - {sensor.supply_voltage_max}V
+              </span>
+            ) : (
+              ""
+            ),
+          axes: sensor.axes,
+          interface: [
+            sensor.has_spi && "SPI",
+            sensor.has_i2c && "I2C",
+            sensor.has_uart && "UART",
+          ]
+            .filter(Boolean)
+            .join(", "),
+          stock: <span className="tabular-nums">{sensor.stock}</span>,
+          price: (
+            <span className="tabular-nums">{formatPrice(sensor.price1)}</span>
+          ),
+        }))}
+      />
+    </div>,
+    "JLCPCB IMU Search",
+  )
+})

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -31,6 +31,7 @@ export default withWinterSpec({
         <a href="/analog_multiplexers/list">Analog Muxes</a>
         <a href="/analog_switches/list">Analog Switches</a>
         <a href="/io_expanders/list">I/O Expanders</a>
+        <a href="/imus/list">IMUs</a>
         <a href="/gyroscopes/list">Gyroscopes</a>
         <a href="/accelerometers/list">Accelerometers</a>
         <a href="/gas_sensors/list">Gas Sensors</a>

--- a/tests/routes/imus/list.test.ts
+++ b/tests/routes/imus/list.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "../../fixtures/get-test-server"
+
+test("GET /imus/list with json param returns IMU data", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/imus/list?json=true")
+
+  expect(res.data).toHaveProperty("imus")
+  expect(Array.isArray(res.data.imus)).toBe(true)
+
+  if (res.data.imus.length > 0) {
+    const imu = res.data.imus[0]
+    expect(["accelerometer", "gyroscope"]).toContain(imu.type)
+    expect(imu).toHaveProperty("lcsc")
+    expect(imu).toHaveProperty("mfr")
+    expect(imu).toHaveProperty("package")
+    expect(imu).toHaveProperty("has_spi")
+    expect(typeof imu.lcsc).toBe("number")
+    expect(typeof imu.has_spi).toBe("boolean")
+    expect(typeof imu.has_i2c).toBe("boolean")
+  }
+})
+
+test("GET /imus/list supports interface filtering", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/imus/list?json=true&interface=i2c")
+
+  expect(res.data).toHaveProperty("imus")
+  for (const imu of res.data.imus) {
+    expect(imu.has_i2c).toBe(true)
+  }
+})


### PR DESCRIPTION
﻿Fixes #53

Summary
- Add `/imus/list` and `/imus/list.json` by combining existing accelerometer and gyroscope derived tables.
- Include `type` so API consumers can distinguish `accelerometer` and `gyroscope` rows.
- Support package and interface filters (`spi`, `i2c`, `uart`).
- Add the IMU link to the app index and the Cloudflare D1 route renderer/handler.
- Add route coverage for JSON shape and interface filtering.

Verification
- bun x biome check routes/imus/list.tsx routes/imus/list.json.tsx tests/routes/imus/list.test.ts routes/index.tsx cf-proxy/src/render.ts cf-proxy/src/d1-routes.ts
- bun x tsc --noEmit
- git diff --check
- bun test tests/routes/imus/list.test.ts currently hits the same local fixture issue as existing `tests/routes/accelerometers/list.test.ts`: `driver has already been destroyed`.
