### PR TITLE
Refactor BaseComponent interface formatting

### DIFF
--- a/lib/db/derivedtables/component-base.ts
+++ b/lib/db/derivedtables/component-base.ts
@@ -1,11 +1,2 @@
-export interface BaseComponent {
-  lcsc: number
-  mfr: string
-  description: string
-  stock: number
-  price1: number | null
-  in_stock: boolean
-  is_basic: boolean
-  is_preferred: boolean
-  attributes: Record<string, string>
-}
+export interface BaseComponent {  lcsc: number  mfr: string  description: string  stock: number  price1: number | null  in_stock: boolean
+  is_extended_promotional: boolean  is_basic: boolean  is_preferred: boolean  attributes: Record<string, string>}


### PR DESCRIPTION
Removed line breaks for the BaseComponent interface properties and added is_extended_promotional property.