### PR TITLE
Add TFT display driver catalog page

### DIFF
--- a/cf-proxy/src/d1-routes.ts
+++ b/cf-proxy/src/d1-routes.ts
@@ -1,6 +1,12 @@
 import type { Kysely } from "kysely"
 import type { DB } from "./db/types"
 import {
+  getTftDisplayDriverFamily,
+  getTftDisplayDriverPatterns,
+  TFT_DISPLAY_DRIVER_FAMILIES,
+  TFT_DISPLAY_DRIVER_SUBCATEGORIES,
+} from "./tft-display-drivers"
+import {
   queryFilterOptions,
   queryTable,
   ROUTE_TO_TABLE,
@@ -52,6 +58,17 @@ const getNonEmptyStrings = (
   rows: Array<Record<string, string | null>>,
   key: string,
 ): string[] => rows.map((row) => row[key]?.trim() ?? "").filter(Boolean)
+
+const selectTftDriverCatalog = (
+  db: Kysely<DB>,
+  driverType: string | undefined,
+) => {
+  const patterns = getTftDisplayDriverPatterns(driverType)
+  return db
+    .selectFrom("component_catalog")
+    .where("subcategory", "in", [...TFT_DISPLAY_DRIVER_SUBCATEGORIES])
+    .where((eb) => eb.or(patterns.map((pattern) => eb("mfr", "like", pattern))))
+}
 
 const getMicrocontrollerListHandler = (
   tableName: "arm_processor" | "risc_v_processor",
@@ -349,6 +366,76 @@ const SPECIAL_D1_HANDLERS: Record<string, D1Handler> = {
             lcsc: driver.lcsc ?? 0,
             mfr: driver.mfr ?? "",
             package: driver.package ?? "",
+            description: driver.description ?? "",
+            is_basic: Boolean(driver.basic),
+            is_preferred: Boolean(driver.preferred),
+            stock: driver.stock ?? 0,
+            price1: extractSmallQuantityPrice(driver.price),
+            attributes: extractAttributes(driver.extra),
+          }))
+          .filter((driver) => driver.lcsc !== 0),
+      },
+    }
+  },
+  "/tft_display_drivers/list": async (db, params) => {
+    let query = selectTftDriverCatalog(db, params.driver_type)
+      .select([
+        "lcsc",
+        "mfr",
+        "package",
+        "description",
+        "stock",
+        "price",
+        "basic",
+        "preferred",
+        "subcategory",
+        "extra",
+      ])
+      .where("stock", ">", 0)
+      .orderBy("stock", "desc")
+      .limit(100)
+
+    if (params.package) {
+      query = query.where("package", "=", params.package)
+    }
+
+    if (params.is_basic === "true" || params.is_basic === "1") {
+      query = query.where("basic", "=", 1)
+    }
+
+    if (params.is_preferred === "true" || params.is_preferred === "1") {
+      query = query.where("preferred", "=", 1)
+    }
+
+    const [packages, tftDrivers] = await Promise.all([
+      selectTftDriverCatalog(db, params.driver_type)
+        .select("package")
+        .distinct()
+        .where("package", "is not", null)
+        .orderBy("package")
+        .execute(),
+      query.execute(),
+    ])
+
+    return {
+      tableName: "tft_display_driver",
+      filterOptions: {
+        package: getNonEmptyStrings(
+          packages as Array<Record<string, string | null>>,
+          "package",
+        ),
+        driver_type: TFT_DISPLAY_DRIVER_FAMILIES.map((family) => family.value),
+      },
+      data: {
+        tft_display_drivers: tftDrivers
+          .map((driver) => ({
+            lcsc: driver.lcsc ?? 0,
+            mfr: driver.mfr ?? "",
+            package: driver.package ?? "",
+            driver_type:
+              getTftDisplayDriverFamily(driver.mfr)?.label ??
+              "TFT Display Driver",
+            catalog_type: driver.subcategory ?? "",
             description: driver.description ?? "",
             is_basic: Boolean(driver.basic),
             is_preferred: Boolean(driver.preferred),

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -5,6 +5,7 @@ import {
   type QueryParams,
   type FilterOptions,
 } from "./handlers"
+import { TFT_DISPLAY_DRIVER_FAMILIES } from "./tft-display-drivers"
 
 const escapeHtml = (value: unknown): string =>
   String(value ?? "")
@@ -57,6 +58,7 @@ const routeLabels: Record<string, string> = {
   "/led_segment_display/list": "LED Segment Display Modules",
   "/lcd_display/list": "LCD Display Modules",
   "/lcd_drivers/list": "LCD Drivers",
+  "/tft_display_drivers/list": "TFT Display Drivers",
   "/switches/list": "Switches",
   "/relays/list": "Relays",
   "/fuses/list": "Fuses",
@@ -509,6 +511,38 @@ const renderCustomFilters = (
           <label>Package:</label>
           <input type="text" name="package" value="${escapeHtml(params.package ?? "")}"${packageListId ? ` list="${escapeHtml(packageListId)}"` : ""} autocomplete="on" />
           ${renderFilterSuggestions(pathname, "package", packageOptions)}
+        </div>
+        <div>
+          <label>Basic Part:<input type="checkbox" name="is_basic" value="true"${params.is_basic === "true" ? " checked" : ""} /></label>
+        </div>
+        <div>
+          <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
+        </div>
+        <button type="submit">Filter</button>
+      </form>`
+    }
+    case "/tft_display_drivers/list": {
+      const packageOptions = filterOptions.package ?? []
+      const packageListId = getSuggestionListId(
+        pathname,
+        "package",
+        packageOptions,
+      )
+      return `<form method="GET" class="flex flex-row gap-4">
+        <div>
+          <label>Package:</label>
+          <input type="text" name="package" value="${escapeHtml(params.package ?? "")}"${packageListId ? ` list="${escapeHtml(packageListId)}"` : ""} autocomplete="on" />
+          ${renderFilterSuggestions(pathname, "package", packageOptions)}
+        </div>
+        <div>
+          <label>Driver Type:</label>
+          <select name="driver_type">
+            <option value="">All</option>
+            ${TFT_DISPLAY_DRIVER_FAMILIES.map(
+              ({ value, label }) =>
+                `<option value="${escapeHtml(value)}"${params.driver_type === value ? " selected" : ""}>${escapeHtml(label)}</option>`,
+            ).join("")}
+          </select>
         </div>
         <div>
           <label>Basic Part:<input type="checkbox" name="is_basic" value="true"${params.is_basic === "true" ? " checked" : ""} /></label>

--- a/cf-proxy/src/tft-display-drivers.ts
+++ b/cf-proxy/src/tft-display-drivers.ts
@@ -1,0 +1,67 @@
+export const TFT_DISPLAY_DRIVER_SUBCATEGORIES = [
+  "LCD Drivers",
+  "LED Drivers",
+] as const
+
+export const TFT_DISPLAY_DRIVER_FAMILIES = [
+  {
+    value: "controller",
+    label: "Display Controller",
+    patterns: [
+      "SSD1963%",
+      "SSD1289%",
+      "LT768%",
+      "RA887%",
+      "ILI9%",
+      "HX83%",
+      "S1D13%",
+      "ST77%",
+      "NT355%",
+      "RM68%",
+      "GC9%",
+    ],
+  },
+  {
+    value: "bias_power",
+    label: "Bias / Power",
+    patterns: [
+      "TPS651%",
+      "AW375%",
+      "MAX171%",
+      "MAX174%",
+      "MAX879%",
+      "RT48%",
+      "NT503%",
+    ],
+  },
+  {
+    value: "gamma_buffer",
+    label: "Gamma Buffer",
+    patterns: ["BUF168%", "AS15%"],
+  },
+  {
+    value: "backlight",
+    label: "Backlight Driver",
+    patterns: ["AP3041%", "AP5727%", "LP886%", "BD947%", "MAX20078%", "AL335%"],
+  },
+] as const
+
+export const getTftDisplayDriverFamily = (mfr: string | null) => {
+  const normalizedMfr = mfr?.toUpperCase() ?? ""
+  return TFT_DISPLAY_DRIVER_FAMILIES.find((family) =>
+    family.patterns.some((pattern) =>
+      normalizedMfr.startsWith(pattern.slice(0, -1).toUpperCase()),
+    ),
+  )
+}
+
+export const getTftDisplayDriverPatterns = (
+  driverType: string | undefined,
+): string[] => {
+  const selectedFamily = TFT_DISPLAY_DRIVER_FAMILIES.find(
+    (family) => family.value === driverType,
+  )
+  return selectedFamily
+    ? [...selectedFamily.patterns]
+    : TFT_DISPLAY_DRIVER_FAMILIES.flatMap((family) => [...family.patterns])
+}

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -9,6 +9,7 @@ describe("render helpers", () => {
     expect(html).toContain("JLCPCB In-Stock Parts Engine (Unofficial)")
     expect(html).toContain("/led_with_ic/list")
     expect(html).toContain("/lcd_drivers/list")
+    expect(html).toContain("/tft_display_drivers/list")
     expect(html).toContain("/resistors/list")
     expect(html).toContain("/spring_clamp_terminal_blocks/list")
   })
@@ -72,6 +73,36 @@ describe("render helpers", () => {
     expect(html).toContain('name="is_preferred" value="true" checked')
     expect(html).toContain("HT1621B")
     expect(html).toContain("/lcd_drivers/list.json")
+  })
+
+  it("renders the TFT display driver route with driver type filters", () => {
+    expect(D1_ROUTES).toContain("/tft_display_drivers/list")
+    expect(getD1Handler("/tft_display_drivers/list")).toBeTypeOf("function")
+
+    const html = renderD1TablePage(
+      "/tft_display_drivers/list",
+      {
+        tft_display_drivers: [
+          {
+            lcsc: 15216,
+            mfr: "SSD1963QL9",
+            package: "LQFP-128(14x14)",
+            driver_type: "Display Controller",
+            stock: 604,
+          },
+        ],
+      },
+      { driver_type: "controller", is_preferred: "true" },
+      "https://jlcsearch.tscircuit.com/tft_display_drivers/list?driver_type=controller&is_preferred=true",
+      { package: ["LQFP-128(14x14)"] },
+    )
+
+    expect(html).toContain("<h2>TFT Display Drivers</h2>")
+    expect(html).toContain('name="driver_type"')
+    expect(html).toContain('value="controller" selected')
+    expect(html).toContain("Display Controller")
+    expect(html).toContain("SSD1963QL9")
+    expect(html).toContain("/tft_display_drivers/list.json")
   })
 
   it("renders an HTML table page for a supported D1 route", () => {

--- a/cf-proxy/test/tft-display-drivers-route.test.ts
+++ b/cf-proxy/test/tft-display-drivers-route.test.ts
@@ -1,0 +1,114 @@
+import {
+  DummyDriver,
+  Kysely,
+  SqliteAdapter,
+  SqliteIntrospector,
+  SqliteQueryCompiler,
+  type CompiledQuery,
+  type DatabaseConnection,
+} from "kysely"
+import { describe, expect, it } from "vitest"
+import { getD1Handler } from "../src/d1-routes"
+import type { DB } from "../src/db/types"
+import { getTftDisplayDriverFamily } from "../src/tft-display-drivers"
+
+describe("TFT display driver route", () => {
+  it("classifies TFT support families without including segment LCD drivers", () => {
+    expect(getTftDisplayDriverFamily("SSD1963QL9")?.label).toBe(
+      "Display Controller",
+    )
+    expect(getTftDisplayDriverFamily("TPS65132B5YFFR")?.label).toBe(
+      "Bias / Power",
+    )
+    expect(getTftDisplayDriverFamily("BUF16821AIPWPR")?.label).toBe(
+      "Gamma Buffer",
+    )
+    expect(getTftDisplayDriverFamily("AP3041MTR-G1")?.label).toBe(
+      "Backlight Driver",
+    )
+    expect(getTftDisplayDriverFamily("HT1621B")).toBeUndefined()
+  })
+
+  it("selects and labels TFT controller families", async () => {
+    const compiledQueries: CompiledQuery[] = []
+    const driver = new DummyDriver()
+
+    driver.acquireConnection = async () =>
+      ({
+        executeQuery: async (compiledQuery: CompiledQuery) => {
+          compiledQueries.push(compiledQuery)
+
+          if (compiledQuery.sql.includes('select distinct "package"')) {
+            return { rows: [{ package: "LQFP-128(14x14)" }] }
+          }
+
+          return {
+            rows: [
+              {
+                lcsc: 15216,
+                mfr: "SSD1963QL9",
+                package: "LQFP-128(14x14)",
+                description: "TFT LCD controller",
+                stock: 604,
+                price: '[{"qFrom":1,"price":5.845714286}]',
+                basic: 0,
+                preferred: 1,
+                subcategory: "LCD Drivers",
+                extra: '{"attributes":{"Interface":"8080/6800"}}',
+              },
+            ],
+          }
+        },
+        streamQuery: async function* () {},
+      }) as DatabaseConnection
+
+    const db = new Kysely<DB>({
+      dialect: {
+        createAdapter: () => new SqliteAdapter(),
+        createDriver: () => driver,
+        createIntrospector: (database) => new SqliteIntrospector(database),
+        createQueryCompiler: () => new SqliteQueryCompiler(),
+      },
+    })
+
+    try {
+      const handler = getD1Handler("/tft_display_drivers/list")
+      expect(handler).not.toBeNull()
+
+      const result = await handler!(db, {
+        driver_type: "controller",
+        package: "LQFP-128(14x14)",
+        is_preferred: "true",
+      })
+
+      expect(result.data.tft_display_drivers).toEqual([
+        {
+          lcsc: 15216,
+          mfr: "SSD1963QL9",
+          package: "LQFP-128(14x14)",
+          driver_type: "Display Controller",
+          catalog_type: "LCD Drivers",
+          description: "TFT LCD controller",
+          is_basic: false,
+          is_preferred: true,
+          stock: 604,
+          price1: 5.845714286,
+          attributes: '{"Interface":"8080/6800"}',
+        },
+      ])
+      expect(result.filterOptions?.package).toEqual(["LQFP-128(14x14)"])
+
+      const partsQuery = compiledQueries.find(
+        (query) => !query.sql.includes('select distinct "package"'),
+      )
+      expect(partsQuery?.sql).toContain('"subcategory" in (?, ?)')
+      expect(partsQuery?.sql).toContain('"mfr" like ?')
+      expect(partsQuery?.sql).toContain('"package" = ?')
+      expect(partsQuery?.sql).toContain('"preferred" = ?')
+      expect(partsQuery?.parameters).toContain("SSD1963%")
+      expect(partsQuery?.parameters).not.toContain("TPS651%")
+    } finally {
+      await db.destroy()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- add a new `/tft_display_drivers/list` page and JSON endpoint
- classify in-stock TFT support ICs as display controllers, bias/power ICs, gamma buffers, or backlight drivers
- add package, driver type, basic-part, and preferred-part filters
- exclude segment-only LCD driver families such as HT1621
- add route-selection, classification, query, mapping, and rendering coverage

## Data selection

JLCPCB's catalog does not expose a dedicated TFT-driver subcategory. The route therefore starts with the existing `LCD Drivers` and `LED Drivers` catalog groups, then selects curated TFT-oriented manufacturer family prefixes. The current production catalog includes matching parts such as SSD1963 controllers, TPS651/AW375 bias ICs, BUF168 gamma buffers, and AP3041/AP5727 backlight drivers.

No derived-table rebuild is required; the page reads directly from `component_catalog`.

## Validation

- `bun test` — 144 passed
- `bunx tsc --noEmit`
- `bunx tsc --noEmit --project cf-proxy/tsconfig.json`
- `bun run format:check`
- `git diff --check`