### PR TITLE
Limit homepage cache to one hour

### DIFF
--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -1,7 +1,7 @@
 import { CacheService, addCorsHeaders, addVaryHeader } from "./cache-service"
 import { queryComponentCatalog } from "./components"
-import { getD1Client } from "./db/get-d1-client"
 import { getD1Handler } from "./d1-routes"
+import { getD1Client } from "./db/get-d1-client"
 import { renderD1TablePage, renderHomePage } from "./render"
 import { searchIndex } from "./search"
 
@@ -12,6 +12,13 @@ export interface Env {
 }
 
 const CACHE_BUST_QUERY_PARAM = "cachebust"
+const HOME_PAGE_CACHE_MAX_AGE_SECONDS = 60 * 60
+const HOME_PAGE_CACHE_CONTROL = [
+  "public",
+  `max-age=${HOME_PAGE_CACHE_MAX_AGE_SECONDS}`,
+  `s-maxage=${HOME_PAGE_CACHE_MAX_AGE_SECONDS}`,
+  "must-revalidate",
+].join(", ")
 
 const extractSmallQuantityPrice = (price: string | null): string | number => {
   if (!price) return ""
@@ -289,14 +296,8 @@ async function tryD1Route(
   cacheBust = false,
 ): Promise<Response | null> {
   if (url.pathname === "/") {
-    return handleCachedD1Response(
-      url,
-      origin,
-      ctx,
-      cache,
-      async () => handleD1HomePage(origin),
-      { cacheBust },
-    )
+    const response = handleD1HomePage(origin)
+    return cacheBust ? withCacheBustHeaders(response, origin) : response
   }
 
   const hasJsonSuffix = url.pathname.endsWith(".json")
@@ -400,6 +401,7 @@ const getD1RepresentationCacheUrl = (url: URL, isJsonRequest: boolean): URL => {
 
 function handleD1HomePage(origin: string | null): Response {
   const headers = new Headers({
+    "cache-control": HOME_PAGE_CACHE_CONTROL,
     "content-type": "text/html; charset=utf-8",
     "x-data-source": "d1",
     "x-cache": "D1",

--- a/cf-proxy/test/worker.test.ts
+++ b/cf-proxy/test/worker.test.ts
@@ -229,7 +229,7 @@ describe("Worker integration", () => {
     expect(await response.text()).toBe(testBody)
   })
 
-  it("evicts and refreshes the canonical cache entry when cachebust=1 is present", async () => {
+  it("serves the homepage with one-hour caching without using KV", async () => {
     env.USE_D1 = "true"
 
     const url = new URL("https://example.com/")
@@ -244,18 +244,27 @@ describe("Worker integration", () => {
       },
     })
 
+    const response = await SELF.fetch("https://example.com/")
+    const body = await response.text()
+
+    expect(response.headers.get("x-cache")).toBe("D1")
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=3600, s-maxage=3600, must-revalidate",
+    )
+    expect(body).not.toContain(staleBody)
+    expect(body).toContain("JLCPCB In-Stock Parts Engine")
+  })
+
+  it("disables homepage caching when cachebust=1 is present", async () => {
+    env.USE_D1 = "true"
+
     const bustedResponse = await SELF.fetch("https://example.com/?cachebust=1")
     const bustedBody = await bustedResponse.text()
 
-    expect(bustedResponse.headers.get("x-cache")).toBe("BUST")
+    expect(bustedResponse.headers.get("x-cache")).toBe("D1")
     expect(bustedResponse.headers.get("x-cache-bust")).toBe("1")
     expect(bustedResponse.headers.get("cache-control")).toBe("no-store")
-    expect(bustedBody).not.toContain(staleBody)
     expect(bustedBody).toContain("JLCPCB In-Stock Parts Engine")
-
-    const cachedResponse = await SELF.fetch("https://example.com/")
-    expect(cachedResponse.headers.get("x-cache")).toBe("HIT")
-    expect(await cachedResponse.text()).toBe(bustedBody)
   })
 
   it("handles different cache key for different query params", async () => {


### PR DESCRIPTION
## Summary

- bypass the long-lived KV cache for the homepage
- cache homepage responses in browsers/shared caches for one hour with `must-revalidate`
- preserve `cachebust=1` as a `no-store` response
- leave existing API and list-route cache behavior unchanged

## Root cause

The homepage used the generic D1 response cache, which treats KV entries as fresh for 14 days and retains stale entries for up to 30 days. Each cached response also advertised a fresh 14-day HTTP cache window. Deploying new homepage markup did not invalidate the canonical KV entry, so users could continue receiving old HTML until manually requesting `cachebust=1`.

## Impact

New homepage responses can remain cached for at most one hour and must be revalidated afterward. Because the homepage is rendered directly from deployed code, bypassing KV also ensures a deployment is not hidden behind an older server-side homepage entry.

Existing browsers that already stored the previous 14-day response may require one final hard refresh after deployment.

## Validation

- `bunx vitest run` — 137 tests passed
- `bunx tsc --noEmit`
- `bunx @biomejs/biome@1.9.4 check cf-proxy/src/index.ts cf-proxy/test/worker.test.ts`
- `git diff --check`