### PR TITLE
Add automated D1 migration workflow

### DIFF
--- a/.github/workflows/d1-migrations.yml
+++ b/.github/workflows/d1-migrations.yml
@@ -1,0 +1,60 @@
+name: Apply D1 Migrations
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "cf-proxy/migrations/**"
+      - "cf-proxy/wrangler.toml"
+      - "cf-proxy/package.json"
+      - "cf-proxy/bun.lock"
+      - ".github/workflows/d1-migrations.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-d1-migrations
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    name: Apply production migrations
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: cf-proxy
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Verify Cloudflare credentials
+        run: |
+          if [[ -z "${CLOUDFLARE_ACCOUNT_ID}" ]]; then
+            echo "::error::Missing CLOUDFLARE_ACCOUNT_ID repository secret."
+            exit 1
+          fi
+          if [[ -z "${CLOUDFLARE_API_TOKEN}" ]]; then
+            echo "::error::Missing CLOUDFLARE_API_TOKEN repository secret."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Apply D1 migrations
+        run: bunx wrangler d1 migrations apply jlcsearch --remote
+
+      - name: Verify migration status
+        run: bunx wrangler d1 migrations list jlcsearch --remote


### PR DESCRIPTION
## Summary

- add a GitHub Actions workflow that applies production D1 migrations when migration or Worker configuration files reach `main`
- support manual workflow dispatch for recovery and verification
- serialize production migration runs so multiple schema changes cannot overlap
- fail with explicit annotations when the required Cloudflare credentials are missing
- verify the remote migration queue after every apply

## Why

Cloudflare Workers Builds deploys the Worker independently, so the HDMI route reached production before its D1 schema migration was applied. This workflow makes remote migration application an explicit repository automation step.

## Required setup before merge

Add these repository Actions secrets:

- `CLOUDFLARE_ACCOUNT_ID`
- `CLOUDFLARE_API_TOKEN` with account-scoped D1 Edit permission

The workflow includes its own file in the push path filter, so merging this PR will immediately exercise the secret configuration.

## Validation

- `bun run format:check`
- `git diff --check`
- workflow YAML parsed successfully with Ruby Psych

## Scope

This workflow applies schema migrations only. Derived-table data synchronization remains separate because `sync-db.sh` requires a prepared local database source.