### PR TITLE
Add spring clamp terminal block search

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -29,9 +29,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ./db.sqlite3
-          # Keep the schema-compatible fixture that includes the base component
-          # tables. The current upstream archive only contains derived tables.
-          key: db-sqlite3-db037f1104c185bc5ce0f4e5500cd90ff19e3f9c5f92449c6f9859af64a7667c
+          key: db-sqlite3-${{ hashFiles('scripts/setup-*.ts') }}
 
       - name: Run setup if cache miss
         if: steps.cache-setup.outputs.cache-hit != 'true'

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Install Cloudflare proxy dependencies
+        run: bun install --cwd cf-proxy --frozen-lockfile
+
       - name: Cache setup artifacts
         id: cache-setup
         uses: actions/cache@v4

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -29,7 +29,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ./db.sqlite3
-          key: db-sqlite3-${{ hashFiles('scripts/setup-*.ts') }}
+          # Keep the schema-compatible fixture that includes the base component
+          # tables. The current upstream archive only contains derived tables.
+          key: db-sqlite3-db037f1104c185bc5ce0f4e5500cd90ff19e3f9c5f92449c6f9859af64a7667c
 
       - name: Run setup if cache miss
         if: steps.cache-setup.outputs.cache-hit != 'true'

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -1,5 +1,5 @@
 import { sql } from "kysely"
-import { getDbClient } from "lib/db/get-db-client"
+import { destroyDbClient, getDbClient } from "lib/db/get-db-client"
 import { accelerometerTableSpec } from "lib/db/derivedtables/accelerometer"
 import { adcTableSpec } from "lib/db/derivedtables/adc"
 import { analogMultiplexerTableSpec } from "lib/db/derivedtables/analog_multiplexer"
@@ -216,7 +216,7 @@ export const setupDerivedTables = async ({
     }
   } finally {
     if (shouldDestroy) {
-      await activeDb.destroy()
+      await destroyDbClient()
     }
   }
 }

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -33,6 +33,7 @@ import { potentiometerTableSpec } from "lib/db/derivedtables/potentiometer"
 import { relayTableSpec } from "lib/db/derivedtables/relay"
 import { resistorArrayTableSpec } from "lib/db/derivedtables/resistor_array"
 import { resistorTableSpec } from "lib/db/derivedtables/resistor"
+import { springClampTerminalBlockTableSpec } from "lib/db/derivedtables/spring-clamp-terminal-block"
 import { switchTableSpec } from "lib/db/derivedtables/switch"
 import type { DerivedTableSpec } from "lib/db/derivedtables/types"
 import { usbCConnectorTableSpec } from "lib/db/derivedtables/usb_c_connector"
@@ -78,6 +79,7 @@ export const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   pcieM2ConnectorTableSpec,
   jstConnectorTableSpec,
   wireToBoardConnectorTableSpec,
+  springClampTerminalBlockTableSpec,
   fpgaTableSpec,
   batteryHolderTableSpec,
 ]

--- a/lib/db/derivedtables/spring-clamp-terminal-block.ts
+++ b/lib/db/derivedtables/spring-clamp-terminal-block.ts
@@ -1,0 +1,86 @@
+import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+import type { BaseComponent } from "./component-base"
+import type { DerivedTableSpec } from "./types"
+
+export interface SpringClampTerminalBlock extends BaseComponent {
+  package: string
+  pitch_mm: number | null
+  num_pins: number | null
+  voltage_rating: number | null
+  current_rating: number | null
+  wire_gauge_mm2: number | null
+  wire_gauge_awg: string | null
+  mounting_style: string | null
+}
+
+const parseUnit = (value?: string | null) => {
+  if (!value || value === "-") return null
+  const parsed = parseAndConvertSiUnit(value).value
+  return typeof parsed === "number" && !Number.isNaN(parsed) ? parsed : null
+}
+
+const parseInteger = (value?: string | null) => {
+  if (!value) return null
+  const parsed = Number.parseInt(value.replace(/[^0-9]/g, ""), 10)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+export const springClampTerminalBlockTableSpec: DerivedTableSpec<SpringClampTerminalBlock> =
+  {
+    tableName: "spring_clamp_terminal_block",
+    extraColumns: [
+      { name: "package", type: "text" },
+      { name: "pitch_mm", type: "real" },
+      { name: "num_pins", type: "integer" },
+      { name: "voltage_rating", type: "real" },
+      { name: "current_rating", type: "real" },
+      { name: "wire_gauge_mm2", type: "real" },
+      { name: "wire_gauge_awg", type: "text" },
+      { name: "mounting_style", type: "text" },
+      { name: "is_basic", type: "boolean" },
+      { name: "is_preferred", type: "boolean" },
+    ],
+    listCandidateComponents(db: KyselyDatabaseInstance) {
+      return db
+        .selectFrom("components")
+        .innerJoin("categories", "components.category_id", "categories.id")
+        .selectAll()
+        .where(
+          "categories.subcategory",
+          "=",
+          "Spring Clamp System Terminal Block",
+        )
+    },
+    mapToTable(components) {
+      return components.map((c) => {
+        try {
+          const extra = c.extra ? JSON.parse(c.extra) : {}
+          const attrs: Record<string, string> = extra.attributes || {}
+
+          return {
+            lcsc: Number(c.lcsc),
+            mfr: String(c.mfr || ""),
+            description: String(c.description || ""),
+            stock: Number(c.stock || 0),
+            price1: extractMinQPrice(c.price),
+            in_stock: Boolean((c.stock || 0) > 0),
+            is_basic: Boolean(c.basic),
+            is_preferred: Boolean(c.preferred),
+            package: String(c.package || ""),
+            pitch_mm: parseUnit(attrs["Pitch"]),
+            num_pins: parseInteger(attrs["Number of PINs Per Row"]),
+            voltage_rating: parseUnit(attrs["Voltage Rating (Max)"]),
+            current_rating: parseUnit(attrs["Current Rating (Max)"]),
+            wire_gauge_mm2: parseUnit(attrs["Wire Gauge - mm2"]),
+            wire_gauge_awg: attrs["Wire Gauge - AWG"] || null,
+            mounting_style: attrs["Mounting Style"] || null,
+            attributes: attrs,
+          }
+        } catch {
+          return null
+        }
+      })
+    },
+  }

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -326,6 +326,26 @@ export interface Fpga {
   type: string | null;
 }
 
+export interface SpringClampTerminalBlock {
+  attributes: string | null;
+  current_rating: number | null;
+  description: string | null;
+  in_stock: number | null;
+  is_basic: number | null;
+  is_preferred: number | null;
+  lcsc: Generated<number | null>;
+  mfr: string | null;
+  mounting_style: string | null;
+  num_pins: number | null;
+  package: string | null;
+  pitch_mm: number | null;
+  price1: number | null;
+  stock: number | null;
+  voltage_rating: number | null;
+  wire_gauge_awg: string | null;
+  wire_gauge_mm2: number | null;
+}
+
 export interface Fuse {
   attributes: string | null;
   current_rating: number | null;
@@ -931,6 +951,7 @@ export interface DB {
   relay: Relay;
   resistor: Resistor;
   resistor_array: ResistorArray;
+  spring_clamp_terminal_block: SpringClampTerminalBlock;
   switch: Switch;
   usb_c_connector: UsbCConnector;
   v_components: VComponent;

--- a/lib/db/get-db-client.ts
+++ b/lib/db/get-db-client.ts
@@ -83,6 +83,14 @@ export const getDbClient = () => {
   return dbClientSingleton
 }
 
+export const destroyDbClient = async () => {
+  if (!dbClientSingleton) return
+
+  const client = dbClientSingleton
+  dbClientSingleton = undefined
+  await client.destroy()
+}
+
 export const getBunDatabaseClient = () => {
   const Database = getDatabaseCtor()
   return new Database(getResolvedDbPath())

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "type": "module",
   "dependencies": {
     "@tscircuit/footprinter": "^0.0.143",
+    "format-si-unit": "^0.0.10",
     "kysely-bun-sqlite": "^0.3.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -25,6 +25,9 @@ export default withWinterSpec({
         <a href="/fpc_connectors/list">FPC Connectors</a>
         <a href="/jst_connectors/list">JST Connectors</a>
         <a href="/wire_to_board_connectors/list">Wire to Board Connectors</a>
+        <a href="/spring_clamp_terminal_blocks/list">
+          Spring Clamp Terminal Blocks
+        </a>
         <a href="/battery_holders/list">Battery Holders</a>
         <a href="/leds/list">LEDs</a>
         <a href="/adcs/list">ADCs</a>

--- a/routes/spring_clamp_terminal_blocks/list.json.tsx
+++ b/routes/spring_clamp_terminal_blocks/list.json.tsx
@@ -1,0 +1,3 @@
+import list from "./list"
+
+export default list

--- a/routes/spring_clamp_terminal_blocks/list.tsx
+++ b/routes/spring_clamp_terminal_blocks/list.tsx
@@ -1,0 +1,157 @@
+import { Table } from "lib/ui/Table"
+import { formatPrice } from "lib/util/format-price"
+import { withWinterSpec } from "lib/with-winter-spec"
+import { z } from "zod"
+
+export default withWinterSpec({
+  auth: "none",
+  methods: ["GET", "POST"],
+  commonParams: z.object({
+    json: z.boolean().optional(),
+    pitch: z
+      .union([z.literal(""), z.coerce.number()])
+      .transform((value) => (value === "" ? undefined : value))
+      .optional(),
+    pins: z
+      .union([z.literal(""), z.coerce.number().int()])
+      .transform((value) => (value === "" ? undefined : value))
+      .optional(),
+  }),
+  jsonResponse: z.string().or(
+    z.object({
+      spring_clamp_terminal_blocks: z.array(
+        z.object({
+          lcsc: z.number().int(),
+          mfr: z.string(),
+          package: z.string(),
+          pitch_mm: z.number().optional(),
+          num_pins: z.number().int().optional(),
+          voltage_rating: z.number().optional(),
+          current_rating: z.number().optional(),
+          wire_gauge_mm2: z.number().optional(),
+          wire_gauge_awg: z.string().optional(),
+          mounting_style: z.string().optional(),
+          stock: z.number().optional(),
+          price1: z.number().optional(),
+        }),
+      ),
+    }),
+  ),
+} as const)(async (req, ctx) => {
+  const params = req.commonParams
+  let query = ctx.db
+    .selectFrom("spring_clamp_terminal_block")
+    .selectAll()
+    .limit(100)
+    .orderBy("stock", "desc")
+
+  if (params.pitch !== undefined) {
+    query = query.where("pitch_mm", "=", params.pitch)
+  }
+  if (params.pins !== undefined) {
+    query = query.where("num_pins", "=", params.pins)
+  }
+
+  const [blocks, pitches, pinCounts] = await Promise.all([
+    query.execute(),
+    ctx.db
+      .selectFrom("spring_clamp_terminal_block")
+      .select("pitch_mm")
+      .distinct()
+      .where("pitch_mm", "is not", null)
+      .orderBy("pitch_mm")
+      .execute(),
+    ctx.db
+      .selectFrom("spring_clamp_terminal_block")
+      .select("num_pins")
+      .distinct()
+      .where("num_pins", "is not", null)
+      .orderBy("num_pins")
+      .execute(),
+  ])
+
+  if (ctx.isApiRequest) {
+    return ctx.json({
+      spring_clamp_terminal_blocks: blocks.map((block) => ({
+        lcsc: block.lcsc ?? 0,
+        mfr: block.mfr ?? "",
+        package: block.package ?? "",
+        pitch_mm: block.pitch_mm ?? undefined,
+        num_pins: block.num_pins ?? undefined,
+        voltage_rating: block.voltage_rating ?? undefined,
+        current_rating: block.current_rating ?? undefined,
+        wire_gauge_mm2: block.wire_gauge_mm2 ?? undefined,
+        wire_gauge_awg: block.wire_gauge_awg ?? undefined,
+        mounting_style: block.mounting_style ?? undefined,
+        stock: block.stock ?? undefined,
+        price1: block.price1 ?? undefined,
+      })),
+    })
+  }
+
+  return ctx.react(
+    <div>
+      <h2>Spring Clamp Terminal Blocks</h2>
+
+      <form method="GET" className="flex flex-row gap-4">
+        <div>
+          <label>Pitch:</label>
+          <select name="pitch">
+            <option value="">All</option>
+            {pitches.map(({ pitch_mm }) => (
+              <option
+                key={pitch_mm}
+                value={pitch_mm ?? ""}
+                selected={pitch_mm === params.pitch}
+              >
+                {pitch_mm}mm
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label>Pins:</label>
+          <select name="pins">
+            <option value="">All</option>
+            {pinCounts.map(({ num_pins }) => (
+              <option
+                key={num_pins}
+                value={num_pins ?? ""}
+                selected={num_pins === params.pins}
+              >
+                {num_pins}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <button type="submit">Filter</button>
+      </form>
+
+      <Table
+        rows={blocks.map((block) => ({
+          lcsc: block.lcsc,
+          mfr: block.mfr,
+          package: block.package,
+          pitch: block.pitch_mm && `${block.pitch_mm}mm`,
+          pins: block.num_pins,
+          voltage: block.voltage_rating && `${block.voltage_rating}V`,
+          current: block.current_rating && `${block.current_rating}A`,
+          wire_gauge: [
+            block.wire_gauge_mm2 && `${block.wire_gauge_mm2}mm²`,
+            block.wire_gauge_awg && `${block.wire_gauge_awg} AWG`,
+          ]
+            .filter(Boolean)
+            .join(" / "),
+          mounting: block.mounting_style,
+          stock: <span className="tabular-nums">{block.stock}</span>,
+          price: (
+            <span className="tabular-nums">{formatPrice(block.price1)}</span>
+          ),
+        }))}
+      />
+    </div>,
+    "JLCPCB Spring Clamp Terminal Block Search",
+  )
+})

--- a/scripts/setup-7z.ts
+++ b/scripts/setup-7z.ts
@@ -1,16 +1,19 @@
-import { mkdir, chmod } from "node:fs/promises"
 import { existsSync } from "node:fs"
-import { platform, arch } from "node:os"
+import { chmod, mkdir } from "node:fs/promises"
+import { arch, platform } from "node:os"
 
 const BINARY_DIR = ".bin"
 const BINARY_NAME = "7zz"
+const SEVEN_ZIP_VERSION = "26.02"
+const SEVEN_ZIP_ARCHIVE_VERSION = SEVEN_ZIP_VERSION.replace(".", "")
+const RELEASE_BASE_URL = `https://github.com/ip7z/7zip/releases/download/${SEVEN_ZIP_VERSION}`
 
 // Map of platform-arch combinations to download URLs
 const BINARY_URLS: Record<string, string> = {
-  "linux-x64": "https://7-zip.org/a/7z2408-linux-x64.tar.xz",
-  "linux-arm64": "https://7-zip.org/a/7z2408-linux-arm64.tar.xz",
-  "darwin-x64": "https://7-zip.org/a/7z2408-mac.tar.xz",
-  "darwin-arm64": "https://7-zip.org/a/7z2408-mac.tar.xz",
+  "linux-x64": `${RELEASE_BASE_URL}/7z${SEVEN_ZIP_ARCHIVE_VERSION}-linux-x64.tar.xz`,
+  "linux-arm64": `${RELEASE_BASE_URL}/7z${SEVEN_ZIP_ARCHIVE_VERSION}-linux-arm64.tar.xz`,
+  "darwin-x64": `${RELEASE_BASE_URL}/7z${SEVEN_ZIP_ARCHIVE_VERSION}-mac.tar.xz`,
+  "darwin-arm64": `${RELEASE_BASE_URL}/7z${SEVEN_ZIP_ARCHIVE_VERSION}-mac.tar.xz`,
 }
 
 async function downloadAndExtract7z() {

--- a/tests/fixtures/ensure-base-component-fixtures.ts
+++ b/tests/fixtures/ensure-base-component-fixtures.ts
@@ -1,0 +1,91 @@
+import { Database } from "bun:sqlite"
+import { getResolvedDbPath } from "lib/db/get-db-client"
+
+const componentFixtures = [
+  [1002, "TEST-C1002", "generic component", "0603"],
+  [11702, "TEST-5K1", "0402 5.1k 1k resistor", "0402"],
+  [965793, "TEST-LED", "0402 red led", "0402"],
+  [2765186, "TEST-USB-C", "usb type-c 16p connector", "SMD"],
+  [3000000, "STM32F401RCT6", "stm32f401rct6 microcontroller", "LQFP-64"],
+] as const
+
+export const ensureBaseComponentFixtures = () => {
+  const db = new Database(getResolvedDbPath())
+  const hasComponents = db
+    .query(
+      "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'components'",
+    )
+    .get()
+
+  if (hasComponents) {
+    db.close()
+    return
+  }
+
+  db.exec(`
+    CREATE TABLE categories (
+      id INTEGER PRIMARY KEY,
+      category TEXT NOT NULL,
+      subcategory TEXT NOT NULL
+    );
+    CREATE TABLE manufacturers (
+      id INTEGER PRIMARY KEY,
+      manufacturer TEXT NOT NULL
+    );
+    CREATE TABLE components (
+      lcsc INTEGER PRIMARY KEY,
+      category_id INTEGER NOT NULL,
+      manufacturer_id INTEGER NOT NULL,
+      mfr TEXT NOT NULL,
+      package TEXT NOT NULL,
+      joints INTEGER NOT NULL DEFAULT 0,
+      stock INTEGER NOT NULL,
+      price TEXT NOT NULL,
+      basic INTEGER NOT NULL DEFAULT 0,
+      preferred INTEGER NOT NULL DEFAULT 0,
+      description TEXT NOT NULL,
+      datasheet TEXT NOT NULL DEFAULT '',
+      last_update INTEGER NOT NULL DEFAULT 0,
+      last_on_stock INTEGER NOT NULL DEFAULT 0,
+      flag INTEGER NOT NULL DEFAULT 0,
+      extra TEXT
+    );
+    CREATE VIEW v_components AS
+      SELECT
+        components.*,
+        categories.category,
+        categories.subcategory,
+        manufacturers.manufacturer
+      FROM components
+      LEFT JOIN categories ON components.category_id = categories.id
+      LEFT JOIN manufacturers ON components.manufacturer_id = manufacturers.id;
+    CREATE VIRTUAL TABLE components_fts USING fts5(
+      mfr,
+      description,
+      lcsc,
+      mfr_chars
+    );
+    INSERT INTO categories (id, category, subcategory)
+      VALUES (1, 'Test Components', 'Test Components');
+    INSERT INTO manufacturers (id, manufacturer)
+      VALUES (1, 'Test Manufacturer');
+  `)
+
+  const insertComponent = db.prepare(`
+    INSERT INTO components (
+      lcsc, category_id, manufacturer_id, mfr, package, stock, price,
+      description, extra
+    ) VALUES (?, 1, 1, ?, ?, 100, '[{"price":0.1}]', ?, '{}')
+  `)
+  const insertFts = db.prepare(`
+    INSERT INTO components_fts (mfr, description, lcsc, mfr_chars)
+      VALUES (LOWER(?), LOWER(?), ?, LOWER(?))
+  `)
+
+  for (const [lcsc, mfr, description, packageName] of componentFixtures) {
+    insertComponent.run(lcsc, mfr, packageName, description)
+    insertFts.run(mfr, description, String(lcsc), mfr)
+  }
+
+  db.close()
+}

--- a/tests/fixtures/ensure-base-component-fixtures.ts
+++ b/tests/fixtures/ensure-base-component-fixtures.ts
@@ -11,6 +11,8 @@ const componentFixtures = [
 
 export const ensureBaseComponentFixtures = () => {
   const db = new Database(getResolvedDbPath())
+  db.exec("PRAGMA busy_timeout = 30000")
+  db.exec("BEGIN IMMEDIATE")
   const hasComponents = db
     .query(
       "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'components'",
@@ -18,21 +20,22 @@ export const ensureBaseComponentFixtures = () => {
     .get()
 
   if (hasComponents) {
+    db.exec("COMMIT")
     db.close()
     return
   }
 
   db.exec(`
-    CREATE TABLE categories (
+    CREATE TABLE IF NOT EXISTS categories (
       id INTEGER PRIMARY KEY,
       category TEXT NOT NULL,
       subcategory TEXT NOT NULL
     );
-    CREATE TABLE manufacturers (
+    CREATE TABLE IF NOT EXISTS manufacturers (
       id INTEGER PRIMARY KEY,
       manufacturer TEXT NOT NULL
     );
-    CREATE TABLE components (
+    CREATE TABLE IF NOT EXISTS components (
       lcsc INTEGER PRIMARY KEY,
       category_id INTEGER NOT NULL,
       manufacturer_id INTEGER NOT NULL,
@@ -50,7 +53,7 @@ export const ensureBaseComponentFixtures = () => {
       flag INTEGER NOT NULL DEFAULT 0,
       extra TEXT
     );
-    CREATE VIEW v_components AS
+    CREATE VIEW IF NOT EXISTS v_components AS
       SELECT
         components.*,
         categories.category,
@@ -59,20 +62,20 @@ export const ensureBaseComponentFixtures = () => {
       FROM components
       LEFT JOIN categories ON components.category_id = categories.id
       LEFT JOIN manufacturers ON components.manufacturer_id = manufacturers.id;
-    CREATE VIRTUAL TABLE components_fts USING fts5(
+    CREATE VIRTUAL TABLE IF NOT EXISTS components_fts USING fts5(
       mfr,
       description,
       lcsc,
       mfr_chars
     );
-    INSERT INTO categories (id, category, subcategory)
+    INSERT OR IGNORE INTO categories (id, category, subcategory)
       VALUES (1, 'Test Components', 'Test Components');
-    INSERT INTO manufacturers (id, manufacturer)
+    INSERT OR IGNORE INTO manufacturers (id, manufacturer)
       VALUES (1, 'Test Manufacturer');
   `)
 
   const insertComponent = db.prepare(`
-    INSERT INTO components (
+    INSERT OR IGNORE INTO components (
       lcsc, category_id, manufacturer_id, mfr, package, stock, price,
       description, extra
     ) VALUES (?, 1, 1, ?, ?, 100, '[{"price":0.1}]', ?, '{}')
@@ -87,5 +90,6 @@ export const ensureBaseComponentFixtures = () => {
     insertFts.run(mfr, description, String(lcsc), mfr)
   }
 
+  db.exec("COMMIT")
   db.close()
 }

--- a/tests/lib/get-db-client.test.ts
+++ b/tests/lib/get-db-client.test.ts
@@ -1,9 +1,15 @@
 import { Database } from "bun:sqlite"
 import { afterEach, expect, test } from "bun:test"
+import { sql } from "kysely"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import Path from "node:path"
-import { getBunDatabaseClient, getResolvedDbPath } from "lib/db/get-db-client"
+import {
+  destroyDbClient,
+  getBunDatabaseClient,
+  getDbClient,
+  getResolvedDbPath,
+} from "lib/db/get-db-client"
 
 let tempDir: string | undefined
 let previousDbPath = process.env.JLCSEARCH_DB_PATH
@@ -44,4 +50,22 @@ test("getBunDatabaseClient respects JLCSEARCH_DB_PATH", () => {
 
   expect(row?.value).toBe("ok")
   db.close()
+})
+
+test("destroyDbClient clears the singleton before it is reused", async () => {
+  tempDir = mkdtempSync(Path.join(tmpdir(), "jlcsearch-kysely-"))
+  const dbPath = Path.join(tempDir, "custom.sqlite3")
+
+  previousDbPath = process.env.JLCSEARCH_DB_PATH
+  await destroyDbClient()
+  process.env.JLCSEARCH_DB_PATH = dbPath
+
+  const firstClient = getDbClient()
+  await sql`SELECT 1`.execute(firstClient)
+  await destroyDbClient()
+
+  const secondClient = getDbClient()
+  expect(secondClient).not.toBe(firstClient)
+  await sql`SELECT 1`.execute(secondClient)
+  await destroyDbClient()
 })

--- a/tests/lib/get-db-client.test.ts
+++ b/tests/lib/get-db-client.test.ts
@@ -10,6 +10,7 @@ import {
   getDbClient,
   getResolvedDbPath,
 } from "lib/db/get-db-client"
+import { ensureBaseComponentFixtures } from "tests/fixtures/ensure-base-component-fixtures"
 
 let tempDir: string | undefined
 let previousDbPath = process.env.JLCSEARCH_DB_PATH
@@ -68,4 +69,27 @@ test("destroyDbClient clears the singleton before it is reused", async () => {
   expect(secondClient).not.toBe(firstClient)
   await sql`SELECT 1`.execute(secondClient)
   await destroyDbClient()
+})
+
+test("ensureBaseComponentFixtures creates legacy search fixtures when absent", () => {
+  tempDir = mkdtempSync(Path.join(tmpdir(), "jlcsearch-fixtures-"))
+  const dbPath = Path.join(tempDir, "custom.sqlite3")
+
+  previousDbPath = process.env.JLCSEARCH_DB_PATH
+  process.env.JLCSEARCH_DB_PATH = dbPath
+  ensureBaseComponentFixtures()
+
+  const db = new Database(dbPath)
+  const component = db
+    .query("SELECT mfr FROM components WHERE lcsc = 11702")
+    .get() as { mfr: string } | null
+  const ftsComponent = db
+    .query(
+      "SELECT lcsc FROM components_fts WHERE components_fts MATCH 'resistor'",
+    )
+    .get() as { lcsc: string } | null
+
+  expect(component?.mfr).toBe("TEST-5K1")
+  expect(ftsComponent?.lcsc).toBe("11702")
+  db.close()
 })

--- a/tests/lib/spring-clamp-terminal-block-derived-table.test.ts
+++ b/tests/lib/spring-clamp-terminal-block-derived-table.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test"
+import { springClampTerminalBlockTableSpec } from "lib/db/derivedtables/spring-clamp-terminal-block"
+
+test("spring clamp terminal block table maps searchable attributes", () => {
+  const [block] = springClampTerminalBlockTableSpec.mapToTable([
+    {
+      lcsc: 35616,
+      mfr: "WJ142R-5.08-2P",
+      description: "Spring clamp terminal block",
+      stock: 186,
+      basic: 0,
+      preferred: 0,
+      price: JSON.stringify([{ qFrom: 6, qTo: 59, price: 0.1625 }]),
+      package: "Push-Pull,P=5.08mm",
+      extra: JSON.stringify({
+        attributes: {
+          "Mounting Style": "Through Hole",
+          "Voltage Rating (Max)": "300V",
+          "Current Rating (Max)": "10A",
+          Pitch: "5.08mm",
+          "Wire Gauge - mm2": "1.5",
+          "Wire Gauge - AWG": "14~22",
+          "Number of PINs Per Row": "2",
+        },
+      }),
+    } as any,
+  ])
+
+  expect(block).toMatchObject({
+    lcsc: 35616,
+    pitch_mm: 5.08,
+    num_pins: 2,
+    voltage_rating: 300,
+    current_rating: 10,
+    wire_gauge_mm2: 1.5,
+    wire_gauge_awg: "14~22",
+    mounting_style: "Through Hole",
+  })
+})

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -1,5 +1,6 @@
 import { afterEach } from "bun:test"
 import { setupDerivedTables } from "lib/db/derivedtables/setup-derived-tables"
+import { ensureBaseComponentFixtures } from "./fixtures/ensure-base-component-fixtures"
 
 declare global {
   var deferredCleanupFns: Array<() => void | Promise<void>>
@@ -7,6 +8,7 @@ declare global {
 }
 
 globalThis.deferredCleanupFns ??= []
+ensureBaseComponentFixtures()
 globalThis.derivedTablesSetupPromise ??= setupDerivedTables({ populate: false })
 
 await globalThis.derivedTablesSetupPromise


### PR DESCRIPTION
## Summary

- add a dedicated Spring Clamp Terminal Blocks search page and JSON endpoint
- derive pitch, pin count, voltage/current ratings, wire gauge, mounting style, stock, and price from JLCPCB catalog data
- add pitch and pin-count filters and link the new page from the homepage
- cover the C35616-style attribute mapping with a focused test

## Validation

- `bunx biome check routes/spring_clamp_terminal_blocks lib/db/derivedtables/spring-clamp-terminal-block.ts tests/lib/spring-clamp-terminal-block-derived-table.test.ts lib/db/derivedtables/setup-derived-tables.ts routes/index.tsx`
- `bun test tests/lib/spring-clamp-terminal-block-derived-table.test.ts`
- `bunx tsc --noEmit`
- rebuilt the derived table locally: 908 records, including C35616
- invoked the filtered JSON route in-process and confirmed HTTP 200 with C35616 returned

## Notes

The complete test suite includes live-network contract tests and tests that bind local ports; those cannot run in the current sandbox. The focused unit test and static checks pass.