### PR TITLE
Add HDMI port page and API

### DIFF
--- a/cf-proxy/migrations/0002_hdmi_port.sql
+++ b/cf-proxy/migrations/0002_hdmi_port.sql
@@ -1,0 +1,37 @@
+CREATE TABLE IF NOT EXISTS hdmi_port (
+  lcsc INTEGER PRIMARY KEY,
+  mfr TEXT,
+  description TEXT,
+  stock INTEGER,
+  price1 REAL,
+  in_stock BOOLEAN,
+  package TEXT,
+  mounting_style TEXT,
+  orientation TEXT,
+  gender TEXT,
+  number_of_pins INTEGER,
+  number_of_rows INTEGER,
+  current_rating_a REAL,
+  operating_temp_min REAL,
+  operating_temp_max REAL,
+  is_basic BOOLEAN,
+  is_preferred BOOLEAN,
+  attributes TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_hdmi_port_stock
+  ON hdmi_port (stock);
+CREATE INDEX IF NOT EXISTS idx_hdmi_port_package_stock
+  ON hdmi_port (package, stock);
+CREATE INDEX IF NOT EXISTS idx_hdmi_port_mounting_style_stock
+  ON hdmi_port (mounting_style, stock);
+CREATE INDEX IF NOT EXISTS idx_hdmi_port_orientation_stock
+  ON hdmi_port (orientation, stock);
+CREATE INDEX IF NOT EXISTS idx_hdmi_port_gender_stock
+  ON hdmi_port (gender, stock);
+CREATE INDEX IF NOT EXISTS idx_hdmi_port_number_of_pins_stock
+  ON hdmi_port (number_of_pins, stock);
+CREATE INDEX IF NOT EXISTS idx_hdmi_port_is_basic_stock
+  ON hdmi_port (is_basic, stock);
+CREATE INDEX IF NOT EXISTS idx_hdmi_port_is_preferred_stock
+  ON hdmi_port (is_preferred, stock);

--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -39,6 +39,7 @@ DERIVED_TABLES=(
   gas_sensor
   gyroscope
   header
+  hdmi_port
   io_expander
   jst_connector
   lcd_display

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -438,6 +438,27 @@ export interface Header {
   voltage_rating_volt: number | null
 }
 
+export interface HdmiPort {
+  attributes: string | null
+  current_rating_a: number | null
+  description: string | null
+  gender: string | null
+  in_stock: number | null
+  is_basic: number | null
+  is_preferred: number | null
+  lcsc: Generated<number | null>
+  mfr: string | null
+  mounting_style: string | null
+  number_of_pins: number | null
+  number_of_rows: number | null
+  operating_temp_max: number | null
+  operating_temp_min: number | null
+  orientation: string | null
+  package: string | null
+  price1: number | null
+  stock: number | null
+}
+
 export interface IoExpander {
   attributes: string | null
   clock_frequency_hz: number | null
@@ -966,6 +987,7 @@ export interface DB {
   gas_sensor: GasSensor
   gyroscope: Gyroscope
   header: Header
+  hdmi_port: HdmiPort
   io_expander: IoExpander
   jst_connector: JstConnector
   lcd_display: LcdDisplay

--- a/cf-proxy/src/handlers/index.ts
+++ b/cf-proxy/src/handlers/index.ts
@@ -385,6 +385,17 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       sensor_type: { field: "sensor_type", type: "string" },
     },
   },
+  hdmi_port: {
+    filters: {
+      package: { field: "package", type: "string" },
+      mounting_style: { field: "mounting_style", type: "string" },
+      orientation: { field: "orientation", type: "string" },
+      gender: { field: "gender", type: "string" },
+      number_of_pins: { field: "number_of_pins", type: "number" },
+      is_basic: { field: "is_basic", type: "boolean" },
+      is_preferred: { field: "is_preferred", type: "boolean" },
+    },
+  },
   gyroscope: {
     filters: {
       package: { field: "package", type: "string" },
@@ -541,6 +552,7 @@ export const ROUTE_TO_TABLE: Record<string, string> = {
   "/fpgas/list": "fpga",
   "/fuses/list": "fuse",
   "/gas_sensors/list": "gas_sensor",
+  "/hdmi_ports/list": "hdmi_port",
   "/gyroscopes/list": "gyroscope",
   "/io_expanders/list": "io_expander",
   "/jst_connectors/list": "jst_connector",
@@ -588,6 +600,7 @@ export const TABLE_RESPONSE_KEY: Record<string, string> = {
   fpga: "fpgas",
   fuse: "fuses",
   gas_sensor: "gas_sensors",
+  hdmi_port: "hdmi_ports",
   gyroscope: "gyroscopes",
   io_expander: "io_expanders",
   jst_connector: "jst_connectors",

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -42,6 +42,7 @@ const routeLabels: Record<string, string> = {
   "/gyroscopes/list": "Gyroscopes",
   "/accelerometers/list": "Accelerometers",
   "/gas_sensors/list": "Gas Sensors",
+  "/hdmi_ports/list": "HDMI Ports",
   "/microphones/list": "Microphones",
   "/diodes/list": "Diodes",
   "/dacs/list": "DACs",
@@ -167,6 +168,8 @@ const COLUMN_LABELS: Record<string, string> = {
   wavelength_nm: "Wavelength",
   luminous_intensity_mcd: "Intensity",
   number_of_contacts: "Contacts",
+  number_of_pins: "Pins",
+  number_of_rows: "Rows",
   num_channels: "Channels",
   num_bits: "Bits",
   num_pins: "Pins",
@@ -281,6 +284,8 @@ const formatDisplayValue = (column: string, value: unknown): string | null => {
     case "pin_count":
     case "channel_count":
     case "number_of_contacts":
+    case "number_of_pins":
+    case "number_of_rows":
     case "gpio_count":
       return formatCount(value)
     case "current_rating":

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -16,6 +16,58 @@ describe("render helpers", () => {
     expect(html).toContain("/ble_chips/list")
     expect(html).toContain("/dimm_connectors/list")
     expect(html).toContain("/sodimm_connectors/list")
+    expect(html).toContain("/hdmi_ports/list")
+  })
+
+  it("renders the HDMI ports page and JSON API link", () => {
+    const pathname = "/hdmi_ports/list"
+
+    expect(D1_ROUTES).toContain(pathname)
+    expect(getD1Handler(pathname)).toBeTypeOf("function")
+
+    const html = renderD1TablePage(
+      pathname,
+      {
+        hdmi_ports: [
+          {
+            lcsc: 720616,
+            mfr: "HDMI-001S",
+            package: "SMD",
+            mounting_style: "Surface Mount",
+            orientation: "Horizontal",
+            gender: "Female",
+            number_of_pins: 19,
+            current_rating_a: 0.5,
+            stock: 16120,
+          },
+        ],
+      },
+      {
+        package: "SMD",
+        mounting_style: "Surface Mount",
+        gender: "Female",
+        number_of_pins: "19",
+      },
+      "https://jlcsearch.tscircuit.com/hdmi_ports/list?package=SMD&mounting_style=Surface+Mount&gender=Female&number_of_pins=19",
+      {
+        package: ["SMD", "Push-Pull"],
+        mounting_style: ["Surface Mount", "Through Hole"],
+        gender: ["Female", "Male"],
+        number_of_pins: ["19"],
+      },
+    )
+
+    expect(html).toContain("<h2>HDMI Ports</h2>")
+    expect(html).toContain('name="package"')
+    expect(html).toContain('name="mounting_style"')
+    expect(html).toContain('name="orientation"')
+    expect(html).toContain('name="gender"')
+    expect(html).toContain('name="number_of_pins"')
+    expect(html).toContain('name="is_basic"')
+    expect(html).toContain('name="is_preferred"')
+    expect(html).toContain("HDMI-001S")
+    expect(html).toContain("500mA")
+    expect(html).toContain("/hdmi_ports/list.json")
   })
 
   it.each([

--- a/lib/db/derivedtables/hdmi-port.ts
+++ b/lib/db/derivedtables/hdmi-port.ts
@@ -1,0 +1,193 @@
+import { BaseComponent } from "lib/db/derivedtables/component-base"
+import type { DerivedTableSpec } from "lib/db/derivedtables/types"
+import type { KyselyDatabaseInstance } from "lib/db/kysely-types"
+import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+
+export interface HdmiPort extends BaseComponent {
+  package: string
+  mounting_style: string | null
+  orientation: string | null
+  gender: string | null
+  number_of_pins: number | null
+  number_of_rows: number | null
+  current_rating_a: number | null
+  operating_temp_min: number | null
+  operating_temp_max: number | null
+}
+
+const HDMI_SUBCATEGORIES = [
+  "HDMI Connectors",
+  "D-Sub/DVI/HDMI Connectors",
+  "D-Sub / VGA Connectors",
+  "Audio & Video Connectors",
+] as const
+
+const parseNumber = (value: string | undefined): number | null => {
+  if (!value || value === "-") return null
+  const parsed = Number(parseAndConvertSiUnit(value).value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const parseInteger = (value: string | undefined): number | null => {
+  if (!value || value === "-") return null
+  const match = value.match(/\d+/)
+  if (!match) return null
+  const parsed = Number.parseInt(match[0], 10)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const inferPinCount = (
+  attrs: Record<string, string>,
+  description: string,
+): number | null =>
+  parseInteger(attrs["Number of Pins"] ?? attrs["Number of Contacts"]) ??
+  parseInteger(description.match(/\b\d+\s*(?:P|Pins?)\b/i)?.[0])
+
+const inferMountingStyle = (
+  attrs: Record<string, string>,
+  packageName: string,
+  description: string,
+): string | null => {
+  if (attrs["Mounting Style"] && attrs["Mounting Style"] !== "-") {
+    return attrs["Mounting Style"]
+  }
+
+  const searchableText = `${packageName} ${description}`
+  if (/\bSMD\b|surface mount/i.test(searchableText)) return "Surface Mount"
+  if (/\bplugin\b|push-pull|through[- ]hole/i.test(searchableText)) {
+    return "Through Hole"
+  }
+  return null
+}
+
+const inferOrientation = (description: string): string | null => {
+  if (/horizontal attachment|right[- ]angle|bend insert/i.test(description)) {
+    return "Horizontal"
+  }
+  if (/vertical attachment|straight insert/i.test(description)) {
+    return "Vertical"
+  }
+  return null
+}
+
+const parseTemperatureRange = (
+  value: string | undefined,
+): [number | null, number | null] => {
+  if (!value || !value.includes("~")) return [null, null]
+  const [min, max] = value.split("~")
+  return [parseNumber(min), parseNumber(max)]
+}
+
+export const hdmiPortTableSpec: DerivedTableSpec<HdmiPort> = {
+  tableName: "hdmi_port",
+  extraColumns: [
+    { name: "package", type: "text" },
+    { name: "mounting_style", type: "text" },
+    { name: "orientation", type: "text" },
+    { name: "gender", type: "text" },
+    { name: "number_of_pins", type: "integer" },
+    { name: "number_of_rows", type: "integer" },
+    { name: "current_rating_a", type: "real" },
+    { name: "operating_temp_min", type: "real" },
+    { name: "operating_temp_max", type: "real" },
+    { name: "is_basic", type: "boolean" },
+    { name: "is_preferred", type: "boolean" },
+  ],
+  indexes: [
+    { name: "idx_hdmi_port_stock", columns: ["stock"] },
+    {
+      name: "idx_hdmi_port_package_stock",
+      columns: ["package", "stock"],
+    },
+    {
+      name: "idx_hdmi_port_mounting_style_stock",
+      columns: ["mounting_style", "stock"],
+    },
+    {
+      name: "idx_hdmi_port_orientation_stock",
+      columns: ["orientation", "stock"],
+    },
+    {
+      name: "idx_hdmi_port_gender_stock",
+      columns: ["gender", "stock"],
+    },
+    {
+      name: "idx_hdmi_port_number_of_pins_stock",
+      columns: ["number_of_pins", "stock"],
+    },
+    {
+      name: "idx_hdmi_port_is_basic_stock",
+      columns: ["is_basic", "stock"],
+    },
+    {
+      name: "idx_hdmi_port_is_preferred_stock",
+      columns: ["is_preferred", "stock"],
+    },
+  ],
+  listCandidateComponents(db: KyselyDatabaseInstance) {
+    return db
+      .selectFrom("components")
+      .innerJoin("categories", "components.category_id", "categories.id")
+      .selectAll()
+      .where("categories.subcategory", "in", [...HDMI_SUBCATEGORIES])
+  },
+  mapToTable(components) {
+    return components.map((component) => {
+      try {
+        const extra = component.extra ? JSON.parse(component.extra) : {}
+        const attrs: Record<string, string> = extra.attributes || {}
+        const description = String(component.description || "")
+        const packageName = String(component.package || "")
+        const hdmiText = [
+          component.mfr,
+          description,
+          extra.title,
+          attrs["Connector Type"],
+        ]
+          .filter(Boolean)
+          .join(" ")
+
+        if (!/\bHDMI\b/i.test(hdmiText)) return null
+
+        const temperatureRange =
+          attrs["Operating Temperature Range"] ?? attrs["Operating Temperature"]
+        const [operatingTempMin, operatingTempMax] =
+          parseTemperatureRange(temperatureRange)
+
+        const gender =
+          attrs.Gender && attrs.Gender !== "-"
+            ? attrs.Gender
+            : description.match(/\b(?:Female|Male)\b/i)?.[0]
+
+        return {
+          lcsc: Number(component.lcsc),
+          mfr: String(component.mfr || ""),
+          description,
+          stock: Number(component.stock || 0),
+          price1: extractMinQPrice(component.price),
+          in_stock: Boolean((component.stock || 0) > 0),
+          is_basic: Boolean(component.basic),
+          is_preferred: Boolean(component.preferred),
+          package: packageName,
+          mounting_style: inferMountingStyle(attrs, packageName, description),
+          orientation: inferOrientation(description),
+          gender: gender
+            ? gender.charAt(0).toUpperCase() + gender.slice(1).toLowerCase()
+            : null,
+          number_of_pins: inferPinCount(attrs, description),
+          number_of_rows: parseInteger(attrs["Number of Rows"]),
+          current_rating_a: parseNumber(
+            attrs["Current Rating (Max)"] ??
+              attrs["Current Rating-Signal (Max)"],
+          ),
+          operating_temp_min: operatingTempMin,
+          operating_temp_max: operatingTempMax,
+          attributes: attrs,
+        }
+      } catch {
+        return null
+      }
+    })
+  },
+}

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -22,6 +22,7 @@ import { fuseTableSpec } from "lib/db/derivedtables/fuse"
 import { gasSensorTableSpec } from "lib/db/derivedtables/gas_sensor"
 import { gyroscopeTableSpec } from "lib/db/derivedtables/gyroscope"
 import { headerTableSpec } from "lib/db/derivedtables/header"
+import { hdmiPortTableSpec } from "lib/db/derivedtables/hdmi-port"
 import { ioExpanderTableSpec } from "lib/db/derivedtables/io_expander"
 import { jstConnectorTableSpec } from "lib/db/derivedtables/jst_connector"
 import { lcdDisplayTableSpec } from "lib/db/derivedtables/lcd_display"
@@ -54,6 +55,7 @@ export const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   capacitorTableSpec,
   ledTableSpec,
   headerTableSpec,
+  hdmiPortTableSpec,
   adcTableSpec,
   analogMultiplexerTableSpec,
   ioExpanderTableSpec,

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -526,6 +526,27 @@ export interface Header {
   voltage_rating_volt: number | null;
 }
 
+export interface HdmiPort {
+  attributes: string | null;
+  current_rating_a: number | null;
+  description: string | null;
+  gender: string | null;
+  in_stock: number | null;
+  is_basic: number | null;
+  is_preferred: number | null;
+  lcsc: Generated<number | null>;
+  mfr: string | null;
+  mounting_style: string | null;
+  number_of_pins: number | null;
+  number_of_rows: number | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  orientation: string | null;
+  package: string | null;
+  price1: number | null;
+  stock: number | null;
+}
+
 export interface IoExpander {
   attributes: string | null;
   clock_frequency_hz: number | null;
@@ -1025,6 +1046,7 @@ export interface DB {
   gas_sensor: GasSensor;
   gyroscope: Gyroscope;
   header: Header;
+  hdmi_port: HdmiPort;
   io_expander: IoExpander;
   jst_connector: JstConnector;
   lcd_display: LcdDisplay;

--- a/tests/lib/hdmi-port-derived-table.test.ts
+++ b/tests/lib/hdmi-port-derived-table.test.ts
@@ -1,0 +1,188 @@
+import { Database } from "bun:sqlite"
+import { expect, test } from "bun:test"
+import { Kysely } from "kysely"
+import { BunSqliteDialect } from "kysely-bun-sqlite"
+import { hdmiPortTableSpec } from "lib/db/derivedtables/hdmi-port"
+import { setupDerivedTables } from "lib/db/derivedtables/setup-derived-tables"
+
+const makeComponent = (overrides: Record<string, unknown> = {}) =>
+  ({
+    lcsc: 720616,
+    mfr: "HDMI-001S",
+    description:
+      "19P Female HDMI Horizontal attachment 1 500mA -45℃~+85℃ SMD D-Sub / VGA Connectors ROHS",
+    stock: 16120,
+    basic: 0,
+    preferred: 1,
+    price: JSON.stringify([{ qFrom: 1, qTo: null, price: 0.162173913 }]),
+    package: "SMD",
+    extra: JSON.stringify({
+      title: "XUNPU HDMI-001S",
+      attributes: {
+        "Mounting Style": "Surface Mount",
+        "Number of Rows": "1",
+        "Current Rating (Max)": "500mA",
+        "Operating Temperature Range": "-45℃~+85℃",
+        "Number of Pins": "19P",
+        "Connector Type": "HDMI",
+        Gender: "Female",
+      },
+    }),
+    ...overrides,
+  }) as any
+
+const EXPECTED_INDEX_COLUMNS = [
+  "stock",
+  "package,stock",
+  "mounting_style,stock",
+  "orientation,stock",
+  "gender,stock",
+  "number_of_pins,stock",
+  "is_basic,stock",
+  "is_preferred,stock",
+]
+
+test("HDMI port table maps connector attributes", () => {
+  const [port] = hdmiPortTableSpec.mapToTable([makeComponent()])
+
+  expect(port).toMatchObject({
+    lcsc: 720616,
+    mfr: "HDMI-001S",
+    package: "SMD",
+    mounting_style: "Surface Mount",
+    orientation: "Horizontal",
+    gender: "Female",
+    number_of_pins: 19,
+    number_of_rows: 1,
+    current_rating_a: 0.5,
+    operating_temp_min: -45,
+    operating_temp_max: 85,
+    is_preferred: true,
+    price1: 0.162173913,
+  })
+})
+
+test("HDMI port table excludes neighboring D-Sub connectors", () => {
+  const [port] = hdmiPortTableSpec.mapToTable([
+    makeComponent({
+      mfr: "DS1037-09FNAKT74-0CC",
+      description:
+        "9P Female D-Sub Bend insert 2 1.5A -40℃~+105℃ Push-Pull D-Sub / VGA Connectors ROHS",
+      extra: JSON.stringify({
+        attributes: {
+          "Connector Type": "D-Sub",
+          "Number of Pins": "9P",
+          Gender: "Female",
+        },
+      }),
+    }),
+  ])
+
+  expect(port).toBeNull()
+})
+
+test("HDMI port table selects dedicated and legacy connector categories", async () => {
+  const database = new Database(":memory:")
+  const db = new Kysely<any>({
+    dialect: new BunSqliteDialect({ database }),
+  })
+
+  try {
+    await db.schema
+      .createTable("categories")
+      .addColumn("id", "integer", (column) => column.primaryKey())
+      .addColumn("subcategory", "text", (column) => column.notNull())
+      .execute()
+    await db.schema
+      .createTable("components")
+      .addColumn("lcsc", "integer", (column) => column.primaryKey())
+      .addColumn("category_id", "integer", (column) => column.notNull())
+      .execute()
+
+    await db
+      .insertInto("categories")
+      .values([
+        { id: 1, subcategory: "HDMI Connectors" },
+        { id: 2, subcategory: "D-Sub/DVI/HDMI Connectors" },
+        { id: 3, subcategory: "Audio & Video Connectors" },
+        { id: 4, subcategory: "USB Connectors" },
+      ])
+      .execute()
+    await db
+      .insertInto("components")
+      .values([
+        { lcsc: 1, category_id: 1 },
+        { lcsc: 2, category_id: 2 },
+        { lcsc: 3, category_id: 3 },
+        { lcsc: 4, category_id: 4 },
+      ])
+      .execute()
+
+    const candidates = await hdmiPortTableSpec
+      .listCandidateComponents(db)
+      .execute()
+
+    expect(candidates.map((candidate) => candidate.lcsc)).toEqual([1, 2, 3])
+  } finally {
+    await db.destroy()
+  }
+})
+
+test("HDMI port schema and migration create query indexes idempotently", async () => {
+  expect(
+    hdmiPortTableSpec.indexes?.map((index) => index.columns.join(",")),
+  ).toEqual(EXPECTED_INDEX_COLUMNS)
+
+  const database = new Database(":memory:")
+  const db = new Kysely<any>({
+    dialect: new BunSqliteDialect({ database }),
+  })
+
+  try {
+    await setupDerivedTables({ db, populate: false })
+
+    const table = database
+      .query(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'hdmi_port'",
+      )
+      .get()
+    const indexes = database
+      .query(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'hdmi_port' AND name NOT LIKE 'sqlite_%'",
+      )
+      .all()
+
+    expect(table).not.toBeNull()
+    expect(indexes).toHaveLength(EXPECTED_INDEX_COLUMNS.length)
+  } finally {
+    await db.destroy()
+  }
+
+  const migrationDatabase = new Database(":memory:")
+  const migrationPath = new URL(
+    "../../cf-proxy/migrations/0002_hdmi_port.sql",
+    import.meta.url,
+  )
+  const migration = await Bun.file(migrationPath).text()
+
+  try {
+    migrationDatabase.exec(migration)
+    migrationDatabase.exec(migration)
+
+    const table = migrationDatabase
+      .query(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'hdmi_port'",
+      )
+      .get()
+    const indexes = migrationDatabase
+      .query(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'hdmi_port' AND name NOT LIKE 'sqlite_%'",
+      )
+      .all()
+
+    expect(table).not.toBeNull()
+    expect(indexes).toHaveLength(EXPECTED_INDEX_COLUMNS.length)
+  } finally {
+    migrationDatabase.close()
+  }
+})


### PR DESCRIPTION
## Summary

- add a first-class `/hdmi_ports/list` catalog page and matching `.json` API
- derive HDMI port data from dedicated and legacy JLC connector categories while excluding neighboring D-Sub/VGA parts
- expose package, mounting style, orientation, gender, pin count, basic, and preferred filters
- add the D1 schema migration, sync registration, generated types, homepage link, and route/render coverage

## Impact

Users can browse and filter in-stock HDMI ports from the homepage or consume the same results from `/hdmi_ports/list.json`.

## Validation

- `bun test tests/lib` — 32 passed
- `bun run --cwd cf-proxy test` — 138 passed
- `bunx tsc --noEmit`
- `bunx tsc --noEmit --project cf-proxy/tsconfig.json`
- `bun run format:check`