### PR TITLE
feat: add is_extended_promotional column to components

### DIFF
--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -34,6 +35,7 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -660,6 +660,7 @@ export interface SearchIndex {
   basic: number | null
   category: string | null
   description: string | null
+  extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   manufacturer_name: string | null

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -108,6 +109,13 @@ export async function searchIndex(
 
   if (params.is_preferred === "true" || params.is_preferred === "1") {
     conditions.push(sql`search_index.preferred = 1`)
+  }
+
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`search_index.extended_promotional = 1`)
   }
 
   const raw = params.q?.trim()

--- a/lib/db/derivedtables/component-base.ts
+++ b/lib/db/derivedtables/component-base.ts
@@ -7,5 +7,6 @@ export interface BaseComponent {
   in_stock: boolean
   is_basic: boolean
   is_preferred: boolean
+  is_extended_promotional?: boolean
   attributes: Record<string, string>
 }

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -132,6 +132,7 @@ const createTable = async (
     { name: "stock", type: "integer" },
     { name: "price1", type: "real" },
     { name: "in_stock", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ].concat(spec.extraColumns as any, [{ name: "attributes", type: "text" }])) {
     tableCreator = tableCreator.addColumn(
       col.name as string,
@@ -166,6 +167,9 @@ const createTable = async (
         ? null
         : {
             ...c,
+            is_extended_promotional: Boolean(
+              (components[i] as any).extended_promotional,
+            ),
             attributes: jsonParseOrNull(components[i].extra)?.attributes,
           },
     )

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -190,6 +190,7 @@ export interface Component {
   category_id: number;
   datasheet: string;
   description: string;
+  extended_promotional: Generated<number | null>;
   extra: string | null;
   flag: Generated<number>;
   joints: number;


### PR DESCRIPTION
Closes #92

Adds is_extended_promotional support throughout the stack so callers can filter for components that temporarily function as basic parts during JLCPCB promotional periods.

Changes:
- lib/db/generated/kysely.ts: add extended_promotional field to Component interface
- lib/db/derivedtables/component-base.ts: add optional is_extended_promotional to BaseComponent
- lib/db/derivedtables/setup-derived-tables.ts: add is_extended_promotional as a base column on every derived table and inject it from raw component data during population (no individual table spec changes needed)
- cf-proxy/src/db/types.ts: add extended_promotional to SearchIndex
- cf-proxy/src/search.ts: support is_extended_promotional=true/1 query param
- cf-proxy/src/components.ts: forward is_extended_promotional param through to the search index query