### PR TITLE
fix: support c-prefixed lcsc component search

### DIFF
--- a/lib/util/parse-lcsc-search-term.ts
+++ b/lib/util/parse-lcsc-search-term.ts
@@ -1,0 +1,9 @@
+export const parseLcscSearchTerm = (searchTerm: string): number | null => {
+  const trimmedSearchTerm = searchTerm.trim()
+  const match = /^c?(\d+)$/i.exec(trimmedSearchTerm)
+
+  if (!match) return null
+
+  const lcscNumber = Number.parseInt(match[1], 10)
+  return Number.isNaN(lcscNumber) ? null : lcscNumber
+}

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -1,7 +1,8 @@
 import { sql } from "kysely"
+import { parseLcscSearchTerm } from "lib/util/parse-lcsc-search-term"
 import {
-  buildSearchTokenGroups,
   type SearchTokenGroup,
+  buildSearchTokenGroups,
   tokenizeSearchTerm,
 } from "lib/util/search-token-groups"
 import { withWinterSpec } from "lib/with-winter-spec"
@@ -80,13 +81,10 @@ export default withWinterSpec({
   if (req.query.q) {
     const rawSearchTerm = req.query.q.trim()
     const searchTerm = rawSearchTerm.toLowerCase()
+    const lcscSearchTerm = parseLcscSearchTerm(rawSearchTerm)
 
-    if (/^c\d+$/i.test(rawSearchTerm)) {
-      const lcscNumber = Number.parseInt(rawSearchTerm.slice(1), 10)
-
-      if (!Number.isNaN(lcscNumber)) {
-        query = query.where("lcsc", "=", lcscNumber)
-      }
+    if (lcscSearchTerm !== null) {
+      query = query.where("lcsc", "=", lcscSearchTerm)
     } else {
       const searchTokens = tokenizeSearchTerm(searchTerm)
       const searchTokenGroups = buildSearchTokenGroups(searchTerm)

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -1,6 +1,6 @@
-import { sql } from "kysely"
+import { ExpressionBuilder, sql } from "kysely"
 import { Table } from "lib/ui/Table"
-import { ExpressionBuilder } from "kysely"
+import { parseLcscSearchTerm } from "lib/util/parse-lcsc-search-term"
 import { buildSearchTokenGroups } from "lib/util/search-token-groups"
 import { withWinterSpec } from "lib/with-winter-spec"
 import { z } from "zod"
@@ -73,9 +73,10 @@ export default withWinterSpec({
 
   if (req.query.search) {
     const search = req.query.search
+    const lcscSearchTerm = parseLcscSearchTerm(search)
 
-    if (search.match(/^\d+$/)) {
-      query = query.where("lcsc", "=", parseInt(search))
+    if (lcscSearchTerm !== null) {
+      query = query.where("lcsc", "=", lcscSearchTerm)
     } else {
       const tokenGroups = buildSearchTokenGroups(search)
       const searchTokenGroups =

--- a/tests/lib/parse-lcsc-search-term.test.ts
+++ b/tests/lib/parse-lcsc-search-term.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test"
+import { parseLcscSearchTerm } from "lib/util/parse-lcsc-search-term"
+
+test("parseLcscSearchTerm accepts numeric and C-prefixed LCSC part numbers", () => {
+  expect(parseLcscSearchTerm("1002")).toBe(1002)
+  expect(parseLcscSearchTerm("C1002")).toBe(1002)
+  expect(parseLcscSearchTerm("c51950748")).toBe(51950748)
+  expect(parseLcscSearchTerm(" C51950749 ")).toBe(51950749)
+})
+
+test("parseLcscSearchTerm rejects non-LCSC search text", () => {
+  expect(parseLcscSearchTerm("USB Type-C 16P")).toBeNull()
+  expect(parseLcscSearchTerm("C1002 resistor")).toBeNull()
+  expect(parseLcscSearchTerm("")).toBeNull()
+})

--- a/tests/routes/components/list.test.ts
+++ b/tests/routes/components/list.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
 import { getTestServer } from "tests/fixtures/get-test-server"
 
 test("GET /components/list with json param returns component data", async () => {
@@ -6,4 +6,13 @@ test("GET /components/list with json param returns component data", async () => 
   const res = await axios.get("/components/list?json=true")
   expect(res.data).toHaveProperty("components")
   expect(Array.isArray(res.data.components)).toBe(true)
+})
+
+test("GET /components/list supports C-prefixed LCSC search terms", async () => {
+  const { axios } = await getTestServer()
+  const res = await axios.get("/components/list?json=true&search=C1002")
+
+  expect(res.data).toHaveProperty("components")
+  expect(res.data.components).toHaveLength(1)
+  expect(res.data.components[0]).toHaveProperty("lcsc", 1002)
 })


### PR DESCRIPTION
﻿Fixes #168

Summary
- Add a shared LCSC search-term parser for numeric and C-prefixed part numbers.
- Use it in `/components/list?search=...` so values like `C51950748` resolve by the numeric `lcsc` field instead of falling through to FTS text search.
- Reuse the same parser in `/api/search?q=...` so numeric and C-prefixed LCSC handling stays consistent.

Verification
- `bun test tests/lib/parse-lcsc-search-term.test.ts`
- `bun x biome check lib/util/parse-lcsc-search-term.ts routes/components/list.tsx routes/api/search.tsx tests/routes/components/list.test.ts tests/lib/parse-lcsc-search-term.test.ts`
- `bun x tsc --noEmit`
- `git diff --check`

Note
- `bun test tests/routes/components/list.test.ts tests/routes/api/search.test.ts` currently fails in this checkout with the existing route-test fixture error `driver has already been destroyed` before requests can complete.
