### PR TITLE
Add max resolution filters for display drivers

### DIFF
--- a/cf-proxy/src/d1-routes.ts
+++ b/cf-proxy/src/d1-routes.ts
@@ -1,6 +1,10 @@
 import type { Kysely } from "kysely"
 import type { DB } from "./db/types"
 import {
+  createDisplayDriverMaxResolutionResolver,
+  getDisplayDriverMaxResolutionOptions,
+} from "./display-driver-resolution"
+import {
   getTftDisplayDriverFamily,
   getTftDisplayDriverPatterns,
   TFT_DISPLAY_DRIVER_FAMILIES,
@@ -326,7 +330,6 @@ const SPECIAL_D1_HANDLERS: Record<string, D1Handler> = {
       .where("stock", ">", 0)
       .where("subcategory", "=", LCD_DRIVER_SUBCATEGORY)
       .orderBy("stock", "desc")
-      .limit(100)
 
     if (params.package) {
       query = query.where("package", "=", params.package)
@@ -340,7 +343,7 @@ const SPECIAL_D1_HANDLERS: Record<string, D1Handler> = {
       query = query.where("preferred", "=", 1)
     }
 
-    const [packages, lcdDrivers] = await Promise.all([
+    const [packages, resolutionSources, lcdDrivers] = await Promise.all([
       db
         .selectFrom("component_catalog")
         .select("package")
@@ -349,8 +352,21 @@ const SPECIAL_D1_HANDLERS: Record<string, D1Handler> = {
         .where("package", "is not", null)
         .orderBy("package")
         .execute(),
+      db
+        .selectFrom("component_catalog")
+        .select(["mfr", "description", "extra"])
+        .where("stock", ">", 0)
+        .where("subcategory", "=", LCD_DRIVER_SUBCATEGORY)
+        .execute(),
       query.execute(),
     ])
+
+    const maxResolutionFilter =
+      params.max_resolution && params.max_resolution !== "All"
+        ? params.max_resolution
+        : null
+    const resolveMaxResolution =
+      createDisplayDriverMaxResolutionResolver(resolutionSources)
 
     return {
       tableName: "lcd_driver",
@@ -359,6 +375,7 @@ const SPECIAL_D1_HANDLERS: Record<string, D1Handler> = {
           packages as Array<Record<string, string | null>>,
           "package",
         ),
+        max_resolution: getDisplayDriverMaxResolutionOptions(resolutionSources),
       },
       data: {
         lcd_drivers: lcdDrivers
@@ -366,6 +383,7 @@ const SPECIAL_D1_HANDLERS: Record<string, D1Handler> = {
             lcsc: driver.lcsc ?? 0,
             mfr: driver.mfr ?? "",
             package: driver.package ?? "",
+            max_resolution: resolveMaxResolution(driver),
             description: driver.description ?? "",
             is_basic: Boolean(driver.basic),
             is_preferred: Boolean(driver.preferred),
@@ -373,7 +391,13 @@ const SPECIAL_D1_HANDLERS: Record<string, D1Handler> = {
             price1: extractSmallQuantityPrice(driver.price),
             attributes: extractAttributes(driver.extra),
           }))
-          .filter((driver) => driver.lcsc !== 0),
+          .filter(
+            (driver) =>
+              driver.lcsc !== 0 &&
+              (!maxResolutionFilter ||
+                driver.max_resolution === maxResolutionFilter),
+          )
+          .slice(0, 100),
       },
     }
   },
@@ -393,7 +417,6 @@ const SPECIAL_D1_HANDLERS: Record<string, D1Handler> = {
       ])
       .where("stock", ">", 0)
       .orderBy("stock", "desc")
-      .limit(100)
 
     if (params.package) {
       query = query.where("package", "=", params.package)
@@ -407,15 +430,26 @@ const SPECIAL_D1_HANDLERS: Record<string, D1Handler> = {
       query = query.where("preferred", "=", 1)
     }
 
-    const [packages, tftDrivers] = await Promise.all([
+    const [packages, resolutionSources, tftDrivers] = await Promise.all([
       selectTftDriverCatalog(db, params.driver_type)
         .select("package")
         .distinct()
         .where("package", "is not", null)
         .orderBy("package")
         .execute(),
+      selectTftDriverCatalog(db, params.driver_type)
+        .select(["mfr", "description", "extra"])
+        .where("stock", ">", 0)
+        .execute(),
       query.execute(),
     ])
+
+    const maxResolutionFilter =
+      params.max_resolution && params.max_resolution !== "All"
+        ? params.max_resolution
+        : null
+    const resolveMaxResolution =
+      createDisplayDriverMaxResolutionResolver(resolutionSources)
 
     return {
       tableName: "tft_display_driver",
@@ -425,6 +459,7 @@ const SPECIAL_D1_HANDLERS: Record<string, D1Handler> = {
           "package",
         ),
         driver_type: TFT_DISPLAY_DRIVER_FAMILIES.map((family) => family.value),
+        max_resolution: getDisplayDriverMaxResolutionOptions(resolutionSources),
       },
       data: {
         tft_display_drivers: tftDrivers
@@ -436,6 +471,7 @@ const SPECIAL_D1_HANDLERS: Record<string, D1Handler> = {
               getTftDisplayDriverFamily(driver.mfr)?.label ??
               "TFT Display Driver",
             catalog_type: driver.subcategory ?? "",
+            max_resolution: resolveMaxResolution(driver),
             description: driver.description ?? "",
             is_basic: Boolean(driver.basic),
             is_preferred: Boolean(driver.preferred),
@@ -443,7 +479,13 @@ const SPECIAL_D1_HANDLERS: Record<string, D1Handler> = {
             price1: extractSmallQuantityPrice(driver.price),
             attributes: extractAttributes(driver.extra),
           }))
-          .filter((driver) => driver.lcsc !== 0),
+          .filter(
+            (driver) =>
+              driver.lcsc !== 0 &&
+              (!maxResolutionFilter ||
+                driver.max_resolution === maxResolutionFilter),
+          )
+          .slice(0, 100),
       },
     }
   },

--- a/cf-proxy/src/display-driver-resolution.ts
+++ b/cf-proxy/src/display-driver-resolution.ts
@@ -1,0 +1,165 @@
+interface DisplayDriverResolutionSource {
+  mfr?: string | null
+  description?: string | null
+  extra?: string | null
+}
+
+interface Resolution {
+  width: number
+  height: number
+}
+
+const DISPLAY_CONFIGURATION_KEYS = [
+  "Display Configurations(bit)",
+  "Display Configurations",
+  "Display Configuration",
+  "Max Resolution",
+  "Resolution",
+] as const
+
+// These catalog rows do not include resolution attributes. The values come
+// from the datasheets linked by their database records.
+const TFT_CONTROLLER_MAX_RESOLUTIONS = [
+  { pattern: /^SSD1963/i, resolution: "864x480" },
+  { pattern: /^LT7680/i, resolution: "1280x1024" },
+  { pattern: /^LT7681/i, resolution: "640x480" },
+  { pattern: /^LT7683/i, resolution: "1024x768" },
+  { pattern: /^LT7686/i, resolution: "1280x1024" },
+  { pattern: /^LT7689/i, resolution: "1280x1024" },
+] as const
+
+const parseExtraAttributes = (
+  extra: string | null | undefined,
+): Record<string, unknown> => {
+  if (!extra) return {}
+
+  try {
+    const parsed = JSON.parse(extra)
+    return parsed?.attributes && typeof parsed.attributes === "object"
+      ? parsed.attributes
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+const extractResolutions = (value: unknown): Resolution[] => {
+  if (typeof value !== "string") return []
+
+  const resolutions: Resolution[] = []
+  for (const match of value.matchAll(/(\d{1,4})\s*[x×*]\s*(\d{1,4})/gi)) {
+    const width = Number(match[1])
+    const height = Number(match[2])
+    if (width > 0 && height > 0) {
+      resolutions.push({ width, height })
+    }
+  }
+  return resolutions
+}
+
+const getLargestResolution = (
+  resolutions: Resolution[],
+): Resolution | undefined =>
+  [...resolutions].sort(
+    (a, b) =>
+      b.width * b.height - a.width * a.height ||
+      b.width - a.width ||
+      b.height - a.height,
+  )[0]
+
+const formatResolution = (resolution: Resolution): string =>
+  `${resolution.width}x${resolution.height}`
+
+export const getDisplayDriverMaxResolution = ({
+  mfr,
+  description,
+  extra,
+}: DisplayDriverResolutionSource): string => {
+  const attributes = parseExtraAttributes(extra)
+  const attributeResolutions = DISPLAY_CONFIGURATION_KEYS.flatMap((key) =>
+    extractResolutions(attributes[key]),
+  )
+  const largestAttributeResolution = getLargestResolution(attributeResolutions)
+  if (largestAttributeResolution) {
+    return formatResolution(largestAttributeResolution)
+  }
+
+  // Descriptions can also contain package dimensions (for example 14x14), so
+  // only accept dimensions explicitly identified as a bit configuration.
+  const descriptionResolutions = Array.from(
+    description?.matchAll(/(\d{1,4})\s*[x×*]\s*(\d{1,4})\s*bit/gi) ?? [],
+    (match) => ({
+      width: Number(match[1]),
+      height: Number(match[2]),
+    }),
+  )
+  const largestDescriptionResolution = getLargestResolution(
+    descriptionResolutions,
+  )
+  if (largestDescriptionResolution) {
+    return formatResolution(largestDescriptionResolution)
+  }
+
+  return (
+    TFT_CONTROLLER_MAX_RESOLUTIONS.find(({ pattern }) =>
+      pattern.test(mfr ?? ""),
+    )?.resolution ?? ""
+  )
+}
+
+const normalizeMfr = (mfr: string | null | undefined): string =>
+  (mfr ?? "").toUpperCase().replaceAll(/[^A-Z0-9]/g, "")
+
+export const createDisplayDriverMaxResolutionResolver = (
+  rows: DisplayDriverResolutionSource[],
+): ((row: DisplayDriverResolutionSource) => string) => {
+  const resolvedSources = rows
+    .map((row) => ({
+      normalizedMfr: normalizeMfr(row.mfr),
+      resolution: getDisplayDriverMaxResolution(row),
+    }))
+    .filter(
+      ({ normalizedMfr, resolution }) =>
+        normalizedMfr.length >= 6 && resolution,
+    )
+
+  return (row) => {
+    const directResolution = getDisplayDriverMaxResolution(row)
+    if (directResolution) return directResolution
+
+    const normalizedMfr = normalizeMfr(row.mfr)
+    if (normalizedMfr.length < 6) return ""
+
+    // Duplicate catalog entries frequently omit attributes on one package but
+    // retain them on another. Reuse a model-family value only when every
+    // related row agrees, avoiding guesses across families with mixed maxima.
+    const relatedResolutions = new Set(
+      resolvedSources
+        .filter(
+          (source) =>
+            source.normalizedMfr.startsWith(normalizedMfr) ||
+            normalizedMfr.startsWith(source.normalizedMfr),
+        )
+        .map((source) => source.resolution),
+    )
+
+    return relatedResolutions.size === 1
+      ? (relatedResolutions.values().next().value ?? "")
+      : ""
+  }
+}
+
+export const getDisplayDriverMaxResolutionOptions = (
+  rows: DisplayDriverResolutionSource[],
+): string[] =>
+  Array.from(
+    new Set(rows.map(getDisplayDriverMaxResolution).filter(Boolean)),
+  ).sort((a, b) => {
+    const [aWidth, aHeight] = a.split("x").map(Number)
+    const [bWidth, bHeight] = b.split("x").map(Number)
+    return (
+      aWidth * aHeight - bWidth * bHeight ||
+      aWidth - bWidth ||
+      aHeight - bHeight
+    )
+  })

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -507,6 +507,7 @@ const renderCustomFilters = (
     }
     case "/lcd_drivers/list": {
       const packageOptions = filterOptions.package ?? []
+      const maxResolutionOptions = filterOptions.max_resolution ?? []
       const packageListId = getSuggestionListId(
         pathname,
         "package",
@@ -520,6 +521,18 @@ const renderCustomFilters = (
           ${renderFilterSuggestions(pathname, "package", packageOptions)}
         </div>
         <div>
+          <label>Max Resolution:</label>
+          <select name="max_resolution">
+            <option value="">All</option>
+            ${maxResolutionOptions
+              .map(
+                (option) =>
+                  `<option value="${escapeHtml(option)}"${params.max_resolution === option ? " selected" : ""}>${escapeHtml(option)}</option>`,
+              )
+              .join("")}
+          </select>
+        </div>
+        <div>
           <label>Basic Part:<input type="checkbox" name="is_basic" value="true"${params.is_basic === "true" ? " checked" : ""} /></label>
         </div>
         <div>
@@ -530,6 +543,7 @@ const renderCustomFilters = (
     }
     case "/tft_display_drivers/list": {
       const packageOptions = filterOptions.package ?? []
+      const maxResolutionOptions = filterOptions.max_resolution ?? []
       const packageListId = getSuggestionListId(
         pathname,
         "package",
@@ -549,6 +563,18 @@ const renderCustomFilters = (
               ({ value, label }) =>
                 `<option value="${escapeHtml(value)}"${params.driver_type === value ? " selected" : ""}>${escapeHtml(label)}</option>`,
             ).join("")}
+          </select>
+        </div>
+        <div>
+          <label>Max Resolution:</label>
+          <select name="max_resolution">
+            <option value="">All</option>
+            ${maxResolutionOptions
+              .map(
+                (option) =>
+                  `<option value="${escapeHtml(option)}"${params.max_resolution === option ? " selected" : ""}>${escapeHtml(option)}</option>`,
+              )
+              .join("")}
           </select>
         </div>
         <div>

--- a/cf-proxy/test/lcd-drivers-route.test.ts
+++ b/cf-proxy/test/lcd-drivers-route.test.ts
@@ -25,6 +25,27 @@ describe("LCD driver route", () => {
             return { rows: [{ package: "SSOP-48-300mil" }] }
           }
 
+          if (
+            compiledQuery.sql.includes('select "mfr", "description", "extra"')
+          ) {
+            return {
+              rows: [
+                {
+                  mfr: "HT1621B",
+                  description: "32x4 bit LCD driver",
+                  extra:
+                    '{"attributes":{"Display Configurations(bit)":"32x4 bit"}}',
+                },
+                {
+                  mfr: "HT1622",
+                  description: "32x8 bit LCD driver",
+                  extra:
+                    '{"attributes":{"Display Configurations(bit)":"32x8 bit"}}',
+                },
+              ],
+            }
+          }
+
           return {
             rows: [
               {
@@ -36,7 +57,20 @@ describe("LCD driver route", () => {
                 price: '[{"qFrom":1,"price":0.464285714}]',
                 basic: 0,
                 preferred: 1,
-                extra: '{"attributes":{"Interface":"Serial"}}',
+                extra:
+                  '{"attributes":{"Display Configurations":"32x4 bit","Interface":"Serial"}}',
+              },
+              {
+                lcsc: 46302,
+                mfr: "HT1622",
+                package: "LQFP-64(7x7)",
+                description: "LCD driver",
+                stock: 4541,
+                price: '[{"qFrom":1,"price":0.901428571}]',
+                basic: 0,
+                preferred: 1,
+                extra:
+                  '{"attributes":{"Display Configurations(bit)":"32x8 bit"}}',
               },
             ],
           }
@@ -60,30 +94,36 @@ describe("LCD driver route", () => {
       const result = await handler!(db, {
         package: "SSOP-48-300mil",
         is_preferred: "true",
+        max_resolution: "32x4",
       })
 
       expect(result).toEqual({
         tableName: "lcd_driver",
-        filterOptions: { package: ["SSOP-48-300mil"] },
+        filterOptions: {
+          package: ["SSOP-48-300mil"],
+          max_resolution: ["32x4", "32x8"],
+        },
         data: {
           lcd_drivers: [
             {
               lcsc: 7873,
               mfr: "HT1621B",
               package: "SSOP-48-300mil",
+              max_resolution: "32x4",
               description: "LCD driver",
               is_basic: false,
               is_preferred: true,
               stock: 18416,
               price1: 0.464285714,
-              attributes: '{"Interface":"Serial"}',
+              attributes:
+                '{"Display Configurations":"32x4 bit","Interface":"Serial"}',
             },
           ],
         },
       })
 
-      const partsQuery = compiledQueries.find(
-        (query) => !query.sql.includes('select distinct "package"'),
+      const partsQuery = compiledQueries.find((query) =>
+        query.sql.includes('select "lcsc"'),
       )
       expect(partsQuery?.sql).toContain('"subcategory" = ?')
       expect(partsQuery?.sql).toContain('"package" = ?')
@@ -93,7 +133,6 @@ describe("LCD driver route", () => {
         "LCD Drivers",
         "SSOP-48-300mil",
         1,
-        100,
       ])
     } finally {
       await db.destroy()

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -94,19 +94,30 @@ describe("render helpers", () => {
             lcsc: 7873,
             mfr: "HT1621B",
             package: "SSOP-48-300mil",
+            max_resolution: "32x4",
             is_basic: false,
             is_preferred: true,
             stock: 18416,
           },
         ],
       },
-      { package: "SSOP-48-300mil", is_preferred: "true" },
-      "https://jlcsearch.tscircuit.com/lcd_drivers/list?package=SSOP-48-300mil&is_preferred=true",
-      { package: ["SSOP-48-300mil"] },
+      {
+        package: "SSOP-48-300mil",
+        max_resolution: "32x4",
+        is_preferred: "true",
+      },
+      "https://jlcsearch.tscircuit.com/lcd_drivers/list?package=SSOP-48-300mil&max_resolution=32x4&is_preferred=true",
+      {
+        package: ["SSOP-48-300mil"],
+        max_resolution: ["32x4", "32x8"],
+      },
     )
 
     expect(html).toContain("<h2>LCD Drivers</h2>")
     expect(html).toContain('name="package"')
+    expect(html).toContain('name="max_resolution"')
+    expect(html).toContain('value="32x4" selected')
+    expect(html).toContain(">Max Resolution</th>")
     expect(html).toContain('name="is_basic"')
     expect(html).toContain('name="is_preferred" value="true" checked')
     expect(html).toContain("HT1621B")
@@ -126,18 +137,29 @@ describe("render helpers", () => {
             mfr: "SSD1963QL9",
             package: "LQFP-128(14x14)",
             driver_type: "Display Controller",
+            max_resolution: "864x480",
             stock: 604,
           },
         ],
       },
-      { driver_type: "controller", is_preferred: "true" },
-      "https://jlcsearch.tscircuit.com/tft_display_drivers/list?driver_type=controller&is_preferred=true",
-      { package: ["LQFP-128(14x14)"] },
+      {
+        driver_type: "controller",
+        max_resolution: "864x480",
+        is_preferred: "true",
+      },
+      "https://jlcsearch.tscircuit.com/tft_display_drivers/list?driver_type=controller&max_resolution=864x480&is_preferred=true",
+      {
+        package: ["LQFP-128(14x14)"],
+        max_resolution: ["864x480"],
+      },
     )
 
     expect(html).toContain("<h2>TFT Display Drivers</h2>")
     expect(html).toContain('name="driver_type"')
     expect(html).toContain('value="controller" selected')
+    expect(html).toContain('name="max_resolution"')
+    expect(html).toContain('value="864x480" selected')
+    expect(html).toContain(">Max Resolution</th>")
     expect(html).toContain("Display Controller")
     expect(html).toContain("SSD1963QL9")
     expect(html).toContain("/tft_display_drivers/list.json")

--- a/cf-proxy/test/tft-display-drivers-route.test.ts
+++ b/cf-proxy/test/tft-display-drivers-route.test.ts
@@ -10,6 +10,10 @@ import {
 import { describe, expect, it } from "vitest"
 import { getD1Handler } from "../src/d1-routes"
 import type { DB } from "../src/db/types"
+import {
+  createDisplayDriverMaxResolutionResolver,
+  getDisplayDriverMaxResolution,
+} from "../src/display-driver-resolution"
 import { getTftDisplayDriverFamily } from "../src/tft-display-drivers"
 
 describe("TFT display driver route", () => {
@@ -29,6 +33,53 @@ describe("TFT display driver route", () => {
     expect(getTftDisplayDriverFamily("HT1621B")).toBeUndefined()
   })
 
+  it("derives the largest catalog configuration and known TFT maxima", () => {
+    expect(
+      getDisplayDriverMaxResolution({
+        mfr: "HT1621B",
+        description: "SSOP-48-300mil LCD driver",
+        extra:
+          '{"attributes":{"Display Configurations(bit)":"20x4 bit, 16x8 bit"}}',
+      }),
+    ).toBe("16x8")
+    expect(
+      getDisplayDriverMaxResolution({
+        mfr: "HT1622",
+        description: "32x8 bit LQFP-64(7x7) LCD driver",
+        extra: "{}",
+      }),
+    ).toBe("32x8")
+    expect(
+      getDisplayDriverMaxResolution({
+        mfr: "SSD1963QL9",
+        description: "LQFP-128(14x14) LCD driver",
+        extra: "{}",
+      }),
+    ).toBe("864x480")
+    expect(
+      getDisplayDriverMaxResolution({
+        mfr: "LT7689",
+        description: "QFN-96-EP(10x10) LCD driver",
+        extra: "{}",
+      }),
+    ).toBe("1280x1024")
+
+    const resolveFromRelatedCatalogRows =
+      createDisplayDriverMaxResolutionResolver([
+        {
+          mfr: "HT1622-LQFP64",
+          extra: '{"attributes":{"Display Configurations(bit)":"32x8 bit"}}',
+        },
+      ])
+    expect(
+      resolveFromRelatedCatalogRows({
+        mfr: "HT1622",
+        description: "LQFP-64(7x7) LCD driver",
+        extra: "{}",
+      }),
+    ).toBe("32x8")
+  })
+
   it("selects and labels TFT controller families", async () => {
     const compiledQueries: CompiledQuery[] = []
     const driver = new DummyDriver()
@@ -40,6 +91,20 @@ describe("TFT display driver route", () => {
 
           if (compiledQuery.sql.includes('select distinct "package"')) {
             return { rows: [{ package: "LQFP-128(14x14)" }] }
+          }
+
+          if (
+            compiledQuery.sql.includes('select "mfr", "description", "extra"')
+          ) {
+            return {
+              rows: [
+                {
+                  mfr: "SSD1963QL9",
+                  description: "TFT LCD controller",
+                  extra: "{}",
+                },
+              ],
+            }
           }
 
           return {
@@ -79,6 +144,7 @@ describe("TFT display driver route", () => {
         driver_type: "controller",
         package: "LQFP-128(14x14)",
         is_preferred: "true",
+        max_resolution: "864x480",
       })
 
       expect(result.data.tft_display_drivers).toEqual([
@@ -88,6 +154,7 @@ describe("TFT display driver route", () => {
           package: "LQFP-128(14x14)",
           driver_type: "Display Controller",
           catalog_type: "LCD Drivers",
+          max_resolution: "864x480",
           description: "TFT LCD controller",
           is_basic: false,
           is_preferred: true,
@@ -97,9 +164,10 @@ describe("TFT display driver route", () => {
         },
       ])
       expect(result.filterOptions?.package).toEqual(["LQFP-128(14x14)"])
+      expect(result.filterOptions?.max_resolution).toEqual(["864x480"])
 
-      const partsQuery = compiledQueries.find(
-        (query) => !query.sql.includes('select distinct "package"'),
+      const partsQuery = compiledQueries.find((query) =>
+        query.sql.includes('select "lcsc"'),
       )
       expect(partsQuery?.sql).toContain('"subcategory" in (?, ?)')
       expect(partsQuery?.sql).toContain('"mfr" like ?')


### PR DESCRIPTION
## Summary

- add a `Max Resolution` column and exact-value filter to the LCD driver and TFT display driver pages
- derive LCD configurations from the catalog's `Display Configurations(bit)` variants, safe description matches, and agreeing related model rows
- fill current TFT controller maxima from the datasheets linked by their database records when catalog attributes omit resolution
- apply resolution filtering before the 100-row response cap and expose `max_resolution` in JSON responses

## Why

The component catalog does not provide one consistent resolution column. Segment LCD parts use several display-configuration attribute names, some duplicate package rows omit attributes, and the current TFT controller rows do not include resolution attributes at all. Centralizing the derivation keeps the page and API behavior consistent without requiring a database schema migration.

## Impact

Users can see the maximum supported display configuration on both driver pages and filter the catalog to a specific resolution. Parts without enough trustworthy data retain a blank value instead of receiving a guessed resolution.

## Validation

- `bun run test` in `cf-proxy` — 134 tests passed
- `bunx tsc --noEmit --project tsconfig.json` in `cf-proxy`
- `bun run format:check`
- `git diff --check`