### PR TITLE
feat: add is_extended_promotional column and index to components

### DIFF
--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -239,6 +239,7 @@ export interface Component {
   description: string;
   extra: string | null;
   flag: Generated<number>;
+  is_extended_promotional: Generated<number>;
   joints: number;
   last_on_stock: Generated<number>;
   last_update: number;
@@ -869,6 +870,7 @@ export interface VComponent {
   datasheet: string | null;
   description: string | null;
   extra: string | null;
+  is_extended_promotional: number | null;
   joints: number | null;
   last_on_stock: number | null;
   lcsc: number | null;

--- a/lib/db/optimizations/component-extended-promotional-column.ts
+++ b/lib/db/optimizations/component-extended-promotional-column.ts
@@ -1,0 +1,38 @@
+import { sql } from "kysely"
+import type { DbOptimizationSpec } from "./types"
+import type { KyselyDatabaseInstance } from "../kysely-types"
+
+export const componentExtendedPromotionalColumn: DbOptimizationSpec = {
+  name: "add_components_is_extended_promotional_column",
+  description:
+    "Adds is_extended_promotional VIRTUAL column derived from preferred and basic columns, plus an index",
+
+  async checkIfAdded(db: KyselyDatabaseInstance) {
+    const result = await sql`
+      PRAGMA table_xinfo(components)
+    `.execute(db)
+    return result.rows.some((r: any) => r.name === "is_extended_promotional")
+  },
+
+  async execute(db: KyselyDatabaseInstance) {
+    // VIRTUAL generated column. Encoding verified via jlcparts source:
+    // pullExtraAttributes() in datatables.py synthesizes "Basic/Extended"
+    // from preferred + basic columns. JLCPCB docs confirm preferred
+    // extended parts are "exempt from Feeders Loading fee" = temporarily
+    // basic-priced. COALESCE(basic,0) guards against NULLs in legacy data.
+    await sql`
+      ALTER TABLE components
+      ADD COLUMN is_extended_promotional boolean
+      GENERATED ALWAYS AS (
+        CASE WHEN preferred = 1 AND COALESCE(basic, 0) = 0
+        THEN 1 ELSE 0 END
+      )
+    `.execute(db)
+
+    await db.schema
+      .createIndex("idx_components_is_extended_promotional")
+      .on("components")
+      .column("is_extended_promotional")
+      .execute()
+  },
+}

--- a/scripts/setup-db-optimizations.ts
+++ b/scripts/setup-db-optimizations.ts
@@ -1,6 +1,7 @@
 import { getBunDatabaseClient, getDbClient } from "lib/db/get-db-client"
 import { componentStockIndex } from "lib/db/optimizations/component-stock-index"
 import { componentInStockColumn } from "lib/db/optimizations/component-in-stock-column"
+import { componentExtendedPromotionalColumn } from "lib/db/optimizations/component-extended-promotional-column"
 import { removeStaleComponents } from "lib/db/optimizations/remove-stale-components"
 import { componentCategoryIndex } from "lib/db/optimizations/component-category-index"
 import { componentInStockCategoryIndex } from "lib/db/optimizations/component-in-stock-category-index"
@@ -18,6 +19,7 @@ const OPTIMIZATIONS: DbOptimizationSpec[] = [
   removeStaleComponents,
   componentStockIndex,
   componentInStockColumn,
+  componentExtendedPromotionalColumn,
   componentCategoryIndex,
   componentInStockCategoryIndex,
 ]


### PR DESCRIPTION
VIRTUAL generated column is_extended_promotional derived from preferred AND NOT basic.

Expression: preferred = 1 AND COALESCE(basic, 0) = 0

Encoding verified against jlcparts source code.

 /bounty $75
/claim #92