### PR TITLE
Fall back when BLE D1 tables are missing

### DIFF
--- a/cf-proxy/src/ble-catalog.ts
+++ b/cf-proxy/src/ble-catalog.ts
@@ -1,0 +1,172 @@
+import type { Kysely } from "kysely"
+import {
+  BLE_CHIP_MFR_PATTERNS,
+  BLE_CHIP_SUBCATEGORIES,
+  isBleChip,
+  isLikelyBareBleChip,
+  mapBleFields,
+  readComponentAttributes,
+} from "../../lib/db/derivedtables/ble-utils"
+import type { DB } from "./db/types"
+import type { FilterOptions, QueryParams } from "./handlers"
+
+type BleCatalogKind = "chip" | "module"
+
+export interface BleCatalogQueryResult {
+  data: Record<string, unknown[]>
+  tableName: string
+  filterOptions: FilterOptions
+}
+
+const STRING_FILTERS = [
+  "package",
+  "bluetooth_version",
+  "core_processor",
+  "antenna_type",
+] as const
+
+const BOOLEAN_FILTERS = ["has_uart", "has_i2c", "has_spi", "has_usb"] as const
+
+const extractSmallQuantityPrice = (price: string | null): number => {
+  if (!price) return 0
+
+  try {
+    const priceObj = JSON.parse(price)
+    return Number(priceObj[0]?.price ?? 0) || 0
+  } catch {
+    return 0
+  }
+}
+
+const getStringOptions = (
+  rows: Array<Record<string, unknown>>,
+  field: string,
+): string[] =>
+  Array.from(
+    new Set(
+      rows
+        .map((row) => row[field])
+        .filter((value): value is string => typeof value === "string")
+        .map((value) => value.trim())
+        .filter(Boolean),
+    ),
+  ).sort((a, b) => a.localeCompare(b))
+
+const matchesFilters = (
+  row: Record<string, unknown>,
+  params: QueryParams,
+): boolean => {
+  for (const field of STRING_FILTERS) {
+    const value = params[field]
+    if (value && value !== "All" && row[field] !== value) return false
+  }
+
+  for (const field of BOOLEAN_FILTERS) {
+    const value = params[field]
+    if (!value || value === "All") continue
+
+    const expected = value === "true" || value === "1"
+    if (Boolean(row[field]) !== expected) return false
+  }
+
+  return true
+}
+
+export const queryBleCatalog = async (
+  db: Kysely<DB>,
+  params: QueryParams,
+  kind: BleCatalogKind,
+): Promise<BleCatalogQueryResult> => {
+  let candidateQuery = db.selectFrom("component_catalog").where("stock", ">", 0)
+
+  candidateQuery =
+    kind === "module"
+      ? candidateQuery.where("subcategory", "=", "Bluetooth Modules")
+      : candidateQuery
+          .where("subcategory", "in", [...BLE_CHIP_SUBCATEGORIES])
+          .where((eb) =>
+            eb.or([
+              eb("extra", "like", "%Bluetooth%"),
+              eb("description", "like", "%Bluetooth%"),
+              ...BLE_CHIP_MFR_PATTERNS.map((pattern) =>
+                eb("mfr", "like", pattern),
+              ),
+            ]),
+          )
+
+  const candidates = await candidateQuery
+    .select([
+      "lcsc",
+      "mfr",
+      "package",
+      "description",
+      "stock",
+      "price",
+      "basic",
+      "preferred",
+      "subcategory",
+      "extra",
+    ])
+    .orderBy("stock", "desc")
+    .limit(1000)
+    .execute()
+
+  const mappedRows = candidates
+    .map((row): Record<string, unknown> | null => {
+      const component = {
+        lcsc: row.lcsc ?? 0,
+        mfr: row.mfr ?? "",
+        package: row.package ?? "",
+        description: row.description ?? "",
+        stock: row.stock ?? 0,
+        basic: row.basic ?? 0,
+        preferred: row.preferred ?? 0,
+      }
+      const attributes = readComponentAttributes(row.extra) ?? {}
+      const isBareChip = isLikelyBareBleChip(component)
+
+      if (kind === "module" && isBareChip) return null
+      if (kind === "chip") {
+        if (!isBleChip(component, attributes)) return null
+        if (row.subcategory === "Bluetooth Modules" && !isBareChip) return null
+      }
+
+      const mapped = mapBleFields(component, attributes)
+      const antennaType = attributes["Antenna Type"]
+
+      return {
+        ...mapped,
+        price1: extractSmallQuantityPrice(row.price),
+        attributes: JSON.stringify(mapped.attributes),
+        ...(kind === "module"
+          ? {
+              antenna_type:
+                typeof antennaType === "string" && antennaType.trim() !== "-"
+                  ? antennaType.trim()
+                  : null,
+            }
+          : {}),
+      }
+    })
+    .filter((row): row is Record<string, unknown> => row !== null)
+
+  const optionFields =
+    kind === "module"
+      ? STRING_FILTERS
+      : STRING_FILTERS.filter((field) => field !== "antenna_type")
+  const filterOptions = Object.fromEntries(
+    optionFields.map((field) => [field, getStringOptions(mappedRows, field)]),
+  )
+  const tableName = kind === "module" ? "ble_module" : "ble_chip"
+  const responseKey = kind === "module" ? "ble_modules" : "ble_chips"
+
+  return {
+    tableName,
+    filterOptions,
+    data: {
+      [responseKey]: mappedRows
+        .filter((row) => matchesFilters(row, params))
+        .slice(0, 100),
+    },
+  }
+}

--- a/cf-proxy/src/d1-routes.ts
+++ b/cf-proxy/src/d1-routes.ts
@@ -1,4 +1,5 @@
 import type { Kysely } from "kysely"
+import { queryBleCatalog } from "./ble-catalog"
 import type { DB } from "./db/types"
 import {
   getTftDisplayDriverFamily,
@@ -27,6 +28,13 @@ type D1Handler = (db: Kysely<DB>, params: QueryParams) => Promise<D1QueryResult>
 const PROCESSOR_INTERFACES = ["uart", "i2c", "spi", "can", "usb"] as const
 const MICROPHONE_SUBCATEGORIES = ["Microphones", "MEMS Microphones"] as const
 const LCD_DRIVER_SUBCATEGORY = "LCD Drivers"
+
+const isMissingDerivedTableError = (
+  error: unknown,
+  tableName: string,
+): boolean =>
+  error instanceof Error &&
+  error.message.includes(`no such table: ${tableName}`)
 
 const parseFiniteNumber = (value: string | undefined): number | null => {
   if (value === undefined || value === "") return null
@@ -544,13 +552,25 @@ export function getD1Handler(pathname: string): D1Handler | null {
   }
 
   return async (db, params) => {
-    const results = await queryTable(db, tableName, params, config)
-    const filterOptions = await queryFilterOptions(db, tableName, config)
-    const responseKey = TABLE_RESPONSE_KEY[tableName] || tableName + "s"
-    return {
-      data: { [responseKey]: results },
-      tableName,
-      filterOptions,
+    try {
+      const results = await queryTable(db, tableName, params, config)
+      const filterOptions = await queryFilterOptions(db, tableName, config)
+      const responseKey = TABLE_RESPONSE_KEY[tableName] || tableName + "s"
+      return {
+        data: { [responseKey]: results },
+        tableName,
+        filterOptions,
+      }
+    } catch (error) {
+      if (isMissingDerivedTableError(error, tableName)) {
+        if (tableName === "ble_module") {
+          return queryBleCatalog(db, params, "module")
+        }
+        if (tableName === "ble_chip") {
+          return queryBleCatalog(db, params, "chip")
+        }
+      }
+      throw error
     }
   }
 }

--- a/cf-proxy/test/ble-catalog-fallback.test.ts
+++ b/cf-proxy/test/ble-catalog-fallback.test.ts
@@ -1,0 +1,115 @@
+import {
+  DummyDriver,
+  Kysely,
+  SqliteAdapter,
+  SqliteIntrospector,
+  SqliteQueryCompiler,
+  type CompiledQuery,
+  type DatabaseConnection,
+} from "kysely"
+import { describe, expect, it } from "vitest"
+import { getD1Handler } from "../src/d1-routes"
+import type { DB } from "../src/db/types"
+
+interface FallbackCase {
+  path: string
+  missingTable: string
+  responseKey: string
+  catalogRow: Record<string, unknown>
+  expectedMfr: string
+}
+
+const fallbackCases: FallbackCase[] = [
+  {
+    path: "/ble_modules/list",
+    missingTable: "ble_module",
+    responseKey: "ble_modules",
+    catalogRow: {
+      lcsc: 20539408,
+      mfr: "VG6328A",
+      package: "SMD,16x13.6mm",
+      description: "BLE module",
+      stock: 8848,
+      price: '[{"qFrom":1,"price":0.938571429}]',
+      basic: 0,
+      preferred: 0,
+      subcategory: "Bluetooth Modules",
+      extra:
+        '{"attributes":{"Bluetooth Version":"BLE 5.2","Antenna Type":"On-Board PCB Antenna","Support Interface":"UART;I2C"}}',
+    },
+    expectedMfr: "VG6328A",
+  },
+  {
+    path: "/ble_chips/list",
+    missingTable: "ble_chip",
+    responseKey: "ble_chips",
+    catalogRow: {
+      lcsc: 77540,
+      mfr: "NRF52832-QFAA-R",
+      package: "QFN-48-EP(6x6)",
+      description: "Bluetooth RF transceiver",
+      stock: 19295,
+      price: '[{"qFrom":1,"price":2.562857143}]',
+      basic: 0,
+      preferred: 0,
+      subcategory: "RF Transceiver ICs",
+      extra:
+        '{"attributes":{"Applications":"Bluetooth","Bluetooth Version":"5.0","Interface":"I2C,SPI,UART"}}',
+    },
+    expectedMfr: "NRF52832-QFAA-R",
+  },
+]
+
+describe("BLE catalog fallback", () => {
+  for (const fallbackCase of fallbackCases) {
+    it(`serves ${fallbackCase.path} when ${fallbackCase.missingTable} has not been synced`, async () => {
+      const compiledQueries: CompiledQuery[] = []
+      const driver = new DummyDriver()
+
+      driver.acquireConnection = async () =>
+        ({
+          executeQuery: async (compiledQuery: CompiledQuery) => {
+            compiledQueries.push(compiledQuery)
+
+            if (compiledQuery.sql.includes(`"${fallbackCase.missingTable}"`)) {
+              throw new Error(
+                `D1_ERROR: no such table: ${fallbackCase.missingTable}`,
+              )
+            }
+
+            return { rows: [fallbackCase.catalogRow] }
+          },
+          streamQuery: async function* () {},
+        }) as DatabaseConnection
+
+      const db = new Kysely<DB>({
+        dialect: {
+          createAdapter: () => new SqliteAdapter(),
+          createDriver: () => driver,
+          createIntrospector: (database) => new SqliteIntrospector(database),
+          createQueryCompiler: () => new SqliteQueryCompiler(),
+        },
+      })
+
+      try {
+        const handler = getD1Handler(fallbackCase.path)
+        expect(handler).not.toBeNull()
+
+        const result = await handler!(db, {})
+        const rows = result.data[fallbackCase.responseKey] as Array<{
+          mfr: string
+        }>
+
+        expect(rows).toHaveLength(1)
+        expect(rows[0].mfr).toBe(fallbackCase.expectedMfr)
+        expect(
+          compiledQueries.some((query) =>
+            query.sql.includes("component_catalog"),
+          ),
+        ).toBe(true)
+      } finally {
+        await db.destroy()
+      }
+    })
+  }
+})

--- a/lib/db/derivedtables/ble-chip.ts
+++ b/lib/db/derivedtables/ble-chip.ts
@@ -1,5 +1,7 @@
 import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
 import {
+  BLE_CHIP_MFR_PATTERNS,
+  BLE_CHIP_SUBCATEGORIES,
   isBleChip,
   isLikelyBareBleChip,
   mapBleFields,
@@ -7,39 +9,6 @@ import {
   type BleComponentFields,
 } from "./ble-utils"
 import type { DerivedTableSpec } from "./types"
-
-const BLE_CHIP_SUBCATEGORIES = [
-  "RF Transceiver ICs",
-  "Microcontroller Units (MCUs/MPUs/SOCs)",
-  "Bluetooth Modules",
-] as const
-
-const BLE_CHIP_MFR_PATTERNS = [
-  "NRF5%",
-  "nRF5%",
-  "CC1352%",
-  "CC1354%",
-  "CC254%",
-  "CC264%",
-  "CC265%",
-  "CC267%",
-  "EFR32BG%",
-  "EFR32MG%",
-  "BLUENRG%",
-  "STM32WB%",
-  "STM32WBA%",
-  "N32WB%",
-  "CH57%",
-  "CH58%",
-  "CH59%",
-  "GR55%",
-  "QN90%",
-  "RSL10%",
-  "DA14%",
-  "RA4W1%",
-  "TLSR%",
-  "ESP32%",
-] as const
 
 export type BleChip = BleComponentFields
 

--- a/lib/db/derivedtables/ble-utils.ts
+++ b/lib/db/derivedtables/ble-utils.ts
@@ -10,6 +10,39 @@ interface SourceComponent {
   package: string
 }
 
+export const BLE_CHIP_SUBCATEGORIES = [
+  "RF Transceiver ICs",
+  "Microcontroller Units (MCUs/MPUs/SOCs)",
+  "Bluetooth Modules",
+] as const
+
+export const BLE_CHIP_MFR_PATTERNS = [
+  "NRF5%",
+  "nRF5%",
+  "CC1352%",
+  "CC1354%",
+  "CC254%",
+  "CC264%",
+  "CC265%",
+  "CC267%",
+  "EFR32BG%",
+  "EFR32MG%",
+  "BLUENRG%",
+  "STM32WB%",
+  "STM32WBA%",
+  "N32WB%",
+  "CH57%",
+  "CH58%",
+  "CH59%",
+  "GR55%",
+  "QN90%",
+  "RSL10%",
+  "DA14%",
+  "RA4W1%",
+  "TLSR%",
+  "ESP32%",
+] as const
+
 export interface BleComponentFields extends BaseComponent {
   package: string
   core_processor: string | null


### PR DESCRIPTION
## Summary

- fall back to the existing `component_catalog` when `ble_module` or `ble_chip` has not yet been synced to D1
- reuse the same BLE classification and attribute parsing as the derived-table pipeline
- preserve package, Bluetooth version, processor, antenna, and interface filters in fallback mode
- add route tests for both missing-table cases

## Root cause

PR #415 deployed the new worker routes before the corresponding derived tables were present in production D1. Requests therefore failed with `D1_ERROR: no such table: ble_module` (and would do the same for `ble_chip`). The code deployment workflow does not run the separate database-sync script.

## Impact

The BLE pages now remain available during database rollout gaps. Once the derived tables are synced, the normal derived-table query path continues to be used automatically.

## Validation

- reproduced the production 500 and confirmed production D1 contains `component_catalog` but not the two BLE tables
- verified the production catalog has 103 Bluetooth module candidates and 223 BLE chip candidates, below the fallback query cap
- `bun test` — 156 tests passed
- `bunx tsc --noEmit --project tsconfig.json`
- `bunx tsc --noEmit --project cf-proxy/tsconfig.json`
- `bunx wrangler deploy --dry-run`
- `git diff --check`