### PR TITLE
Add extended promotional component field

### DIFF
--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -1,5 +1,5 @@
 import { sql } from "kysely"
-import { getDbClient } from "lib/db/get-db-client"
+import { destroyDbClient, getDbClient } from "lib/db/get-db-client"
 import { accelerometerTableSpec } from "lib/db/derivedtables/accelerometer"
 import { adcTableSpec } from "lib/db/derivedtables/adc"
 import { analogMultiplexerTableSpec } from "lib/db/derivedtables/analog_multiplexer"
@@ -214,7 +214,7 @@ export const setupDerivedTables = async ({
     }
   } finally {
     if (shouldDestroy) {
-      await activeDb.destroy()
+      await destroyDbClient()
     }
   }
 }

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -192,6 +192,7 @@ export interface Component {
   description: string;
   extra: string | null;
   flag: Generated<number>;
+  is_extended_promotional: Generated<number>;
   joints: number;
   last_on_stock: Generated<number>;
   last_update: number;
@@ -805,6 +806,7 @@ export interface VComponent {
   joints: number | null;
   last_on_stock: number | null;
   lcsc: number | null;
+  is_extended_promotional: number | null;
   manufacturer: string | null;
   mfr: string | null;
   package: string | null;

--- a/lib/db/get-db-client.ts
+++ b/lib/db/get-db-client.ts
@@ -83,6 +83,13 @@ export const getDbClient = () => {
   return dbClientSingleton
 }
 
+export const destroyDbClient = async () => {
+  if (!dbClientSingleton) return
+  const db = dbClientSingleton
+  dbClientSingleton = undefined
+  await db.destroy()
+}
+
 export const getBunDatabaseClient = () => {
   const Database = getDatabaseCtor()
   return new Database(getResolvedDbPath())

--- a/lib/db/optimizations/component-extended-promotional-column.ts
+++ b/lib/db/optimizations/component-extended-promotional-column.ts
@@ -1,0 +1,37 @@
+import { sql } from "kysely"
+import type { DbOptimizationSpec } from "./types"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+
+export const componentExtendedPromotionalColumn: DbOptimizationSpec = {
+  name: "add_components_is_extended_promotional_column",
+  description:
+    "Adds is_extended_promotional column to components table derived from preferred",
+
+  async checkIfAdded(db: KyselyDatabaseInstance) {
+    const result = await sql`
+      PRAGMA table_info(components)
+    `.execute(db)
+
+    return result.rows.some(
+      (row: any) => row.name === "is_extended_promotional",
+    )
+  },
+
+  async execute(db: KyselyDatabaseInstance) {
+    await sql`
+      ALTER TABLE components
+      ADD COLUMN is_extended_promotional INTEGER NOT NULL DEFAULT 0
+    `.execute(db)
+
+    await sql`
+      UPDATE components
+      SET is_extended_promotional = preferred
+    `.execute(db)
+
+    await db.schema
+      .createIndex("idx_components_is_extended_promotional")
+      .on("components")
+      .column("is_extended_promotional")
+      .execute()
+  },
+}

--- a/lib/db/optimizations/component-in-stock-column.ts
+++ b/lib/db/optimizations/component-in-stock-column.ts
@@ -8,13 +8,11 @@ export const componentInStockColumn: DbOptimizationSpec = {
     "Adds in_stock boolean column to components table derived from stock > 0",
 
   async checkIfAdded(db: KyselyDatabaseInstance) {
-    const {
-      rows: [ex],
-    } = await sql<any>`
-      SELECT * FROM components LIMIT 1
+    const result = await sql<any>`
+      PRAGMA table_info(components)
     `.execute(db)
 
-    return "in_stock" in ex
+    return result.rows.some((row: any) => row.name === "in_stock")
   },
 
   async execute(db: KyselyDatabaseInstance) {

--- a/lib/db/optimizations/component-source-compat.ts
+++ b/lib/db/optimizations/component-source-compat.ts
@@ -35,10 +35,159 @@ const getTableColumns = async (
 
 const sqlIdentifier = (name: string) => sql.raw(`"${name.replace(/"/g, '""')}"`)
 
+const ensureViewComponents = async (db: KyselyDatabaseInstance) => {
+  if (await tableExists(db, "v_components")) {
+    return
+  }
+
+  await sql`
+    CREATE VIEW v_components AS
+    SELECT
+      components.*,
+      categories.category,
+      categories.subcategory
+    FROM components
+    LEFT JOIN categories ON components.category_id = categories.id
+  `.execute(db)
+}
+
+const ensureComponentsFromJlcSourceDb = async (db: KyselyDatabaseInstance) => {
+  if (!(await tableExists(db, "jlc_components"))) {
+    return false
+  }
+
+  await sql`
+    CREATE TABLE categories (
+      id INTEGER PRIMARY KEY,
+      category TEXT,
+      subcategory TEXT
+    )
+  `.execute(db)
+
+  await sql`
+    INSERT INTO categories (id, category, subcategory)
+    SELECT
+      ROW_NUMBER() OVER (ORDER BY category, subcategory),
+      category,
+      subcategory
+    FROM (
+      SELECT DISTINCT category, subcategory
+      FROM jlc_components
+      WHERE present = 1
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE components (
+      lcsc INTEGER PRIMARY KEY,
+      mfr TEXT,
+      description TEXT,
+      stock INTEGER,
+      price TEXT,
+      package TEXT,
+      joints INTEGER,
+      manufacturer TEXT,
+      datasheet TEXT,
+      extra TEXT,
+      basic INTEGER NOT NULL DEFAULT 0,
+      preferred INTEGER NOT NULL DEFAULT 0,
+      in_stock INTEGER NOT NULL DEFAULT 0,
+      category_id INTEGER,
+      last_on_stock INTEGER
+    )
+  `.execute(db)
+
+  await sql`
+    INSERT INTO components (
+      lcsc,
+      mfr,
+      description,
+      stock,
+      price,
+      package,
+      joints,
+      manufacturer,
+      datasheet,
+      extra,
+      basic,
+      preferred,
+      in_stock,
+      category_id,
+      last_on_stock
+    )
+    WITH priced AS (
+      SELECT
+        j.*,
+        c.id AS normalized_category_id,
+        COALESCE(l.attributes, j.attributes, '{}') AS source_attributes,
+        CASE
+          WHEN instr(j.price, ',') > 0
+            THEN substr(j.price, 1, instr(j.price, ',') - 1)
+          ELSE j.price
+        END AS first_price
+      FROM jlc_components j
+      LEFT JOIN lcsc_components l ON l.lcsc = j.lcsc
+      INNER JOIN categories c
+        ON c.category = j.category
+        AND c.subcategory = j.subcategory
+      WHERE j.present = 1
+    ),
+    parsed_price AS (
+      SELECT
+        *,
+        substr(first_price, 1, instr(first_price, ':') - 1) AS price_range,
+        substr(first_price, instr(first_price, ':') + 1) AS price_value
+      FROM priced
+    ),
+    parsed_range AS (
+      SELECT
+        *,
+        substr(price_range, 1, instr(price_range, '-') - 1) AS q_from,
+        substr(price_range, instr(price_range, '-') + 1) AS q_to
+      FROM parsed_price
+    )
+    SELECT
+      lcsc,
+      mfr,
+      description,
+      stock,
+      CASE
+        WHEN price_value IS NULL OR price_value = '' THEN '[]'
+        ELSE json_array(json_object(
+          'qFrom',
+          CAST(q_from AS INTEGER),
+          'qTo',
+          CASE WHEN q_to = '' THEN NULL ELSE CAST(q_to AS INTEGER) END,
+          'price',
+          CAST(price_value AS REAL)
+        ))
+      END,
+      package,
+      joints,
+      manufacturer,
+      datasheet,
+      json_object('attributes', json(source_attributes)),
+      CASE WHEN library_type = 'base' THEN 1 ELSE 0 END,
+      preferred,
+      CASE WHEN stock > 0 THEN 1 ELSE 0 END,
+      normalized_category_id,
+      last_on_stock
+    FROM parsed_range
+  `.execute(db)
+
+  await ensureViewComponents(db)
+  return true
+}
+
 export const ensureComponentSourceCompat = async (
   db: KyselyDatabaseInstance,
 ) => {
   if (await tableExists(db, "components")) {
+    await ensureViewComponents(db)
+    return
+  }
+
+  if (await ensureComponentsFromJlcSourceDb(db)) {
     return
   }
 
@@ -137,15 +286,5 @@ export const ensureComponentSourceCompat = async (
     `.execute(db)
   }
 
-  if (!(await tableExists(db, "v_components"))) {
-    await sql`
-      CREATE VIEW v_components AS
-      SELECT
-        components.*,
-        categories.category,
-        categories.subcategory
-      FROM components
-      LEFT JOIN categories ON components.category_id = categories.id
-    `.execute(db)
-  }
+  await ensureViewComponents(db)
 }

--- a/lib/db/optimizations/component-source-compat.ts
+++ b/lib/db/optimizations/component-source-compat.ts
@@ -74,6 +74,8 @@ const ensureComponentsFromJlcSourceDb = async (db: KyselyDatabaseInstance) => {
       SELECT DISTINCT category, subcategory
       FROM jlc_components
       WHERE present = 1
+        AND category != ''
+        AND subcategory != ''
     )
   `.execute(db)
 
@@ -131,6 +133,8 @@ const ensureComponentsFromJlcSourceDb = async (db: KyselyDatabaseInstance) => {
         ON c.category = j.category
         AND c.subcategory = j.subcategory
       WHERE j.present = 1
+        AND j.category != ''
+        AND j.subcategory != ''
     ),
     parsed_price AS (
       SELECT

--- a/lib/db/optimizations/component-source-compat.ts
+++ b/lib/db/optimizations/component-source-compat.ts
@@ -1,0 +1,151 @@
+import { sql } from "kysely"
+import { DERIVED_TABLES } from "lib/db/derivedtables/setup-derived-tables"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+
+type SqliteColumn = {
+  name: string
+}
+
+const titleFromTableName = (tableName: string) =>
+  tableName
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ")
+
+const tableExists = async (db: KyselyDatabaseInstance, tableName: string) => {
+  const result = await sql`
+    SELECT name FROM sqlite_master
+    WHERE type IN ('table', 'view') AND name=${tableName}
+  `.execute(db)
+
+  return result.rows.length > 0
+}
+
+const getTableColumns = async (
+  db: KyselyDatabaseInstance,
+  tableName: string,
+) => {
+  const result =
+    await sql<SqliteColumn>`PRAGMA table_info(${sql.raw(tableName)})`.execute(
+      db,
+    )
+
+  return new Set(result.rows.map((row) => row.name))
+}
+
+const sqlIdentifier = (name: string) => sql.raw(`"${name.replace(/"/g, '""')}"`)
+
+export const ensureComponentSourceCompat = async (
+  db: KyselyDatabaseInstance,
+) => {
+  if (await tableExists(db, "components")) {
+    return
+  }
+
+  const sourceTables = []
+  for (const tableSpec of DERIVED_TABLES) {
+    if (await tableExists(db, tableSpec.tableName)) {
+      sourceTables.push(tableSpec.tableName)
+    }
+  }
+
+  if (sourceTables.length === 0) {
+    return
+  }
+
+  if (!(await tableExists(db, "categories"))) {
+    await sql`
+      CREATE TABLE categories (
+        id INTEGER PRIMARY KEY,
+        category TEXT,
+        subcategory TEXT
+      )
+    `.execute(db)
+
+    for (const [index, tableName] of sourceTables.entries()) {
+      await sql`
+        INSERT INTO categories (id, category, subcategory)
+        VALUES (${index + 1}, ${titleFromTableName(tableName)}, ${tableName})
+      `.execute(db)
+    }
+  }
+
+  await sql`
+    CREATE TABLE components (
+      lcsc INTEGER PRIMARY KEY,
+      mfr TEXT,
+      description TEXT,
+      stock INTEGER,
+      price TEXT,
+      package TEXT,
+      extra TEXT,
+      basic INTEGER NOT NULL DEFAULT 0,
+      preferred INTEGER NOT NULL DEFAULT 0,
+      in_stock INTEGER NOT NULL DEFAULT 0,
+      category_id INTEGER,
+      last_on_stock INTEGER
+    )
+  `.execute(db)
+
+  for (const [index, tableName] of sourceTables.entries()) {
+    const columns = await getTableColumns(db, tableName)
+    const table = sqlIdentifier(tableName)
+    const packageExpr = columns.has("package") ? sql`package` : sql`NULL`
+    const attributesExpr = columns.has("attributes")
+      ? sql`attributes`
+      : sql`NULL`
+    const basicExpr = columns.has("is_basic")
+      ? sql`COALESCE(is_basic, 0)`
+      : sql`0`
+    const preferredExpr = columns.has("is_preferred")
+      ? sql`COALESCE(is_preferred, 0)`
+      : sql`0`
+
+    await sql`
+      INSERT OR IGNORE INTO components (
+        lcsc,
+        mfr,
+        description,
+        stock,
+        price,
+        package,
+        extra,
+        basic,
+        preferred,
+        in_stock,
+        category_id,
+        last_on_stock
+      )
+      SELECT
+        lcsc,
+        mfr,
+        description,
+        COALESCE(stock, 0),
+        CASE
+          WHEN price1 IS NULL THEN '[]'
+          ELSE json_array(json_object('price', CAST(price1 AS TEXT)))
+        END,
+        ${packageExpr},
+        ${attributesExpr},
+        ${basicExpr},
+        ${preferredExpr},
+        CASE WHEN COALESCE(stock, 0) > 0 THEN 1 ELSE 0 END,
+        ${index + 1},
+        NULL
+      FROM ${table}
+      WHERE lcsc IS NOT NULL
+    `.execute(db)
+  }
+
+  if (!(await tableExists(db, "v_components"))) {
+    await sql`
+      CREATE VIEW v_components AS
+      SELECT
+        components.*,
+        categories.category,
+        categories.subcategory
+      FROM components
+      LEFT JOIN categories ON components.category_id = categories.id
+    `.execute(db)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@types/react-dom": "^18.3.1",
     "better-sqlite3": "^11.7.0",
     "kysely": "^0.28.3",
+    "kysely-d1": "^0.4.0",
     "kysely-codegen": "^0.17.0",
     "winterspec": "^0.0.96"
   },
@@ -36,6 +37,7 @@
   "type": "module",
   "dependencies": {
     "@tscircuit/footprinter": "^0.0.143",
+    "format-si-unit": "^0.0.10",
     "kysely-bun-sqlite": "^0.3.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -50,6 +50,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -58,6 +59,7 @@ export default withWinterSpec({
   let query = ctx.db
     .selectFrom("components")
     .selectAll()
+    .select(sql<number>`preferred`.as("is_extended_promotional"))
     .limit(limit)
     .orderBy("stock", "desc")
     .where("stock", ">", 0)
@@ -70,6 +72,9 @@ export default withWinterSpec({
     query = query.where("basic", "=", 1)
   }
   if (req.query.is_preferred) {
+    query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
     query = query.where("preferred", "=", 1)
   }
 
@@ -193,6 +198,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.is_extended_promotional),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -35,6 +35,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -51,6 +52,8 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
+      sql<number>`preferred`.as("is_extended_promotional"),
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -68,6 +71,9 @@ export default withWinterSpec({
     query = query.where("basic", "=", 1)
   }
   if (req.query.is_preferred) {
+    query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
     query = query.where("preferred", "=", 1)
   }
 
@@ -111,6 +117,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.is_extended_promotional),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +159,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional Part:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/scripts/setup-7z.ts
+++ b/scripts/setup-7z.ts
@@ -7,10 +7,10 @@ const BINARY_NAME = "7zz"
 
 // Map of platform-arch combinations to download URLs
 const BINARY_URLS: Record<string, string> = {
-  "linux-x64": "https://7-zip.org/a/7z2408-linux-x64.tar.xz",
-  "linux-arm64": "https://7-zip.org/a/7z2408-linux-arm64.tar.xz",
-  "darwin-x64": "https://7-zip.org/a/7z2408-mac.tar.xz",
-  "darwin-arm64": "https://7-zip.org/a/7z2408-mac.tar.xz",
+  "linux-x64": "https://7-zip.org/a/7z2501-linux-x64.tar.xz",
+  "linux-arm64": "https://7-zip.org/a/7z2501-linux-arm64.tar.xz",
+  "darwin-x64": "https://7-zip.org/a/7z2501-mac.tar.xz",
+  "darwin-arm64": "https://7-zip.org/a/7z2501-mac.tar.xz",
 }
 
 async function downloadAndExtract7z() {

--- a/scripts/setup-db-optimizations.ts
+++ b/scripts/setup-db-optimizations.ts
@@ -9,12 +9,14 @@ import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
 import { componentPackageIndex } from "lib/db/optimizations/component-indexes"
 import { componentBasicIndex } from "lib/db/optimizations/component-basic-index"
 import { componentPreferredIndex } from "lib/db/optimizations/component-preferred-index"
+import { componentExtendedPromotionalColumn } from "lib/db/optimizations/component-extended-promotional-column"
 
 const OPTIMIZATIONS: DbOptimizationSpec[] = [
   componentSearchFTS,
   componentPackageIndex,
   componentBasicIndex,
   componentPreferredIndex,
+  componentExtendedPromotionalColumn,
   removeStaleComponents,
   componentStockIndex,
   componentInStockColumn,

--- a/scripts/setup-db-optimizations.ts
+++ b/scripts/setup-db-optimizations.ts
@@ -10,6 +10,7 @@ import { componentPackageIndex } from "lib/db/optimizations/component-indexes"
 import { componentBasicIndex } from "lib/db/optimizations/component-basic-index"
 import { componentPreferredIndex } from "lib/db/optimizations/component-preferred-index"
 import { componentExtendedPromotionalColumn } from "lib/db/optimizations/component-extended-promotional-column"
+import { ensureComponentSourceCompat } from "lib/db/optimizations/component-source-compat"
 
 const OPTIMIZATIONS: DbOptimizationSpec[] = [
   componentSearchFTS,
@@ -26,6 +27,8 @@ const OPTIMIZATIONS: DbOptimizationSpec[] = [
 
 async function main() {
   const db = getDbClient()
+
+  await ensureComponentSourceCompat(db)
 
   for (const optimization of OPTIMIZATIONS) {
     const isAdded = await optimization.checkIfAdded(db)

--- a/tests/routes/api/search.test.ts
+++ b/tests/routes/api/search.test.ts
@@ -18,6 +18,8 @@ test("GET /api/search with search query 'STM32F401RCT6' returns expected compone
   expect(component).toHaveProperty("package")
   expect(component).toHaveProperty("price")
   expect(component).toHaveProperty("stock")
+  expect(component).toHaveProperty("is_extended_promotional")
+  expect(typeof component.is_extended_promotional).toBe("boolean")
 })
 
 test("GET /api/search with search query '555 Timer' returns expected components", async () => {

--- a/tests/routes/components/list.test.ts
+++ b/tests/routes/components/list.test.ts
@@ -6,4 +6,10 @@ test("GET /components/list with json param returns component data", async () => 
   const res = await axios.get("/components/list?json=true")
   expect(res.data).toHaveProperty("components")
   expect(Array.isArray(res.data.components)).toBe(true)
+  if (res.data.components.length > 0) {
+    expect(res.data.components[0]).toHaveProperty("is_extended_promotional")
+    expect(typeof res.data.components[0].is_extended_promotional).toBe(
+      "boolean",
+    )
+  }
 })


### PR DESCRIPTION
﻿## Summary

- add `is_extended_promotional` to component search/list responses
- support `is_extended_promotional=true` filtering in `/api/search` and `/components/list`
- add a database optimization step that materializes `is_extended_promotional` from the existing preferred-component flag
- restore compatibility with the current jlcparts source-db-v2 cache so setup/test can build the expected `components` tables
- add route-level assertions that the new boolean field is present in JSON responses

## Notes

The source data currently exposes the JLC preferred/promotional status through the existing `preferred` flag. This keeps `is_preferred` behavior intact while adding the requested `is_extended_promotional` field and query parameter.

## Validation

- GitHub Actions `format-check`: passing
- GitHub Actions `type-check`: passing
- GitHub Actions `test`: passing

Closes #92
/claim #92
