### PR TITLE
Ensure memory connector D1 tables exist before deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ To add a component page:
 5. Run `bun run format`, `bunx tsc --noEmit --project cf-proxy/tsconfig.json`,
    and `bun run test --cwd cf-proxy`.
 
-Use `bun deploy` to publish the worker. Use `cf-proxy/scripts/sync-db.sh` to
-rebuild and synchronize derived tables from a prepared local SQLite database.
+Use `bun deploy` to apply pending D1 schema migrations and then publish the
+worker. Use `cf-proxy/scripts/sync-db.sh` to rebuild and synchronize derived
+table data from a prepared local SQLite database.
 
 ## How Does It work?
 As a developer new to this codebase, or a curious user, you may have some questions about the flow of data through the scripts and automations inside this repo.  It all starts with the [jlcparts](https://github.com/yaqwsx/jlcparts) project, which compiles a massive **11GB** sqlite3 database of *everything* [JLCPCB](https://jlcpcb.com) has to offer.  As you can imagine, this would be very resource-intensive and slow to search, so the next steps are scripts that optimize it heavily, although it's more accurate to say that they rebuild it entirely. 

--- a/cf-proxy/migrations/0001_memory_connector_tables.sql
+++ b/cf-proxy/migrations/0001_memory_connector_tables.sql
@@ -1,0 +1,83 @@
+CREATE TABLE IF NOT EXISTS dimm_connector (
+  lcsc INTEGER PRIMARY KEY,
+  mfr TEXT,
+  description TEXT,
+  stock INTEGER,
+  price1 REAL,
+  in_stock BOOLEAN,
+  package TEXT,
+  ddr_standard TEXT,
+  num_pins INTEGER,
+  pitch_mm REAL,
+  height_above_board_mm REAL,
+  mounting_type TEXT,
+  operating_temp_min REAL,
+  operating_temp_max REAL,
+  is_right_angle BOOLEAN,
+  is_basic BOOLEAN,
+  is_preferred BOOLEAN,
+  attributes TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_dimm_connector_stock
+  ON dimm_connector (stock);
+CREATE INDEX IF NOT EXISTS idx_dimm_connector_package_stock
+  ON dimm_connector (package, stock);
+CREATE INDEX IF NOT EXISTS idx_dimm_connector_ddr_standard_stock
+  ON dimm_connector (ddr_standard, stock);
+CREATE INDEX IF NOT EXISTS idx_dimm_connector_num_pins_stock
+  ON dimm_connector (num_pins, stock);
+CREATE INDEX IF NOT EXISTS idx_dimm_connector_pitch_mm_stock
+  ON dimm_connector (pitch_mm, stock);
+CREATE INDEX IF NOT EXISTS idx_dimm_connector_height_above_board_mm_stock
+  ON dimm_connector (height_above_board_mm, stock);
+CREATE INDEX IF NOT EXISTS idx_dimm_connector_mounting_type_stock
+  ON dimm_connector (mounting_type, stock);
+CREATE INDEX IF NOT EXISTS idx_dimm_connector_is_right_angle_stock
+  ON dimm_connector (is_right_angle, stock);
+CREATE INDEX IF NOT EXISTS idx_dimm_connector_is_basic_stock
+  ON dimm_connector (is_basic, stock);
+CREATE INDEX IF NOT EXISTS idx_dimm_connector_is_preferred_stock
+  ON dimm_connector (is_preferred, stock);
+
+CREATE TABLE IF NOT EXISTS sodimm_connector (
+  lcsc INTEGER PRIMARY KEY,
+  mfr TEXT,
+  description TEXT,
+  stock INTEGER,
+  price1 REAL,
+  in_stock BOOLEAN,
+  package TEXT,
+  ddr_standard TEXT,
+  num_pins INTEGER,
+  pitch_mm REAL,
+  height_above_board_mm REAL,
+  mounting_type TEXT,
+  operating_temp_min REAL,
+  operating_temp_max REAL,
+  is_right_angle BOOLEAN,
+  is_basic BOOLEAN,
+  is_preferred BOOLEAN,
+  attributes TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_sodimm_connector_stock
+  ON sodimm_connector (stock);
+CREATE INDEX IF NOT EXISTS idx_sodimm_connector_package_stock
+  ON sodimm_connector (package, stock);
+CREATE INDEX IF NOT EXISTS idx_sodimm_connector_ddr_standard_stock
+  ON sodimm_connector (ddr_standard, stock);
+CREATE INDEX IF NOT EXISTS idx_sodimm_connector_num_pins_stock
+  ON sodimm_connector (num_pins, stock);
+CREATE INDEX IF NOT EXISTS idx_sodimm_connector_pitch_mm_stock
+  ON sodimm_connector (pitch_mm, stock);
+CREATE INDEX IF NOT EXISTS idx_sodimm_connector_height_above_board_mm_stock
+  ON sodimm_connector (height_above_board_mm, stock);
+CREATE INDEX IF NOT EXISTS idx_sodimm_connector_mounting_type_stock
+  ON sodimm_connector (mounting_type, stock);
+CREATE INDEX IF NOT EXISTS idx_sodimm_connector_is_right_angle_stock
+  ON sodimm_connector (is_right_angle, stock);
+CREATE INDEX IF NOT EXISTS idx_sodimm_connector_is_basic_stock
+  ON sodimm_connector (is_basic, stock);
+CREATE INDEX IF NOT EXISTS idx_sodimm_connector_is_preferred_stock
+  ON sodimm_connector (is_preferred, stock);

--- a/cf-proxy/package.json
+++ b/cf-proxy/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
+    "deploy": "bash scripts/deploy.sh",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/cf-proxy/scripts/deploy.sh
+++ b/cf-proxy/scripts/deploy.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+bunx wrangler d1 migrations apply jlcsearch --remote
+bunx wrangler deploy

--- a/lib/db/derivedtables/memory-connector.ts
+++ b/lib/db/derivedtables/memory-connector.ts
@@ -157,6 +157,45 @@ const createMemoryConnectorTableSpec = (
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
   ],
+  indexes: [
+    { name: `idx_${tableName}_stock`, columns: ["stock"] },
+    {
+      name: `idx_${tableName}_package_stock`,
+      columns: ["package", "stock"],
+    },
+    {
+      name: `idx_${tableName}_ddr_standard_stock`,
+      columns: ["ddr_standard", "stock"],
+    },
+    {
+      name: `idx_${tableName}_num_pins_stock`,
+      columns: ["num_pins", "stock"],
+    },
+    {
+      name: `idx_${tableName}_pitch_mm_stock`,
+      columns: ["pitch_mm", "stock"],
+    },
+    {
+      name: `idx_${tableName}_height_above_board_mm_stock`,
+      columns: ["height_above_board_mm", "stock"],
+    },
+    {
+      name: `idx_${tableName}_mounting_type_stock`,
+      columns: ["mounting_type", "stock"],
+    },
+    {
+      name: `idx_${tableName}_is_right_angle_stock`,
+      columns: ["is_right_angle", "stock"],
+    },
+    {
+      name: `idx_${tableName}_is_basic_stock`,
+      columns: ["is_basic", "stock"],
+    },
+    {
+      name: `idx_${tableName}_is_preferred_stock`,
+      columns: ["is_preferred", "stock"],
+    },
+  ],
   listCandidateComponents: (db) =>
     db
       .selectFrom("components")

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -104,6 +104,28 @@ const jsonParseOrNull = (strObject: string) => {
   }
 }
 
+const createIndexes = async (
+  db: KyselyDatabaseInstance,
+  spec: DerivedTableSpec<any>,
+) => {
+  for (const index of spec.indexes ?? []) {
+    const columns = index.columns.map(String)
+    if (columns.length === 0) continue
+
+    let indexCreator = db.schema
+      .createIndex(index.name)
+      .ifNotExists()
+      .on(spec.tableName)
+
+    indexCreator =
+      columns.length === 1
+        ? indexCreator.column(columns[0])
+        : indexCreator.columns(columns)
+
+    await indexCreator.execute()
+  }
+}
+
 const createTable = async (
   db: KyselyDatabaseInstance,
   spec: DerivedTableSpec<any>,
@@ -126,6 +148,7 @@ const createTable = async (
 
   if (tableExists.rows.length > 0) {
     if (!resetAll && resetTable !== spec.tableName) {
+      await createIndexes(db, spec)
       logger(
         `Table ${spec.tableName} already exists, skipping (use --reset ${spec.tableName} to recreate this table, or --reset with no parameter to recreate all)`,
       )
@@ -154,6 +177,7 @@ const createTable = async (
   }
 
   await tableCreator.execute()
+  await createIndexes(db, spec)
 
   if (!populate) {
     return

--- a/lib/db/derivedtables/types.ts
+++ b/lib/db/derivedtables/types.ts
@@ -22,6 +22,10 @@ export interface DerivedTableSpec<
     name: keyof Resource
     type: string
   }>
+  indexes?: Array<{
+    name: string
+    columns: Array<keyof Resource>
+  }>
   listCandidateComponents: (
     db: KyselyDatabaseInstance,
   ) => SelectQueryBuilder<any, any, any>

--- a/tests/lib/memory-connector-schema.test.ts
+++ b/tests/lib/memory-connector-schema.test.ts
@@ -1,0 +1,92 @@
+import { Database } from "bun:sqlite"
+import { expect, test } from "bun:test"
+import { Kysely } from "kysely"
+import { BunSqliteDialect } from "kysely-bun-sqlite"
+import {
+  dimmConnectorTableSpec,
+  sodimmConnectorTableSpec,
+} from "lib/db/derivedtables/memory-connector"
+import { setupDerivedTables } from "lib/db/derivedtables/setup-derived-tables"
+
+const EXPECTED_INDEX_COLUMNS = [
+  "stock",
+  "package,stock",
+  "ddr_standard,stock",
+  "num_pins,stock",
+  "pitch_mm,stock",
+  "height_above_board_mm,stock",
+  "mounting_type,stock",
+  "is_right_angle,stock",
+  "is_basic,stock",
+  "is_preferred,stock",
+]
+
+test("memory connector derived table specs declare their query indexes", () => {
+  for (const spec of [dimmConnectorTableSpec, sodimmConnectorTableSpec]) {
+    expect(spec.indexes?.map((index) => index.columns.join(","))).toEqual(
+      EXPECTED_INDEX_COLUMNS,
+    )
+  }
+})
+
+test("derived table setup creates memory connector tables and indexes", async () => {
+  const database = new Database(":memory:")
+  const db = new Kysely<any>({
+    dialect: new BunSqliteDialect({ database }),
+  })
+
+  try {
+    await setupDerivedTables({ db, populate: false })
+
+    for (const tableName of ["dimm_connector", "sodimm_connector"]) {
+      const table = database
+        .query(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+        )
+        .get(tableName)
+      const indexes = database
+        .query(
+          "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = ? AND name NOT LIKE 'sqlite_%'",
+        )
+        .all(tableName)
+
+      expect(table).not.toBeNull()
+      expect(indexes).toHaveLength(EXPECTED_INDEX_COLUMNS.length)
+    }
+  } finally {
+    await db.destroy()
+  }
+})
+
+test("D1 migration creates both memory connector schemas idempotently", async () => {
+  const database = new Database(":memory:")
+  const migrationPath = new URL(
+    "../../cf-proxy/migrations/0001_memory_connector_tables.sql",
+    import.meta.url,
+  )
+  const migration = await Bun.file(migrationPath).text()
+
+  try {
+    database.exec(migration)
+    database.exec(migration)
+
+    const tables = database
+      .query(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('dimm_connector', 'sodimm_connector') ORDER BY name",
+      )
+      .all() as Array<{ name: string }>
+    const indexes = database
+      .query(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name IN ('dimm_connector', 'sodimm_connector') AND name NOT LIKE 'sqlite_%'",
+      )
+      .all()
+
+    expect(tables.map((table) => table.name)).toEqual([
+      "dimm_connector",
+      "sodimm_connector",
+    ])
+    expect(indexes).toHaveLength(EXPECTED_INDEX_COLUMNS.length * 2)
+  } finally {
+    database.close()
+  }
+})


### PR DESCRIPTION
## Summary

- add an idempotent D1 migration for `dimm_connector` and `sodimm_connector`
- apply pending D1 migrations before every worker deployment
- add derived-table index declarations and create missing indexes during normal table setup
- index stock ordering and every DIMM/SO-DIMM filter field
- add schema, index, and migration idempotency tests

## Incident

After #418 deployed, both connector routes returned `D1_ERROR: no such table` because the worker route was published before the new derived tables had been synchronized. This keeps the routes backed exclusively by their derived tables—there is no catalog fallback.

The production migration has already been applied and the existing catalog records have been materialized. Both `/dimm_connectors/list.json` and `/sodimm_connectors/list.json` now return HTTP 200 from D1.

## Verification

- `bun test` — 163 passed
- `bun run test` in `cf-proxy` — 135 passed
- root and worker TypeScript checks passed
- format and shell syntax checks passed
- production: 10 indexes on each table, 9 DIMM rows, 1 SO-DIMM row