### PR TITLE
Build and populate production D1 data

### DIFF
--- a/.github/workflows/d1-migrations.yml
+++ b/.github/workflows/d1-migrations.yml
@@ -1,34 +1,48 @@
-name: Apply D1 Migrations
+name: Build and Sync D1
 
 on:
   push:
     branches: [main]
     paths:
+      - "lib/**"
+      - "scripts/**"
+      - "package.json"
+      - "bunfig.toml"
       - "cf-proxy/migrations/**"
+      - "cf-proxy/scripts/sync-db.sh"
       - "cf-proxy/wrangler.toml"
       - "cf-proxy/package.json"
       - "cf-proxy/bun.lock"
       - ".github/workflows/d1-migrations.yml"
   workflow_dispatch:
+    inputs:
+      derived_tables:
+        description: Comma-separated derived tables to rebuild and upload
+        required: true
+        default: hdmi_port
+        type: string
+      cache_bust_url:
+        description: Production URL to refresh after the D1 upload
+        required: false
+        default: https://jlcsearch.tscircuit.com/hdmi_ports/list.json
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: production-d1-migrations
+  group: production-d1-sync
   cancel-in-progress: false
 
 jobs:
-  migrate:
-    name: Apply production migrations
+  sync:
+    name: Build database and sync production
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    defaults:
-      run:
-        working-directory: cf-proxy
+    timeout-minutes: 120
     env:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      DERIVED_TABLES_LIST: ${{ inputs.derived_tables || 'hdmi_port' }}
 
     steps:
       - name: Checkout code
@@ -49,12 +63,114 @@ jobs:
             echo "::error::Missing CLOUDFLARE_API_TOKEN repository secret."
             exit 1
           fi
+          if [[ -z "${DERIVED_TABLES_LIST}" ]]; then
+            echo "::error::At least one derived table is required."
+            exit 1
+          fi
 
-      - name: Install dependencies
+      - name: Install database pipeline dependencies
+        run: bun install
+
+      - name: Install Cloudflare worker dependencies
+        working-directory: cf-proxy
         run: bun install --frozen-lockfile
 
+      - name: Generate daily database cache key
+        id: cache-date
+        run: echo "bucket=$(($(date -u +%s) / 86400))" >> "${GITHUB_OUTPUT}"
+
+      - name: Cache prepared SQLite database
+        id: cache-database
+        uses: actions/cache@v4
+        with:
+          path: db.sqlite3
+          key: prepared-db-${{ runner.os }}-${{ steps.cache-date.outputs.bucket }}-${{ hashFiles('package.json', 'bunfig.toml', 'scripts/**', 'lib/**') }}
+
+      - name: Build prepared SQLite database
+        if: steps.cache-database.outputs.cache-hit != 'true'
+        run: bun run setup
+
+      - name: Verify prepared derived tables
+        run: |
+          if [[ ! -s db.sqlite3 ]]; then
+            echo "::error::Database setup did not create db.sqlite3."
+            exit 1
+          fi
+
+          integrity_check="$(sqlite3 db.sqlite3 "PRAGMA integrity_check;")"
+          if [[ "${integrity_check}" != "ok" ]]; then
+            echo "::error::Prepared database failed its integrity check: ${integrity_check}"
+            exit 1
+          fi
+
+          IFS=',' read -ra tables <<< "${DERIVED_TABLES_LIST}"
+          for raw_table in "${tables[@]}"; do
+            table="$(echo "${raw_table}" | xargs)"
+            if [[ ! "${table}" =~ ^[a-z0-9_]+$ ]]; then
+              echo "::error::Invalid derived table name: ${table}"
+              exit 1
+            fi
+
+            table_exists="$(sqlite3 db.sqlite3 "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='${table}');")"
+            if [[ "${table_exists}" != "1" ]]; then
+              echo "::error::Prepared database does not contain ${table}."
+              exit 1
+            fi
+
+            row_count="$(sqlite3 db.sqlite3 "SELECT COUNT(*) FROM \"${table}\";")"
+            if [[ "${row_count}" == "0" ]]; then
+              echo "::error::Refusing to replace ${table} with an empty table."
+              exit 1
+            fi
+            echo "${table}: ${row_count} prepared rows"
+          done
+
       - name: Apply D1 migrations
+        working-directory: cf-proxy
         run: bunx wrangler d1 migrations apply jlcsearch --remote
 
-      - name: Verify migration status
-        run: bunx wrangler d1 migrations list jlcsearch --remote
+      - name: Upload derived tables to D1
+        env:
+          SOURCE_DB_PATH: ${{ github.workspace }}/db.sqlite3
+        run: ./cf-proxy/scripts/sync-db.sh
+
+      - name: Verify migration status and remote row counts
+        working-directory: cf-proxy
+        run: |
+          bunx wrangler d1 migrations list jlcsearch --remote
+
+          IFS=',' read -ra tables <<< "${DERIVED_TABLES_LIST}"
+          for raw_table in "${tables[@]}"; do
+            table="$(echo "${raw_table}" | xargs)"
+            bunx wrangler d1 execute jlcsearch --remote \
+              --command "SELECT COUNT(*) AS row_count FROM \"${table}\";"
+          done
+
+      - name: Refresh and verify the production API cache
+        env:
+          CACHE_BUST_URL: ${{ inputs.cache_bust_url || 'https://jlcsearch.tscircuit.com/hdmi_ports/list.json' }}
+        shell: bash
+        run: |
+          if [[ -z "${CACHE_BUST_URL}" ]]; then
+            echo "No cache-bust URL supplied; skipping production API refresh."
+            exit 0
+          fi
+
+          separator="?"
+          if [[ "${CACHE_BUST_URL}" == *"?"* ]]; then
+            separator="&"
+          fi
+
+          curl --fail --silent --show-error \
+            "${CACHE_BUST_URL}${separator}cachebust=1" \
+            --output /tmp/d1-sync-response.json
+
+          if [[ "${CACHE_BUST_URL}" == *"/hdmi_ports/list.json"* ]]; then
+            hdmi_port_count="$(jq '.hdmi_ports | length' /tmp/d1-sync-response.json)"
+            if [[ "${hdmi_port_count}" == "0" || "${hdmi_port_count}" == "null" ]]; then
+              echo "::error::Production HDMI API still returned no ports."
+              cat /tmp/d1-sync-response.json
+              exit 1
+            fi
+            echo "Production HDMI API returned ${hdmi_port_count} ports."
+          fi

--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ Use `bun deploy` to apply pending D1 schema migrations and then publish the
 worker. Use `cf-proxy/scripts/sync-db.sh` to rebuild and synchronize derived
 table data from a prepared local SQLite database.
 
+Production D1 data is populated by the **Build and Sync D1** GitHub Actions
+workflow. On relevant merges to `main`, it downloads the current upstream
+database, builds and verifies `db.sqlite3`, applies D1 migrations, uploads the
+requested derived tables, and refreshes the affected production API cache. The
+workflow can also be run manually with a comma-separated `derived_tables`
+input and an optional `cache_bust_url`. It requires the
+`CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` repository secrets.
+
 ## How Does It work?
 As a developer new to this codebase, or a curious user, you may have some questions about the flow of data through the scripts and automations inside this repo.  It all starts with the [jlcparts](https://github.com/yaqwsx/jlcparts) project, which compiles a massive **11GB** sqlite3 database of *everything* [JLCPCB](https://jlcpcb.com) has to offer.  As you can imagine, this would be very resource-intensive and slow to search, so the next steps are scripts that optimize it heavily, although it's more accurate to say that they rebuild it entirely. 
 `scripts/setup-db-optimizations.ts` and `scripts/setup-derived-tables.ts` show the various optimizations that are performed, including:

--- a/scripts/download-cache-fragments.ts
+++ b/scripts/download-cache-fragments.ts
@@ -1,26 +1,25 @@
-import { mkdir } from "node:fs/promises"
 import { existsSync } from "node:fs"
+import { mkdir } from "node:fs/promises"
 
 const BASE_URL = "https://yaqwsx.github.io/jlcparts/data"
 const OUTPUT_DIR = ".buildtmp"
 
-async function downloadFile(url: string, outputPath: string): Promise<boolean> {
-  try {
-    const response = await fetch(url)
-    if (!response.ok) {
-      if (response.status === 404) {
-        return false
-      }
-      throw new Error(`HTTP error! status: ${response.status}`)
+async function downloadFile(
+  url: string,
+  outputPath: string,
+): Promise<"downloaded" | "not-found"> {
+  const response = await fetch(url)
+  if (!response.ok) {
+    if (response.status === 404) {
+      return "not-found"
     }
-    const fileData = await response.arrayBuffer()
-    await Bun.write(outputPath, fileData)
-    console.log(`Downloaded: ${url}`)
-    return true
-  } catch (error) {
-    console.error(`Error downloading ${url}:`, error)
-    return false
+    throw new Error(`Failed to download ${url}: HTTP ${response.status}`)
   }
+
+  const fileData = await response.arrayBuffer()
+  await Bun.write(outputPath, fileData)
+  console.log(`Downloaded: ${url}`)
+  return "downloaded"
 }
 
 async function main() {
@@ -31,18 +30,24 @@ async function main() {
 
   console.log(`Downloading into ${OUTPUT_DIR}`)
   // Download initial cache.zip
-  await downloadFile(`${BASE_URL}/cache.zip`, `${OUTPUT_DIR}/cache.zip`)
+  const initialArchive = await downloadFile(
+    `${BASE_URL}/cache.zip`,
+    `${OUTPUT_DIR}/cache.zip`,
+  )
+  if (initialArchive === "not-found") {
+    throw new Error("The initial cache.zip archive does not exist")
+  }
 
   // Download fragments until we get a 404
   let index = 1
   while (true) {
     const paddedIndex = index.toString().padStart(2, "0")
-    const success = await downloadFile(
+    const result = await downloadFile(
       `${BASE_URL}/cache.z${paddedIndex}`,
       `${OUTPUT_DIR}/cache.z${paddedIndex}`,
     )
 
-    if (!success) {
+    if (result === "not-found") {
       console.log(`Stopped at index ${paddedIndex} (404 encountered)`)
       break
     }
@@ -50,4 +55,4 @@ async function main() {
   }
 }
 
-main().catch(console.error)
+await main()

--- a/scripts/setup-db-optimizations.ts
+++ b/scripts/setup-db-optimizations.ts
@@ -1,14 +1,14 @@
 import { getBunDatabaseClient, getDbClient } from "lib/db/get-db-client"
-import { componentStockIndex } from "lib/db/optimizations/component-stock-index"
-import { componentInStockColumn } from "lib/db/optimizations/component-in-stock-column"
-import { removeStaleComponents } from "lib/db/optimizations/remove-stale-components"
+import { componentBasicIndex } from "lib/db/optimizations/component-basic-index"
 import { componentCategoryIndex } from "lib/db/optimizations/component-category-index"
 import { componentInStockCategoryIndex } from "lib/db/optimizations/component-in-stock-category-index"
-import type { DbOptimizationSpec } from "lib/db/optimizations/types"
-import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
+import { componentInStockColumn } from "lib/db/optimizations/component-in-stock-column"
 import { componentPackageIndex } from "lib/db/optimizations/component-indexes"
-import { componentBasicIndex } from "lib/db/optimizations/component-basic-index"
 import { componentPreferredIndex } from "lib/db/optimizations/component-preferred-index"
+import { componentSearchFTS } from "lib/db/optimizations/component-search-fts"
+import { componentStockIndex } from "lib/db/optimizations/component-stock-index"
+import { removeStaleComponents } from "lib/db/optimizations/remove-stale-components"
+import type { DbOptimizationSpec } from "lib/db/optimizations/types"
 
 const OPTIMIZATIONS: DbOptimizationSpec[] = [
   componentSearchFTS,
@@ -47,4 +47,4 @@ async function main() {
   bunDb.close()
 }
 
-main().catch(console.error)
+await main()

--- a/scripts/setup-derived-tables.ts
+++ b/scripts/setup-derived-tables.ts
@@ -12,4 +12,4 @@ async function main() {
   })
 }
 
-main().catch(console.error)
+await main()


### PR DESCRIPTION
## Summary

- expand the existing D1 workflow into a complete production data pipeline
- build a fresh optimized `db.sqlite3` from the published jlcparts cache, with a daily Actions cache
- verify the requested derived tables are present and non-empty before changing production
- apply D1 migrations, upload the selected derived tables, verify remote row counts, and cache-bust the affected production API
- make database setup scripts fail the job on download or processing errors
- document the production sync workflow and required secrets

## Root cause

The merged workflow only applied schema migrations. That created the `hdmi_port` table in D1 but never built the local source database or ran `cf-proxy/scripts/sync-db.sh`, so production had zero HDMI rows.

## Impact

Once this PR is merged, the push-triggered workflow defaults to rebuilding and uploading `hdmi_port`, then verifies that the production HDMI API returns at least one port. Future manual runs can provide a comma-separated derived-table list and a cache-bust URL.

## Validation

- `bun run format:check`
- `bunx tsc --noEmit`
- `git diff --check`
- workflow YAML parse check