### PR TITLE
Fix LCD display list and add LCD driver page

### DIFF
--- a/cf-proxy/src/d1-routes.ts
+++ b/cf-proxy/src/d1-routes.ts
@@ -20,6 +20,7 @@ type D1Handler = (db: Kysely<DB>, params: QueryParams) => Promise<D1QueryResult>
 
 const PROCESSOR_INTERFACES = ["uart", "i2c", "spi", "can", "usb"] as const
 const MICROPHONE_SUBCATEGORIES = ["Microphones", "MEMS Microphones"] as const
+const LCD_DRIVER_SUBCATEGORY = "LCD Drivers"
 
 const parseFiniteNumber = (value: string | undefined): number | null => {
   if (value === undefined || value === "") return null
@@ -34,6 +35,16 @@ const extractSmallQuantityPrice = (price: string | null): number => {
     return Number(priceObj[0]?.price ?? 0) || 0
   } catch {
     return 0
+  }
+}
+
+const extractAttributes = (extra: string | null): string => {
+  if (!extra) return "{}"
+  try {
+    const attributes = JSON.parse(extra)?.attributes
+    return JSON.stringify(attributes ?? {})
+  } catch {
+    return "{}"
   }
 }
 
@@ -278,6 +289,74 @@ const SPECIAL_D1_HANDLERS: Record<string, D1Handler> = {
             price1: extractSmallQuantityPrice(m.price),
           }))
           .filter((m) => m.lcsc !== 0 && m.package !== ""),
+      },
+    }
+  },
+  "/lcd_drivers/list": async (db, params) => {
+    let query = db
+      .selectFrom("component_catalog")
+      .select([
+        "lcsc",
+        "mfr",
+        "package",
+        "description",
+        "stock",
+        "price",
+        "basic",
+        "preferred",
+        "extra",
+      ])
+      .where("stock", ">", 0)
+      .where("subcategory", "=", LCD_DRIVER_SUBCATEGORY)
+      .orderBy("stock", "desc")
+      .limit(100)
+
+    if (params.package) {
+      query = query.where("package", "=", params.package)
+    }
+
+    if (params.is_basic === "true" || params.is_basic === "1") {
+      query = query.where("basic", "=", 1)
+    }
+
+    if (params.is_preferred === "true" || params.is_preferred === "1") {
+      query = query.where("preferred", "=", 1)
+    }
+
+    const [packages, lcdDrivers] = await Promise.all([
+      db
+        .selectFrom("component_catalog")
+        .select("package")
+        .distinct()
+        .where("subcategory", "=", LCD_DRIVER_SUBCATEGORY)
+        .where("package", "is not", null)
+        .orderBy("package")
+        .execute(),
+      query.execute(),
+    ])
+
+    return {
+      tableName: "lcd_driver",
+      filterOptions: {
+        package: getNonEmptyStrings(
+          packages as Array<Record<string, string | null>>,
+          "package",
+        ),
+      },
+      data: {
+        lcd_drivers: lcdDrivers
+          .map((driver) => ({
+            lcsc: driver.lcsc ?? 0,
+            mfr: driver.mfr ?? "",
+            package: driver.package ?? "",
+            description: driver.description ?? "",
+            is_basic: Boolean(driver.basic),
+            is_preferred: Boolean(driver.preferred),
+            stock: driver.stock ?? 0,
+            price1: extractSmallQuantityPrice(driver.price),
+            attributes: extractAttributes(driver.extra),
+          }))
+          .filter((driver) => driver.lcsc !== 0),
       },
     }
   },

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -56,6 +56,7 @@ const routeLabels: Record<string, string> = {
   "/oled_display/list": " OLED Displays Modules",
   "/led_segment_display/list": "LED Segment Display Modules",
   "/lcd_display/list": "LCD Display Modules",
+  "/lcd_drivers/list": "LCD Drivers",
   "/switches/list": "Switches",
   "/relays/list": "Relays",
   "/fuses/list": "Fuses",
@@ -491,6 +492,29 @@ const renderCustomFilters = (
               })
               .join("")}
           </select>
+        </div>
+        <button type="submit">Filter</button>
+      </form>`
+    }
+    case "/lcd_drivers/list": {
+      const packageOptions = filterOptions.package ?? []
+      const packageListId = getSuggestionListId(
+        pathname,
+        "package",
+        packageOptions,
+      )
+
+      return `<form method="GET" class="flex flex-row gap-4">
+        <div>
+          <label>Package:</label>
+          <input type="text" name="package" value="${escapeHtml(params.package ?? "")}"${packageListId ? ` list="${escapeHtml(packageListId)}"` : ""} autocomplete="on" />
+          ${renderFilterSuggestions(pathname, "package", packageOptions)}
+        </div>
+        <div>
+          <label>Basic Part:<input type="checkbox" name="is_basic" value="true"${params.is_basic === "true" ? " checked" : ""} /></label>
+        </div>
+        <div>
+          <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
         </div>
         <button type="submit">Filter</button>
       </form>`

--- a/cf-proxy/test/lcd-drivers-route.test.ts
+++ b/cf-proxy/test/lcd-drivers-route.test.ts
@@ -1,0 +1,102 @@
+import {
+  DummyDriver,
+  Kysely,
+  SqliteAdapter,
+  SqliteIntrospector,
+  SqliteQueryCompiler,
+  type CompiledQuery,
+  type DatabaseConnection,
+} from "kysely"
+import { describe, expect, it } from "vitest"
+import { getD1Handler } from "../src/d1-routes"
+import type { DB } from "../src/db/types"
+
+describe("LCD driver route", () => {
+  it("queries LCD driver chips and applies catalog filters", async () => {
+    const compiledQueries: CompiledQuery[] = []
+    const driver = new DummyDriver()
+
+    driver.acquireConnection = async () =>
+      ({
+        executeQuery: async (compiledQuery: CompiledQuery) => {
+          compiledQueries.push(compiledQuery)
+
+          if (compiledQuery.sql.includes('select distinct "package"')) {
+            return { rows: [{ package: "SSOP-48-300mil" }] }
+          }
+
+          return {
+            rows: [
+              {
+                lcsc: 7873,
+                mfr: "HT1621B",
+                package: "SSOP-48-300mil",
+                description: "LCD driver",
+                stock: 18416,
+                price: '[{"qFrom":1,"price":0.464285714}]',
+                basic: 0,
+                preferred: 1,
+                extra: '{"attributes":{"Interface":"Serial"}}',
+              },
+            ],
+          }
+        },
+        streamQuery: async function* () {},
+      }) as DatabaseConnection
+
+    const db = new Kysely<DB>({
+      dialect: {
+        createAdapter: () => new SqliteAdapter(),
+        createDriver: () => driver,
+        createIntrospector: (database) => new SqliteIntrospector(database),
+        createQueryCompiler: () => new SqliteQueryCompiler(),
+      },
+    })
+
+    try {
+      const handler = getD1Handler("/lcd_drivers/list")
+      expect(handler).not.toBeNull()
+
+      const result = await handler!(db, {
+        package: "SSOP-48-300mil",
+        is_preferred: "true",
+      })
+
+      expect(result).toEqual({
+        tableName: "lcd_driver",
+        filterOptions: { package: ["SSOP-48-300mil"] },
+        data: {
+          lcd_drivers: [
+            {
+              lcsc: 7873,
+              mfr: "HT1621B",
+              package: "SSOP-48-300mil",
+              description: "LCD driver",
+              is_basic: false,
+              is_preferred: true,
+              stock: 18416,
+              price1: 0.464285714,
+              attributes: '{"Interface":"Serial"}',
+            },
+          ],
+        },
+      })
+
+      const partsQuery = compiledQueries.find(
+        (query) => !query.sql.includes('select distinct "package"'),
+      )
+      expect(partsQuery?.sql).toContain('"subcategory" = ?')
+      expect(partsQuery?.sql).toContain('"package" = ?')
+      expect(partsQuery?.sql).toContain('"preferred" = ?')
+      expect(partsQuery?.parameters).toEqual([
+        0,
+        "LCD Drivers",
+        "SSOP-48-300mil",
+        1,
+        100,
+      ])
+    } finally {
+      await db.destroy()
+    }
+  })
+})

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -8,6 +8,7 @@ describe("render helpers", () => {
 
     expect(html).toContain("JLCPCB In-Stock Parts Engine (Unofficial)")
     expect(html).toContain("/led_with_ic/list")
+    expect(html).toContain("/lcd_drivers/list")
     expect(html).toContain("/resistors/list")
     expect(html).toContain("/spring_clamp_terminal_blocks/list")
   })
@@ -40,6 +41,37 @@ describe("render helpers", () => {
     expect(html).toContain('name="pins"')
     expect(html).toContain("WJ142R-5.08-2P")
     expect(html).toContain("/spring_clamp_terminal_blocks/list.json")
+  })
+
+  it("renders the LCD driver catalog route with package and assembly filters", () => {
+    expect(D1_ROUTES).toContain("/lcd_drivers/list")
+    expect(getD1Handler("/lcd_drivers/list")).toBeTypeOf("function")
+
+    const html = renderD1TablePage(
+      "/lcd_drivers/list",
+      {
+        lcd_drivers: [
+          {
+            lcsc: 7873,
+            mfr: "HT1621B",
+            package: "SSOP-48-300mil",
+            is_basic: false,
+            is_preferred: true,
+            stock: 18416,
+          },
+        ],
+      },
+      { package: "SSOP-48-300mil", is_preferred: "true" },
+      "https://jlcsearch.tscircuit.com/lcd_drivers/list?package=SSOP-48-300mil&is_preferred=true",
+      { package: ["SSOP-48-300mil"] },
+    )
+
+    expect(html).toContain("<h2>LCD Drivers</h2>")
+    expect(html).toContain('name="package"')
+    expect(html).toContain('name="is_basic"')
+    expect(html).toContain('name="is_preferred" value="true" checked')
+    expect(html).toContain("HT1621B")
+    expect(html).toContain("/lcd_drivers/list.json")
   })
 
   it("renders an HTML table page for a supported D1 route", () => {

--- a/lib/db/derivedtables/lcd_display.ts
+++ b/lib/db/derivedtables/lcd_display.ts
@@ -3,6 +3,12 @@ import type { KyselyDatabaseInstance } from "../kysely-types"
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
 import { BaseComponent } from "./component-base"
 
+const LCD_DISPLAY_SUBCATEGORIES = [
+  "LCD Displays Modules",
+  "Liquid Crystal Display Screen",
+  "LCD Screen",
+] as const
+
 export interface LCDDisplay extends BaseComponent {
   package?: string
   display_size?: string
@@ -25,7 +31,7 @@ export const lcdDisplayTableSpec: DerivedTableSpec<LCDDisplay> = {
       .selectFrom("components")
       .innerJoin("categories", "components.category_id", "categories.id")
       .selectAll()
-      .where((eb) => eb("description", "like", "%LCD%"))
+      .where("categories.subcategory", "in", [...LCD_DISPLAY_SUBCATEGORIES])
   },
   mapToTable(components) {
     return components.map((c) => {

--- a/tests/lib/lcd-display-derived-table.test.ts
+++ b/tests/lib/lcd-display-derived-table.test.ts
@@ -1,0 +1,53 @@
+import { Database } from "bun:sqlite"
+import { expect, test } from "bun:test"
+import { Kysely } from "kysely"
+import { BunSqliteDialect } from "kysely-bun-sqlite"
+import { lcdDisplayTableSpec } from "lib/db/derivedtables/lcd_display"
+
+test("lcd display table selects display subcategories when descriptions are blank", async () => {
+  const database = new Database(":memory:")
+  const db = new Kysely<any>({
+    dialect: new BunSqliteDialect({ database }),
+  })
+
+  try {
+    await db.schema
+      .createTable("categories")
+      .addColumn("id", "integer", (column) => column.primaryKey())
+      .addColumn("subcategory", "text", (column) => column.notNull())
+      .execute()
+    await db.schema
+      .createTable("components")
+      .addColumn("lcsc", "integer", (column) => column.primaryKey())
+      .addColumn("category_id", "integer", (column) => column.notNull())
+      .addColumn("description", "text", (column) => column.notNull())
+      .execute()
+
+    await db
+      .insertInto("categories")
+      .values([
+        { id: 1, subcategory: "LCD Displays Modules" },
+        { id: 2, subcategory: "Liquid Crystal Display Screen" },
+        { id: 3, subcategory: "LCD Screen" },
+        { id: 4, subcategory: "LCD Drivers" },
+      ])
+      .execute()
+    await db
+      .insertInto("components")
+      .values([
+        { lcsc: 1, category_id: 1, description: "" },
+        { lcsc: 2, category_id: 2, description: "" },
+        { lcsc: 3, category_id: 3, description: "" },
+        { lcsc: 4, category_id: 4, description: "LCD driver" },
+      ])
+      .execute()
+
+    const candidates = await lcdDisplayTableSpec
+      .listCandidateComponents(db)
+      .execute()
+
+    expect(candidates.map((candidate) => candidate.lcsc)).toEqual([1, 2, 3])
+  } finally {
+    await db.destroy()
+  }
+})


### PR DESCRIPTION
## Summary

- populate the LCD display derived table from current and historical LCD display subcategories
- add a separate `/lcd_drivers/list` page backed by the existing component catalog
- support package, Basic, and Preferred filters on the LCD driver page
- show LCD driver pricing, stock, and catalog attributes
- add regression coverage for candidate selection, driver queries, filters, and rendering

## Root cause

The LCD display derived-table builder selected candidates with a `description LIKE "%LCD%"` predicate. Synced catalog descriptions are now blank, so rebuilds produced an empty `lcd_display` table even though LCD modules remain available under dedicated subcategories.

LCD driver ICs are intentionally kept separate from display modules. The new driver route selects the existing `LCD Drivers` catalog subcategory directly, avoiding a second derived table and excluding unrelated display hardware.

## Impact

- after rebuilding and syncing `lcd_display`, `/lcd_display/list` and its JSON endpoint will return LCD modules again
- after deploying the worker, `/lcd_drivers/list` and `/lcd_drivers/list.json` will list in-stock LCD driver chips without an additional database rebuild

## Validation

- `bun test` — 141 tests passed
- targeted LCD driver route and rendering tests — 6 tests passed
- `bunx tsc --noEmit`
- `bunx tsc --noEmit --project cf-proxy/tsconfig.json`
- `bun run format:check`
- `git diff --check`