### PR TITLE
Add BLE module and chip pages

### DIFF
--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -25,6 +25,8 @@ DERIVED_TABLES=(
   analog_multiplexer
   battery_holder
   bjt_transistor
+  ble_chip
+  ble_module
   boost_converter
   buck_boost_converter
   capacitor

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -95,6 +95,53 @@ export interface BatteryHolder {
   stock: number | null
 }
 
+export interface BleChip {
+  attributes: string | null
+  bluetooth_version: string | null
+  core_processor: string | null
+  data_rate_mbps: number | null
+  description: string | null
+  frequency_ghz: number | null
+  has_i2c: number | null
+  has_spi: number | null
+  has_uart: number | null
+  has_usb: number | null
+  in_stock: number | null
+  is_basic: number | null
+  is_preferred: number | null
+  lcsc: Generated<number | null>
+  mfr: string | null
+  operating_voltage_max: number | null
+  operating_voltage_min: number | null
+  package: string | null
+  price1: number | null
+  stock: number | null
+}
+
+export interface BleModule {
+  antenna_type: string | null
+  attributes: string | null
+  bluetooth_version: string | null
+  core_processor: string | null
+  data_rate_mbps: number | null
+  description: string | null
+  frequency_ghz: number | null
+  has_i2c: number | null
+  has_spi: number | null
+  has_uart: number | null
+  has_usb: number | null
+  in_stock: number | null
+  is_basic: number | null
+  is_preferred: number | null
+  lcsc: Generated<number | null>
+  mfr: string | null
+  operating_voltage_max: number | null
+  operating_voltage_min: number | null
+  package: string | null
+  price1: number | null
+  stock: number | null
+}
+
 export interface BjtTransistor {
   attributes: string | null
   collector_current: number | null
@@ -861,6 +908,8 @@ export interface DB {
   adc: Adc
   analog_multiplexer: AnalogMultiplexer
   battery_holder: BatteryHolder
+  ble_chip: BleChip
+  ble_module: BleModule
   bjt_transistor: BjtTransistor
   boost_converter: BoostConverter
   buck_boost_converter: BuckBoostConverter

--- a/cf-proxy/src/handlers/index.ts
+++ b/cf-proxy/src/handlers/index.ts
@@ -293,6 +293,29 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       battery_type: { field: "battery_type", type: "string" },
     },
   },
+  ble_chip: {
+    filters: {
+      package: { field: "package", type: "string" },
+      bluetooth_version: { field: "bluetooth_version", type: "string" },
+      core_processor: { field: "core_processor", type: "string" },
+      has_uart: { field: "has_uart", type: "boolean" },
+      has_i2c: { field: "has_i2c", type: "boolean" },
+      has_spi: { field: "has_spi", type: "boolean" },
+      has_usb: { field: "has_usb", type: "boolean" },
+    },
+  },
+  ble_module: {
+    filters: {
+      package: { field: "package", type: "string" },
+      bluetooth_version: { field: "bluetooth_version", type: "string" },
+      core_processor: { field: "core_processor", type: "string" },
+      antenna_type: { field: "antenna_type", type: "string" },
+      has_uart: { field: "has_uart", type: "boolean" },
+      has_i2c: { field: "has_i2c", type: "boolean" },
+      has_spi: { field: "has_spi", type: "boolean" },
+      has_usb: { field: "has_usb", type: "boolean" },
+    },
+  },
   bjt_transistor: {
     filters: {
       package: { field: "package", type: "string" },
@@ -481,6 +504,8 @@ export const ROUTE_TO_TABLE: Record<string, string> = {
   "/adcs/list": "adc",
   "/analog_multiplexers/list": "analog_multiplexer",
   "/battery_holders/list": "battery_holder",
+  "/ble_chips/list": "ble_chip",
+  "/ble_modules/list": "ble_module",
   "/bjt_transistors/list": "bjt_transistor",
   "/boost_converters/list": "boost_converter",
   "/buck_boost_converters/list": "buck_boost_converter",
@@ -524,6 +549,8 @@ export const TABLE_RESPONSE_KEY: Record<string, string> = {
   adc: "adcs",
   analog_multiplexer: "multiplexers",
   battery_holder: "battery_holders",
+  ble_chip: "ble_chips",
+  ble_module: "ble_modules",
   bjt_transistor: "bjt_transistors",
   boost_converter: "boost_converters",
   buck_boost_converter: "buck_boost_converters",

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -30,6 +30,8 @@ const routeLabels: Record<string, string> = {
   "/wire_to_board_connectors/list": "Wire to Board Connectors",
   "/spring_clamp_terminal_blocks/list": "Spring Clamp Terminal Blocks",
   "/battery_holders/list": "Battery Holders",
+  "/ble_modules/list": "BLE Modules",
+  "/ble_chips/list": "BLE Chips",
   "/leds/list": "LEDs",
   "/adcs/list": "ADCs",
   "/analog_multiplexers/list": "Analog Muxes",
@@ -182,6 +184,7 @@ const COLUMN_LABELS: Record<string, string> = {
   gpio_count: "GPIO",
   clock_frequency_hz: "Clock",
   frequency_ghz: "Frequency",
+  data_rate_mbps: "Data Rate",
   display_type: "Display Type",
   matrix_size: "Matrix Size",
   forward_current: "Forward Current",
@@ -254,6 +257,8 @@ const formatDisplayValue = (column: string, value: unknown): string | null => {
       return `${formatSiUnit(value)}Hz`
     case "frequency_ghz":
       return withUnit(value, "GHz")
+    case "data_rate_mbps":
+      return withUnit(value, "Mbps")
     case "wavelength_nm":
       return withUnit(value, "nm")
     case "luminous_intensity_mcd":
@@ -290,6 +295,8 @@ const formatDisplayValue = (column: string, value: unknown): string | null => {
     case "gate_threshold_voltage":
     case "supply_voltage_min":
     case "supply_voltage_max":
+    case "operating_voltage_min":
+    case "operating_voltage_max":
     case "input_voltage_min":
     case "input_voltage_max":
     case "output_voltage_min":

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -12,7 +12,45 @@ describe("render helpers", () => {
     expect(html).toContain("/tft_display_drivers/list")
     expect(html).toContain("/resistors/list")
     expect(html).toContain("/spring_clamp_terminal_blocks/list")
+    expect(html).toContain("/ble_modules/list")
+    expect(html).toContain("/ble_chips/list")
   })
+
+  it.each([
+    ["/ble_modules/list", "ble_modules", "BLE Modules", "VG6328A"],
+    ["/ble_chips/list", "ble_chips", "BLE Chips", "NRF52832-QFAA-R"],
+  ])(
+    "renders the %s page with BLE filters",
+    (pathname, responseKey, heading, mfr) => {
+      expect(D1_ROUTES).toContain(pathname)
+      expect(getD1Handler(pathname)).toBeTypeOf("function")
+
+      const html = renderD1TablePage(
+        pathname,
+        {
+          [responseKey]: [
+            {
+              lcsc: 77540,
+              mfr,
+              package: "QFN-48-EP(6x6)",
+              bluetooth_version: "5.3",
+              has_spi: true,
+              stock: 100,
+            },
+          ],
+        },
+        { bluetooth_version: "5.3", has_spi: "true" },
+        `https://jlcsearch.tscircuit.com${pathname}?bluetooth_version=5.3&has_spi=true`,
+        { bluetooth_version: ["5.3"] },
+      )
+
+      expect(html).toContain(`<h2>${heading}</h2>`)
+      expect(html).toContain('name="bluetooth_version"')
+      expect(html).toContain('name="has_spi"')
+      expect(html).toContain(mfr)
+      expect(html).toContain(`${pathname}.json`)
+    },
+  )
 
   it("renders the spring clamp route with pitch and pin filters", () => {
     expect(D1_ROUTES).toContain("/spring_clamp_terminal_blocks/list")

--- a/lib/db/derivedtables/ble-chip.ts
+++ b/lib/db/derivedtables/ble-chip.ts
@@ -1,0 +1,101 @@
+import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import {
+  isBleChip,
+  isLikelyBareBleChip,
+  mapBleFields,
+  readComponentAttributes,
+  type BleComponentFields,
+} from "./ble-utils"
+import type { DerivedTableSpec } from "./types"
+
+const BLE_CHIP_SUBCATEGORIES = [
+  "RF Transceiver ICs",
+  "Microcontroller Units (MCUs/MPUs/SOCs)",
+  "Bluetooth Modules",
+] as const
+
+const BLE_CHIP_MFR_PATTERNS = [
+  "NRF5%",
+  "nRF5%",
+  "CC1352%",
+  "CC1354%",
+  "CC254%",
+  "CC264%",
+  "CC265%",
+  "CC267%",
+  "EFR32BG%",
+  "EFR32MG%",
+  "BLUENRG%",
+  "STM32WB%",
+  "STM32WBA%",
+  "N32WB%",
+  "CH57%",
+  "CH58%",
+  "CH59%",
+  "GR55%",
+  "QN90%",
+  "RSL10%",
+  "DA14%",
+  "RA4W1%",
+  "TLSR%",
+  "ESP32%",
+] as const
+
+export type BleChip = BleComponentFields
+
+export const bleChipTableSpec: DerivedTableSpec<BleChip> = {
+  tableName: "ble_chip",
+  extraColumns: [
+    { name: "package", type: "text" },
+    { name: "core_processor", type: "text" },
+    { name: "bluetooth_version", type: "text" },
+    { name: "frequency_ghz", type: "real" },
+    { name: "operating_voltage_min", type: "real" },
+    { name: "operating_voltage_max", type: "real" },
+    { name: "data_rate_mbps", type: "real" },
+    { name: "has_uart", type: "boolean" },
+    { name: "has_i2c", type: "boolean" },
+    { name: "has_spi", type: "boolean" },
+    { name: "has_usb", type: "boolean" },
+    { name: "is_basic", type: "boolean" },
+    { name: "is_preferred", type: "boolean" },
+  ],
+  listCandidateComponents: (db) =>
+    db
+      .selectFrom("components")
+      .innerJoin("categories", "components.category_id", "categories.id")
+      .selectAll("components")
+      .select(["categories.subcategory as source_subcategory"])
+      .where("categories.subcategory", "in", [...BLE_CHIP_SUBCATEGORIES])
+      .where((eb) =>
+        eb.or([
+          eb("components.extra", "like", "%Bluetooth%"),
+          eb("components.description", "like", "%Bluetooth%"),
+          ...BLE_CHIP_MFR_PATTERNS.map((pattern) =>
+            eb("components.mfr", "like", pattern),
+          ),
+        ]),
+      ),
+  mapToTable: (components) =>
+    components.map((component): BleChip | null => {
+      const attributes = readComponentAttributes(component.extra)
+      if (!attributes || !isBleChip(component, attributes)) return null
+
+      const sourceSubcategory = (
+        component as typeof component & {
+          source_subcategory?: string | null
+        }
+      ).source_subcategory
+      if (
+        sourceSubcategory === "Bluetooth Modules" &&
+        !isLikelyBareBleChip(component)
+      ) {
+        return null
+      }
+
+      return {
+        ...mapBleFields(component, attributes),
+        price1: extractMinQPrice(component.price),
+      }
+    }),
+}

--- a/lib/db/derivedtables/ble-module.ts
+++ b/lib/db/derivedtables/ble-module.ts
@@ -1,0 +1,53 @@
+import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import {
+  isLikelyBareBleChip,
+  mapBleFields,
+  readComponentAttributes,
+  type BleComponentFields,
+} from "./ble-utils"
+import type { DerivedTableSpec } from "./types"
+
+export interface BleModule extends BleComponentFields {
+  antenna_type: string | null
+}
+
+export const bleModuleTableSpec: DerivedTableSpec<BleModule> = {
+  tableName: "ble_module",
+  extraColumns: [
+    { name: "package", type: "text" },
+    { name: "core_processor", type: "text" },
+    { name: "bluetooth_version", type: "text" },
+    { name: "antenna_type", type: "text" },
+    { name: "frequency_ghz", type: "real" },
+    { name: "operating_voltage_min", type: "real" },
+    { name: "operating_voltage_max", type: "real" },
+    { name: "data_rate_mbps", type: "real" },
+    { name: "has_uart", type: "boolean" },
+    { name: "has_i2c", type: "boolean" },
+    { name: "has_spi", type: "boolean" },
+    { name: "has_usb", type: "boolean" },
+    { name: "is_basic", type: "boolean" },
+    { name: "is_preferred", type: "boolean" },
+  ],
+  listCandidateComponents: (db) =>
+    db
+      .selectFrom("components")
+      .innerJoin("categories", "components.category_id", "categories.id")
+      .selectAll()
+      .where("categories.subcategory", "=", "Bluetooth Modules"),
+  mapToTable: (components) =>
+    components.map((component): BleModule | null => {
+      const attributes = readComponentAttributes(component.extra)
+      if (!attributes || isLikelyBareBleChip(component)) return null
+
+      return {
+        ...mapBleFields(component, attributes),
+        price1: extractMinQPrice(component.price),
+        antenna_type:
+          typeof attributes["Antenna Type"] === "string" &&
+          attributes["Antenna Type"].trim() !== "-"
+            ? attributes["Antenna Type"].trim()
+            : null,
+      }
+    }),
+}

--- a/lib/db/derivedtables/ble-utils.ts
+++ b/lib/db/derivedtables/ble-utils.ts
@@ -1,0 +1,218 @@
+import type { BaseComponent } from "./component-base"
+
+interface SourceComponent {
+  lcsc: number
+  mfr: string
+  description: string
+  stock: number
+  basic: number
+  preferred: number
+  package: string
+}
+
+export interface BleComponentFields extends BaseComponent {
+  package: string
+  core_processor: string | null
+  bluetooth_version: string | null
+  frequency_ghz: number | null
+  operating_voltage_min: number | null
+  operating_voltage_max: number | null
+  data_rate_mbps: number | null
+  has_uart: boolean
+  has_i2c: boolean
+  has_spi: boolean
+  has_usb: boolean
+}
+
+const getFirstAttribute = (
+  attributes: Record<string, unknown>,
+  keys: string[],
+): string | null => {
+  for (const key of keys) {
+    const value = attributes[key]
+    if (value === undefined || value === null) continue
+
+    const normalized = String(value).trim()
+    if (normalized && normalized !== "-") return normalized
+  }
+
+  return null
+}
+
+const parseValuesWithUnit = (value: string | null, unit: string): number[] => {
+  if (!value) return []
+
+  const matches = value.matchAll(
+    new RegExp(`(-?\\d+(?:\\.\\d+)?)\\s*${unit}`, "gi"),
+  )
+  return Array.from(matches, (match) => Number(match[1])).filter(
+    Number.isFinite,
+  )
+}
+
+const parseFrequencyGhz = (value: string | null): number | null => {
+  if (!value) return null
+
+  const match = value.match(/(-?\d+(?:\.\d+)?)\s*(GHz|MHz|kHz|Hz)/i)
+  if (!match) return null
+
+  const frequency = Number(match[1])
+  const unit = match[2].toLowerCase()
+  if (unit === "ghz") return frequency
+  if (unit === "mhz") return frequency / 1e3
+  if (unit === "khz") return frequency / 1e6
+  return frequency / 1e9
+}
+
+const parseDataRateMbps = (value: string | null): number | null => {
+  if (!value) return null
+
+  const match = value.match(/(\d+(?:\.\d+)?)\s*(Gbps|Mbps|Kbps|bps)/i)
+  if (!match) return null
+
+  const dataRate = Number(match[1])
+  const unit = match[2].toLowerCase()
+  if (unit === "gbps") return dataRate * 1e3
+  if (unit === "mbps") return dataRate
+  if (unit === "kbps") return dataRate / 1e3
+  return dataRate / 1e6
+}
+
+const parseBluetoothVersion = (value: string | null): string | null => {
+  if (!value) return null
+
+  const versionMatch = value.match(
+    /(?:bluetooth|ble)?\s*(?:version|v)?\s*(\d+(?:\.\d+)?)/i,
+  )
+  return versionMatch?.[1] ?? value
+}
+
+export const readComponentAttributes = (
+  extra: string | null,
+): Record<string, unknown> | null => {
+  if (!extra) return null
+
+  try {
+    const parsed = JSON.parse(extra)
+    if (!parsed.attributes || typeof parsed.attributes !== "object") {
+      return null
+    }
+    return parsed.attributes
+  } catch {
+    return null
+  }
+}
+
+export const isBleChip = (
+  component: Pick<SourceComponent, "description" | "mfr">,
+  attributes: Record<string, unknown>,
+): boolean => {
+  const bluetoothMetadata = [
+    "Applications",
+    "Bluetooth Version",
+    "Bluetooth Protocol",
+    "Bluetooth Standard",
+    "Protocol",
+    "Wireless Standard",
+  ]
+    .map((key) => attributes[key])
+    .filter((value) => value !== undefined && value !== null)
+    .join(" ")
+
+  if (/bluetooth|\bble\b|low[ -]?energy/i.test(bluetoothMetadata)) {
+    return true
+  }
+
+  const searchableText = `${component.mfr} ${component.description}`
+  if (/\besp32-(?:s2|p4)/i.test(searchableText)) return false
+
+  return /\b(?:n?rf5\d+|cc(?:135[24]|254|264|265|267)\d*|efr32(?:bg|mg)\d+|bluenrg|stm32wba?|n32wb|ch5[789]|gr55|qn90|rsl10|da14\d+|ra4w1|tlsr\d+|esp32)/i.test(
+    searchableText,
+  )
+}
+
+export const isLikelyBareBleChip = (
+  component: Pick<SourceComponent, "package">,
+): boolean => {
+  const packageName = component.package.trim()
+  return /^(?:[A-Z]*QFN|[A-Z]*QFPN|[A-Z]*BGA|WLCSP|CSP|DFN|LQFP|TQFP|QFP|SOIC|SOP|SSOP|TSSOP)(?:-|\b)/i.test(
+    packageName,
+  )
+}
+
+export const mapBleFields = (
+  component: SourceComponent,
+  attributes: Record<string, unknown>,
+): BleComponentFields => {
+  const rawVoltage = getFirstAttribute(attributes, [
+    "Operating Voltage",
+    "Operating Voltage Range",
+    "Supply Voltage",
+    "Working Voltage",
+    "mains input",
+  ])
+  const voltages = parseValuesWithUnit(rawVoltage, "V")
+
+  const interfaceText = [
+    "Support Interface",
+    "Interface",
+    "Interface Type",
+    "interface type",
+    "Peripheral/Function",
+  ]
+    .map((key) => attributes[key])
+    .filter((value) => value !== undefined && value !== null)
+    .join(" ")
+    .toLowerCase()
+
+  const rawBluetoothVersion = getFirstAttribute(attributes, [
+    "Bluetooth Version",
+    "Bluetooth Protocol",
+    "Bluetooth Standard",
+    "Wireless Standard",
+  ])
+
+  return {
+    lcsc: component.lcsc,
+    mfr: component.mfr,
+    description: component.description,
+    stock: component.stock,
+    price1: null,
+    in_stock: component.stock > 0,
+    is_basic: Boolean(component.basic),
+    is_preferred: Boolean(component.preferred),
+    package: component.package || "",
+    core_processor: getFirstAttribute(attributes, [
+      "Core Processor",
+      "Core IC",
+      "CPU Core",
+      "Core",
+      "Chip Model",
+    ]),
+    bluetooth_version: parseBluetoothVersion(rawBluetoothVersion),
+    frequency_ghz: parseFrequencyGhz(
+      getFirstAttribute(attributes, [
+        "Frequency",
+        "Frequency Range",
+        "Typical Application Frequency",
+        "Working Frequency",
+      ]),
+    ),
+    operating_voltage_min: voltages.length > 0 ? Math.min(...voltages) : null,
+    operating_voltage_max: voltages.length > 0 ? Math.max(...voltages) : null,
+    data_rate_mbps: parseDataRateMbps(
+      getFirstAttribute(attributes, [
+        "Data Rate",
+        "Transmission Rate",
+        "transmission rate",
+      ]),
+    ),
+    has_uart: interfaceText.includes("uart"),
+    has_i2c: interfaceText.includes("i2c"),
+    has_spi: interfaceText.includes("spi"),
+    has_usb: interfaceText.includes("usb"),
+    attributes: Object.fromEntries(
+      Object.entries(attributes).map(([key, value]) => [key, String(value)]),
+    ),
+  }
+}

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -5,6 +5,8 @@ import { adcTableSpec } from "lib/db/derivedtables/adc"
 import { analogMultiplexerTableSpec } from "lib/db/derivedtables/analog_multiplexer"
 import { batteryHolderTableSpec } from "lib/db/derivedtables/battery_holder"
 import { bjtTransistorTableSpec } from "lib/db/derivedtables/bjt_transistor"
+import { bleChipTableSpec } from "lib/db/derivedtables/ble-chip"
+import { bleModuleTableSpec } from "lib/db/derivedtables/ble-module"
 import { boostConverterTableSpec } from "lib/db/derivedtables/boost_converter"
 import { buckBoostConverterTableSpec } from "lib/db/derivedtables/buck_boost_converter"
 import { capacitorTableSpec } from "lib/db/derivedtables/capacitor"
@@ -54,6 +56,8 @@ export const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   diodeTableSpec,
   dacTableSpec,
   wifiModuleTableSpec,
+  bleModuleTableSpec,
+  bleChipTableSpec,
   microcontrollerTableSpec,
   voltageRegulatorTableSpec,
   ldoTableSpec,

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -95,6 +95,53 @@ export interface BatteryHolder {
   stock: number | null;
 }
 
+export interface BleChip {
+  attributes: string | null;
+  bluetooth_version: string | null;
+  core_processor: string | null;
+  data_rate_mbps: number | null;
+  description: string | null;
+  frequency_ghz: number | null;
+  has_i2c: number | null;
+  has_spi: number | null;
+  has_uart: number | null;
+  has_usb: number | null;
+  in_stock: number | null;
+  is_basic: number | null;
+  is_preferred: number | null;
+  lcsc: Generated<number | null>;
+  mfr: string | null;
+  operating_voltage_max: number | null;
+  operating_voltage_min: number | null;
+  package: string | null;
+  price1: number | null;
+  stock: number | null;
+}
+
+export interface BleModule {
+  antenna_type: string | null;
+  attributes: string | null;
+  bluetooth_version: string | null;
+  core_processor: string | null;
+  data_rate_mbps: number | null;
+  description: string | null;
+  frequency_ghz: number | null;
+  has_i2c: number | null;
+  has_spi: number | null;
+  has_uart: number | null;
+  has_usb: number | null;
+  in_stock: number | null;
+  is_basic: number | null;
+  is_preferred: number | null;
+  lcsc: Generated<number | null>;
+  mfr: string | null;
+  operating_voltage_max: number | null;
+  operating_voltage_min: number | null;
+  package: string | null;
+  price1: number | null;
+  stock: number | null;
+}
+
 export interface BjtTransistor {
   attributes: string | null;
   collector_current: number | null;
@@ -913,6 +960,8 @@ export interface DB {
   adc: Adc;
   analog_multiplexer: AnalogMultiplexer;
   battery_holder: BatteryHolder;
+  ble_chip: BleChip;
+  ble_module: BleModule;
   bjt_transistor: BjtTransistor;
   boost_converter: BoostConverter;
   buck_boost_converter: BuckBoostConverter;

--- a/tests/lib/ble-derived-tables.test.ts
+++ b/tests/lib/ble-derived-tables.test.ts
@@ -1,0 +1,155 @@
+import { expect, test } from "bun:test"
+import { bleChipTableSpec } from "lib/db/derivedtables/ble-chip"
+import { bleModuleTableSpec } from "lib/db/derivedtables/ble-module"
+
+const makeComponent = (overrides: Record<string, unknown> = {}) =>
+  ({
+    lcsc: 77540,
+    mfr: "NRF52832-QFAA-R",
+    description: "2.4GHz Bluetooth RF Transceiver",
+    stock: 100,
+    basic: 0,
+    preferred: 1,
+    price: JSON.stringify([{ qFrom: 1, qTo: null, price: 2.5 }]),
+    package: "QFN-48-EP(6x6)",
+    extra: JSON.stringify({
+      attributes: {
+        Applications: "Bluetooth;General-purpose ISM>1GHz",
+        "Bluetooth Version": "Bluetooth 5.3",
+        "CPU Core": "ARM Cortex-M4",
+        "Frequency Range": "2.4GHz~2.483GHz",
+        "Operating Voltage": "1.7V~3.6V",
+        "Data Rate": "2Mbps",
+        Interface: "I2C,SPI,UART,USB",
+      },
+    }),
+    ...overrides,
+  }) as any
+
+test("BLE chip table maps Bluetooth radio attributes", () => {
+  const [chip] = bleChipTableSpec.mapToTable([makeComponent()])
+
+  expect(chip).toMatchObject({
+    lcsc: 77540,
+    mfr: "NRF52832-QFAA-R",
+    bluetooth_version: "5.3",
+    core_processor: "ARM Cortex-M4",
+    frequency_ghz: 2.4,
+    operating_voltage_min: 1.7,
+    operating_voltage_max: 3.6,
+    data_rate_mbps: 2,
+    has_i2c: true,
+    has_spi: true,
+    has_uart: true,
+    has_usb: true,
+    is_preferred: true,
+    price1: 2.5,
+  })
+})
+
+test("BLE chip table rejects non-Bluetooth RF transceivers", () => {
+  const [chip] = bleChipTableSpec.mapToTable([
+    makeComponent({
+      mfr: "SX1276",
+      description: "LoRa RF transceiver",
+      extra: JSON.stringify({
+        attributes: {
+          Applications: "LoRa;General-purpose ISM<1GHz",
+          "Frequency Range": "137MHz~1020MHz",
+        },
+      }),
+    }),
+  ])
+
+  expect(chip).toBeNull()
+})
+
+test.each(["CC2500RGPR", "ESP32-S2"])(
+  "BLE chip table does not classify %s as BLE",
+  (mfr) => {
+    const [chip] = bleChipTableSpec.mapToTable([
+      makeComponent({
+        mfr,
+        description: "2.4GHz RF transceiver",
+        extra: JSON.stringify({ attributes: {} }),
+      }),
+    ])
+
+    expect(chip).toBeNull()
+  },
+)
+
+test("BLE chip table recognizes BLE SoC families when metadata is sparse", () => {
+  const [chip] = bleChipTableSpec.mapToTable([
+    makeComponent({
+      description: "",
+      extra: JSON.stringify({ attributes: {} }),
+    }),
+  ])
+
+  expect(chip?.mfr).toBe("NRF52832-QFAA-R")
+})
+
+test("BLE module table maps module-specific attributes", () => {
+  const [module] = bleModuleTableSpec.mapToTable([
+    makeComponent({
+      lcsc: 20539408,
+      mfr: "VG6328A",
+      package: "SMD,16x13.6mm",
+      extra: JSON.stringify({
+        attributes: {
+          "Core IC": "BLE SoC",
+          "Bluetooth Version": "BLE 5.2",
+          "Antenna Type": "On-Board PCB Antenna",
+          Frequency: "2.4GHz",
+          "Operating Voltage": "3.3V",
+          "Support Interface": "UART;GPIO;I2C",
+        },
+      }),
+    }),
+  ])
+
+  expect(module).toMatchObject({
+    lcsc: 20539408,
+    bluetooth_version: "5.2",
+    core_processor: "BLE SoC",
+    antenna_type: "On-Board PCB Antenna",
+    frequency_ghz: 2.4,
+    operating_voltage_min: 3.3,
+    operating_voltage_max: 3.3,
+    has_uart: true,
+    has_i2c: true,
+  })
+})
+
+test("BLE module and chip tables split bare ICs miscategorized as modules", () => {
+  const component = makeComponent({
+    lcsc: 2976510,
+    mfr: "GR5513BENDU",
+    package: "QFN-40(5x5)",
+    description: "",
+    source_subcategory: "Bluetooth Modules",
+    extra: JSON.stringify({ attributes: {} }),
+  })
+
+  const [module] = bleModuleTableSpec.mapToTable([component])
+  const [chip] = bleChipTableSpec.mapToTable([component])
+
+  expect(module).toBeNull()
+  expect(chip?.mfr).toBe("GR5513BENDU")
+})
+
+test("BLE module table keeps packaged ESP32 modules out of the chip table", () => {
+  const component = makeComponent({
+    lcsc: 5361945,
+    mfr: "ESP32-WROOM-32E-N8R2",
+    package: "LCC-38(18x25.5)",
+    source_subcategory: "Bluetooth Modules",
+  })
+
+  const [module] = bleModuleTableSpec.mapToTable([component])
+  const [chip] = bleChipTableSpec.mapToTable([component])
+
+  expect(module?.mfr).toBe("ESP32-WROOM-32E-N8R2")
+  expect(chip).toBeNull()
+})


### PR DESCRIPTION
## Summary

- add dedicated `/ble_modules/list` and `/ble_chips/list` pages and JSON endpoints
- add derived BLE tables with package, Bluetooth version, processor, antenna, voltage, data-rate, and interface metadata
- register the tables with the D1 sync pipeline, route handlers, filters, database types, and home page
- distinguish packaged modules from bare BLE silicon, including parts miscategorized by the upstream catalog

## Why

BLE modules and BLE-capable chips were only discoverable through the general component search. These pages make in-stock parts directly browsable and filterable while excluding unrelated RF transceivers.

## Impact

Users can compare BLE modules and BLE chips separately, filter by common electrical and interface properties, and consume the same results through the JSON API.

## Validation

- `bunx tsc --noEmit --project tsconfig.json`
- `bunx tsc --noEmit --project cf-proxy/tsconfig.json`
- `bun test` — 154 tests passed
- `git diff --check`