### PR TITLE
Add is_extended_promotional to search and component list

### DIFF
--- a/routes/api/search.tsx
+++ b/routes/api/search.tsx
@@ -50,6 +50,7 @@ export default withWinterSpec({
     limit: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -58,6 +59,7 @@ export default withWinterSpec({
   let query = ctx.db
     .selectFrom("components")
     .selectAll()
+    .select(sql<number>`preferred`.as("is_extended_promotional"))
     .limit(limit)
     .orderBy("stock", "desc")
     .where("stock", ">", 0)
@@ -70,6 +72,9 @@ export default withWinterSpec({
     query = query.where("basic", "=", 1)
   }
   if (req.query.is_preferred) {
+    query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
     query = query.where("preferred", "=", 1)
   }
 
@@ -193,6 +198,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.is_extended_promotional),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),

--- a/routes/components/list.tsx
+++ b/routes/components/list.tsx
@@ -35,6 +35,7 @@ export default withWinterSpec({
     search: z.string().optional(),
     is_basic: z.boolean().optional(),
     is_preferred: z.boolean().optional(),
+    is_extended_promotional: z.boolean().optional(),
   }),
   jsonResponse: z.any(),
 } as const)(async (req, ctx) => {
@@ -51,6 +52,8 @@ export default withWinterSpec({
       "price",
       "extra",
       "basic",
+      "preferred",
+      sql<number>`preferred`.as("is_extended_promotional"),
     ])
     .limit(limit)
     .orderBy("stock", "desc")
@@ -68,6 +71,9 @@ export default withWinterSpec({
     query = query.where("basic", "=", 1)
   }
   if (req.query.is_preferred) {
+    query = query.where("preferred", "=", 1)
+  }
+  if (req.query.is_extended_promotional) {
     query = query.where("preferred", "=", 1)
   }
 
@@ -111,6 +117,7 @@ export default withWinterSpec({
     package: c.package,
     is_basic: Boolean(c.basic),
     is_preferred: Boolean(c.preferred),
+    is_extended_promotional: Boolean(c.is_extended_promotional),
     description: c.description,
     stock: c.stock,
     price: extractSmallQuantityPrice(c.price),
@@ -152,6 +159,17 @@ export default withWinterSpec({
               name="is_preferred"
               value="true"
               checked={req.query.is_preferred}
+            />
+          </label>
+        </div>
+        <div>
+          <label>
+            Extended Promotional Part:
+            <input
+              type="checkbox"
+              name="is_extended_promotional"
+              value="true"
+              checked={req.query.is_extended_promotional}
             />
           </label>
         </div>

--- a/tests/routes/api/search.test.ts
+++ b/tests/routes/api/search.test.ts
@@ -18,6 +18,8 @@ test("GET /api/search with search query 'STM32F401RCT6' returns expected compone
   expect(component).toHaveProperty("package")
   expect(component).toHaveProperty("price")
   expect(component).toHaveProperty("stock")
+  expect(component).toHaveProperty("is_extended_promotional")
+  expect(typeof component.is_extended_promotional).toBe("boolean")
 })
 
 test("GET /api/search with search query '555 Timer' returns expected components", async () => {

--- a/tests/routes/components/list.test.ts
+++ b/tests/routes/components/list.test.ts
@@ -6,4 +6,8 @@ test("GET /components/list with json param returns component data", async () => 
   const res = await axios.get("/components/list?json=true")
   expect(res.data).toHaveProperty("components")
   expect(Array.isArray(res.data.components)).toBe(true)
+  if (res.data.components.length > 0) {
+    expect(res.data.components[0]).toHaveProperty("is_extended_promotional")
+    expect(typeof res.data.components[0].is_extended_promotional).toBe("boolean")
+  }
 })


### PR DESCRIPTION
Expose is_extended_promotional on search/list APIs and filters (sourced from preferred). Adds tests. Closes #92.