### PR TITLE
Add extended promotional component filter

### DIFF
--- a/cf-proxy/scripts/rebuild-search-index-batched.sh
+++ b/cf-proxy/scripts/rebuild-search-index-batched.sh
@@ -43,6 +43,7 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
      price1 REAL,
      basic INTEGER,
      preferred INTEGER,
+     is_extended_promotional INTEGER,
      category TEXT,
      subcategory TEXT,
      manufacturer_name TEXT,
@@ -70,6 +71,7 @@ INSERT INTO search_index_next (
   price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   manufacturer_name,
@@ -91,6 +93,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -133,7 +136,8 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
    CREATE INDEX IF NOT EXISTS idx_search_index_next_lcsc ON search_index_next(lcsc);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_package ON search_index_next(package);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_basic ON search_index_next(basic);
-   CREATE INDEX IF NOT EXISTS idx_search_index_next_preferred ON search_index_next(preferred);"
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_preferred ON search_index_next(preferred);
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_extended_promotional ON search_index_next(is_extended_promotional);"
 
 echo "Validating row count..."
 run_wrangler d1 execute "$DB_NAME" --remote --command \
@@ -157,11 +161,13 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
    DROP INDEX IF EXISTS idx_search_index_package;
    DROP INDEX IF EXISTS idx_search_index_basic;
    DROP INDEX IF EXISTS idx_search_index_preferred;
+   DROP INDEX IF EXISTS idx_search_index_extended_promotional;
    ALTER TABLE search_index_next RENAME TO search_index;
    CREATE INDEX IF NOT EXISTS idx_search_index_stock ON search_index(stock DESC);
    CREATE INDEX IF NOT EXISTS idx_search_index_lcsc ON search_index(lcsc);
    CREATE INDEX IF NOT EXISTS idx_search_index_package ON search_index(package);
    CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
-   CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);"
+   CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
+   CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);"
 
 echo "Done. Old table kept as search_index_old for rollback."

--- a/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
+++ b/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
@@ -14,6 +14,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -55,3 +56,5 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);

--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -296,6 +296,7 @@ SELECT
   package,
   basic,
   preferred,
+  is_extended_promotional,
   description,
   stock,
   price,
@@ -306,6 +307,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(is_extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA
 
@@ -319,6 +321,7 @@ CREATE TABLE component_catalog (
   package TEXT,
   basic INTEGER,
   preferred INTEGER,
+  is_extended_promotional INTEGER,
   description TEXT,
   stock INTEGER,
   price TEXT,
@@ -328,6 +331,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(is_extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA_EXPORT
 }
@@ -350,6 +354,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -391,6 +396,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);
 SEARCH_INDEX_SCHEMA
 
   cat > search_index_schema.sql <<'SEARCH_INDEX_SCHEMA_EXPORT'
@@ -405,6 +412,7 @@ CREATE TABLE search_index (
   price1 REAL,
   basic INTEGER,
   preferred INTEGER,
+  is_extended_promotional INTEGER,
   category TEXT,
   subcategory TEXT,
   manufacturer_name TEXT,
@@ -422,6 +430,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);
 SEARCH_INDEX_SCHEMA_EXPORT
 }
 

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -22,6 +23,7 @@ export async function queryComponentCatalog(
     package: string | null
     basic: number | null
     preferred: number | null
+    is_extended_promotional: number | null
     description: string | null
     stock: number | null
     price: string | null
@@ -34,6 +36,7 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -161,6 +161,7 @@ export interface ComponentCatalog {
   category: string | null
   description: string | null
   extra: string | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   package: string | null
@@ -660,6 +661,7 @@ export interface SearchIndex {
   basic: number | null
   category: string | null
   description: string | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   manufacturer_name: string | null

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -367,6 +367,7 @@ async function handleD1Search(
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
       is_preferred: Boolean(row.preferred),
+      is_extended_promotional: Boolean(row.is_extended_promotional),
       description: row.description ?? "",
       stock: row.stock ?? 0,
       price: row.price1 ?? extractSmallQuantityPrice(row.price),
@@ -491,6 +492,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        is_extended_promotional: Boolean(row.is_extended_promotional),
       })),
     }
 

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -147,6 +147,7 @@ const COLUMN_LABELS: Record<string, string> = {
   in_stock: "In Stock",
   is_basic: "Basic",
   is_preferred: "Preferred",
+  is_extended_promotional: "Extended Promotional",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
   voltage_rating: "Voltage",
@@ -545,6 +546,9 @@ const renderComponentsFilters = (
   </div>
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
+  </div>
+  <div>
+    <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <button type="submit">Filter</button>
 </form>`

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -21,6 +22,7 @@ interface SearchRow {
   price1: number | null
   basic: number | null
   preferred: number | null
+  is_extended_promotional: number | null
   category: string | null
   subcategory: string | null
 }
@@ -110,6 +112,13 @@ export async function searchIndex(
     conditions.push(sql`search_index.preferred = 1`)
   }
 
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`search_index.is_extended_promotional = 1`)
+  }
+
   const raw = params.q?.trim()
 
   if (raw) {
@@ -151,6 +160,7 @@ export async function searchIndex(
       search_index.price1,
       search_index.basic,
       search_index.preferred,
+      search_index.is_extended_promotional,
       search_index.category,
       search_index.subcategory
     FROM search_index

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -192,6 +192,7 @@ export interface Component {
   description: string;
   extra: string | null;
   flag: Generated<number>;
+  is_extended_promotional: Generated<number>;
   joints: number;
   last_on_stock: Generated<number>;
   last_update: number;
@@ -802,6 +803,7 @@ export interface VComponent {
   datasheet: string | null;
   description: string | null;
   extra: string | null;
+  is_extended_promotional: number | null;
   joints: number | null;
   last_on_stock: number | null;
   lcsc: number | null;

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -50,6 +50,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -71,6 +72,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("is_extended_promotional", "=", 1)
   }
 
   const baseQuery = query
@@ -193,6 +197,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.is_extended_promotional),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -35,6 +35,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -51,6 +52,8 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
+      "is_extended_promotional",
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -69,6 +72,9 @@ export default withWinterSpec({
   }
   if (req.query.is_preferred) {
     query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
+    query = query.where("is_extended_promotional", "=", 1)
   }
 
   if (req.query.search) {
@@ -111,6 +117,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.is_extended_promotional),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +159,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/tests/cf-proxy/search.test.ts
+++ b/tests/cf-proxy/search.test.ts
@@ -1,0 +1,73 @@
+import { Database } from "bun:sqlite"
+import { afterEach, expect, test } from "bun:test"
+import { Kysely } from "kysely"
+import { BunSqliteDialect } from "kysely-bun-sqlite"
+import type { DB } from "../../cf-proxy/src/db/types"
+import { searchIndex } from "../../cf-proxy/src/search"
+
+let db: Kysely<DB> | undefined
+let sqlite: Database | undefined
+
+afterEach(async () => {
+  await db?.destroy()
+  sqlite?.close()
+  db = undefined
+  sqlite = undefined
+})
+
+const createSearchDb = () => {
+  sqlite = new Database(":memory:")
+  sqlite.exec(`
+    CREATE TABLE search_index (
+      lcsc INTEGER,
+      mfr TEXT,
+      package TEXT,
+      description TEXT,
+      stock INTEGER,
+      price TEXT,
+      price1 REAL,
+      basic INTEGER,
+      preferred INTEGER,
+      is_extended_promotional INTEGER,
+      category TEXT,
+      subcategory TEXT,
+      manufacturer_name TEXT,
+      title TEXT,
+      mpn TEXT,
+      attributes TEXT,
+      search_text TEXT
+    );
+
+    INSERT INTO search_index (
+      lcsc,
+      mfr,
+      package,
+      description,
+      stock,
+      price,
+      price1,
+      basic,
+      preferred,
+      is_extended_promotional,
+      category,
+      subcategory,
+      search_text
+    ) VALUES
+      (1001, 'PromoCo', '0603', 'extended promotional resistor', 100, '[]', 0.01, 0, 0, 1, 'Resistors', 'Chip Resistor', 'promo resistor'),
+      (1002, 'StdCo', '0603', 'standard resistor', 100, '[]', 0.02, 0, 0, 0, 'Resistors', 'Chip Resistor', 'standard resistor');
+  `)
+  db = new Kysely<DB>({
+    dialect: new BunSqliteDialect({ database: sqlite }),
+  })
+  return db
+}
+
+test("searchIndex filters and returns extended promotional components", async () => {
+  const rows = await searchIndex(createSearchDb() as any, {
+    is_extended_promotional: "true",
+  })
+
+  expect(rows).toHaveLength(1)
+  expect(rows[0]?.lcsc).toBe(1001)
+  expect(rows[0]?.is_extended_promotional).toBe(1)
+})


### PR DESCRIPTION
Fixes #92.

Changes:
- Propagate is_extended_promotional from component_catalog into search_index.
- Add D1 and legacy search/components filter support.
- Return is_extended_promotional in component responses and render the filter in HTML.
- Add a Bun test for the search_index filter.

Verification:
- bun test tests/cf-proxy/search.test.ts
- bunx tsc --noEmit
- bunx tsc -p cf-proxy/tsconfig.json --noEmit
- bun run format:check