### PR TITLE
Support current jlcparts database format

### DIFF
--- a/.github/workflows/d1-migrations.yml
+++ b/.github/workflows/d1-migrations.yml
@@ -84,11 +84,17 @@ jobs:
         uses: actions/cache@v4
         with:
           path: db.sqlite3
-          key: prepared-db-${{ runner.os }}-${{ steps.cache-date.outputs.bucket }}-${{ hashFiles('package.json', 'bunfig.toml', 'scripts/**', 'lib/**') }}
+          key: derived-db-${{ runner.os }}-${{ env.DERIVED_TABLES_LIST }}-${{ steps.cache-date.outputs.bucket }}-${{ hashFiles('package.json', 'bunfig.toml', 'scripts/**', 'lib/**') }}
 
       - name: Build prepared SQLite database
         if: steps.cache-database.outputs.cache-hit != 'true'
-        run: bun run setup
+        run: |
+          bun run setup:7z
+          bun run setup:download-cache-fragments
+          bun run setup:extract-db
+          bun run setup:derived-sync-db
+          rm -f cache.sqlite3
+          rm -rf .buildtmp
 
       - name: Verify prepared derived tables
         run: |
@@ -132,6 +138,7 @@ jobs:
       - name: Upload derived tables to D1
         env:
           SOURCE_DB_PATH: ${{ github.workspace }}/db.sqlite3
+          REBUILD_DERIVED_TABLES: "0"
         run: ./cf-proxy/scripts/sync-db.sh
 
       - name: Verify migration status and remote row counts

--- a/README.md
+++ b/README.md
@@ -65,11 +65,12 @@ table data from a prepared local SQLite database.
 
 Production D1 data is populated by the **Build and Sync D1** GitHub Actions
 workflow. On relevant merges to `main`, it downloads the current upstream
-database, builds and verifies `db.sqlite3`, applies D1 migrations, uploads the
-requested derived tables, and refreshes the affected production API cache. The
-workflow can also be run manually with a comma-separated `derived_tables`
-input and an optional `cache_bust_url`. It requires the
-`CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` repository secrets.
+source-db-v2 database, builds and verifies a compact `db.sqlite3` containing
+the requested derived tables, applies D1 migrations, uploads those tables, and
+refreshes the affected production API cache. The workflow can also be run
+manually with a comma-separated `derived_tables` input and an optional
+`cache_bust_url`. It requires the `CLOUDFLARE_ACCOUNT_ID` and
+`CLOUDFLARE_API_TOKEN` repository secrets.
 
 ## How Does It work?
 As a developer new to this codebase, or a curious user, you may have some questions about the flow of data through the scripts and automations inside this repo.  It all starts with the [jlcparts](https://github.com/yaqwsx/jlcparts) project, which compiles a massive **11GB** sqlite3 database of *everything* [JLCPCB](https://jlcpcb.com) has to offer.  As you can imagine, this would be very resource-intensive and slow to search, so the next steps are scripts that optimize it heavily, although it's more accurate to say that they rebuild it entirely. 

--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -18,6 +18,7 @@ SYNC_DERIVED_TABLES="${SYNC_DERIVED_TABLES:-1}"
 SYNC_COMPONENT_CATALOG="${SYNC_COMPONENT_CATALOG:-0}"
 SYNC_SEARCH_INDEX="${SYNC_SEARCH_INDEX:-0}"
 DERIVED_TABLES_LIST="${DERIVED_TABLES_LIST:-}"
+REBUILD_DERIVED_TABLES="${REBUILD_DERIVED_TABLES:-1}"
 
 DERIVED_TABLES=(
   accelerometer
@@ -444,7 +445,11 @@ main() {
   select_derived_tables
 
   if [[ "${SYNC_DERIVED_TABLES}" == "1" ]]; then
-    rebuild_derived_tables
+    if [[ "${REBUILD_DERIVED_TABLES}" == "1" ]]; then
+      rebuild_derived_tables
+    else
+      echo "Using derived tables already prepared in the source database."
+    fi
     create_derived_schema_dump
 
     echo "Importing derived-table schema to D1..."

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -228,19 +228,38 @@ export const setupDerivedTables = async ({
   populate = true,
   resetAll = false,
   resetTable = null,
+  tableNames,
   logger = () => {},
 }: {
   db?: KyselyDatabaseInstance
   populate?: boolean
   resetAll?: boolean
   resetTable?: string | null
+  tableNames?: string[]
   logger?: Logger
 } = {}) => {
   const activeDb = db ?? getDbClient()
   const shouldDestroy = !db
+  const requestedTableNames = tableNames
+    ? new Set(tableNames)
+    : new Set(DERIVED_TABLES.map((table) => table.tableName))
+  const knownTableNames = new Set(
+    DERIVED_TABLES.map((table) => table.tableName),
+  )
+  const unknownTableNames = [...requestedTableNames].filter(
+    (tableName) => !knownTableNames.has(tableName),
+  )
+
+  if (unknownTableNames.length > 0) {
+    throw new Error(
+      `Unknown derived table${unknownTableNames.length === 1 ? "" : "s"}: ${unknownTableNames.join(", ")}`,
+    )
+  }
 
   try {
-    for (const tableSpec of DERIVED_TABLES) {
+    for (const tableSpec of DERIVED_TABLES.filter((table) =>
+      requestedTableNames.has(table.tableName),
+    )) {
       logger(`Setting up derived table: ${tableSpec.tableName}`)
       await createTable(activeDb, tableSpec, {
         populate,

--- a/lib/util/extract-min-quantity-price.ts
+++ b/lib/util/extract-min-quantity-price.ts
@@ -6,7 +6,21 @@
 export const extractMinQPrice = (price: string) => {
   try {
     return JSON.parse(price)[0].price as number
-  } catch (e) {
-    return null
+  } catch {
+    const prices = price
+      .split(",")
+      .map((range) => {
+        const [quantityRange, priceText] = range.split(":")
+        const [qFromText] = quantityRange?.split("-") ?? []
+        const qFrom = Number.parseInt(qFromText, 10)
+        const parsedPrice = Number.parseFloat(priceText)
+        return { qFrom, price: parsedPrice }
+      })
+      .filter(
+        (range) => Number.isFinite(range.qFrom) && Number.isFinite(range.price),
+      )
+      .sort((a, b) => a.qFrom - b.qFrom)
+
+    return prices[0]?.price ?? null
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "setup:replace-db-file": "rm -f ./db.sqlite3 && mv ./cache.sqlite3 ./db.sqlite3",
     "setup:optimize-db": "bun run scripts/setup-db-optimizations.ts",
     "setup:derived-tables": "bun run scripts/setup-derived-tables.ts",
+    "setup:derived-sync-db": "bun run scripts/build-derived-sync-db.ts",
     "format": "biome format --write .",
     "format:check": "biome format ."
   },

--- a/scripts/build-derived-sync-db.ts
+++ b/scripts/build-derived-sync-db.ts
@@ -1,0 +1,158 @@
+import { Database } from "bun:sqlite"
+import { existsSync } from "node:fs"
+import { mkdir, rm } from "node:fs/promises"
+import path from "node:path"
+import { setupDerivedTables } from "lib/db/derivedtables/setup-derived-tables"
+import type { DB } from "lib/db/generated/kysely"
+import { Kysely } from "kysely"
+import { BunSqliteDialect } from "kysely-bun-sqlite"
+
+const tableExists = (database: Database, schema: string, table: string) =>
+  Boolean(
+    database
+      .query(
+        `SELECT 1
+         FROM ${schema}.sqlite_master
+         WHERE type = 'table' AND name = ?
+         LIMIT 1`,
+      )
+      .get(table),
+  )
+
+export const buildDerivedSyncDatabase = async ({
+  sourcePath,
+  outputPath,
+  tableNames,
+  logger = console.log,
+}: {
+  sourcePath: string
+  outputPath: string
+  tableNames?: string[]
+  logger?: (message: string) => void
+}) => {
+  const resolvedSourcePath = path.resolve(sourcePath)
+  const resolvedOutputPath = path.resolve(outputPath)
+
+  if (!existsSync(resolvedSourcePath)) {
+    throw new Error(`Source database does not exist: ${resolvedSourcePath}`)
+  }
+  if (resolvedSourcePath === resolvedOutputPath) {
+    throw new Error("Source and output database paths must be different")
+  }
+
+  await mkdir(path.dirname(resolvedOutputPath), { recursive: true })
+  await rm(resolvedOutputPath, { force: true })
+
+  const database = new Database(resolvedOutputPath, { create: true })
+  database.run("ATTACH DATABASE ? AS source", [resolvedSourcePath])
+
+  if (
+    !tableExists(database, "source", "jlc_components") ||
+    !tableExists(database, "source", "lcsc_components")
+  ) {
+    database.close()
+    throw new Error(
+      "Expected a source-db-v2 database with jlc_components and lcsc_components",
+    )
+  }
+
+  database.exec(`
+    CREATE TABLE categories (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      category TEXT NOT NULL,
+      subcategory TEXT NOT NULL,
+      UNIQUE(category, subcategory)
+    );
+
+    INSERT INTO categories(category, subcategory)
+    SELECT DISTINCT category, subcategory
+    FROM source.jlc_components
+    WHERE present = 1
+      AND last_on_stock >= unixepoch('now', '-1 year')
+    ORDER BY category, subcategory;
+
+    CREATE TEMP VIEW components AS
+    SELECT
+      j.lcsc,
+      c.id AS category_id,
+      j.mfr,
+      j.package,
+      j.joints,
+      0 AS manufacturer_id,
+      CASE WHEN j.library_type = 'base' THEN 1 ELSE 0 END AS basic,
+      j.preferred,
+      j.description,
+      j.datasheet,
+      j.stock,
+      j.price,
+      j.last_on_stock,
+      j.fetched_at AS last_update,
+      j.sync_seen AS flag,
+      CASE WHEN j.stock > 0 THEN 1 ELSE 0 END AS in_stock,
+      json_object(
+        'attributes',
+        json(
+          json_patch(
+            CASE
+              WHEN json_valid(j.attributes) THEN j.attributes
+              ELSE '{}'
+            END,
+            CASE
+              WHEN json_valid(l.attributes) THEN l.attributes
+              ELSE '{}'
+            END
+          )
+        ),
+        'manufacturer',
+        NULLIF(l.manufacturer, ''),
+        'url',
+        CASE
+          WHEN l.url_slug IS NOT NULL AND l.url_slug != ''
+          THEN 'https://lcsc.com/product-detail/' || l.url_slug || '_C' || j.lcsc || '.html'
+          ELSE NULL
+        END
+      ) AS extra
+    FROM source.jlc_components AS j
+    INNER JOIN main.categories AS c
+      ON c.category = j.category
+      AND c.subcategory = j.subcategory
+    LEFT JOIN source.lcsc_components AS l ON l.lcsc = j.lcsc
+    WHERE j.present = 1
+      AND j.last_on_stock >= unixepoch('now', '-1 year');
+  `)
+
+  const db = new Kysely<DB>({
+    dialect: new BunSqliteDialect({ database }),
+  })
+
+  try {
+    await setupDerivedTables({
+      db,
+      tableNames,
+      logger,
+    })
+    database.exec("ANALYZE")
+  } finally {
+    await db.destroy()
+  }
+}
+
+const main = async () => {
+  const sourcePath =
+    process.env.SOURCE_DB_PATH?.trim() || path.resolve("cache.sqlite3")
+  const outputPath =
+    process.env.OUTPUT_DB_PATH?.trim() || path.resolve("db.sqlite3")
+  const configuredTables = process.env.DERIVED_TABLES_LIST?.split(",")
+    .map((table) => table.trim())
+    .filter(Boolean)
+
+  await buildDerivedSyncDatabase({
+    sourcePath,
+    outputPath,
+    tableNames: configuredTables?.length ? configuredTables : undefined,
+  })
+}
+
+if (import.meta.main) {
+  await main()
+}

--- a/tests/build-derived-sync-db.test.ts
+++ b/tests/build-derived-sync-db.test.ts
@@ -1,0 +1,141 @@
+import { Database } from "bun:sqlite"
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { extractMinQPrice } from "../lib/util/extract-min-quantity-price"
+import { buildDerivedSyncDatabase } from "../scripts/build-derived-sync-db"
+
+const tempDirectories: string[] = []
+
+const createSourceDatabase = async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "jlcsearch-source-v2-"))
+  tempDirectories.push(directory)
+  const sourcePath = path.join(directory, "source.sqlite3")
+  const outputPath = path.join(directory, "derived.sqlite3")
+  const source = new Database(sourcePath, { create: true })
+
+  source.exec(`
+    CREATE TABLE jlc_components (
+      lcsc INTEGER PRIMARY KEY,
+      fetched_at INTEGER NOT NULL,
+      present INTEGER NOT NULL,
+      sync_seen INTEGER NOT NULL,
+      category TEXT NOT NULL,
+      subcategory TEXT NOT NULL,
+      mfr TEXT NOT NULL,
+      package TEXT NOT NULL,
+      joints INTEGER NOT NULL,
+      manufacturer TEXT NOT NULL,
+      library_type TEXT NOT NULL,
+      preferred INTEGER NOT NULL,
+      last_on_stock INTEGER NOT NULL,
+      description TEXT NOT NULL,
+      datasheet TEXT NOT NULL,
+      stock INTEGER NOT NULL,
+      price TEXT NOT NULL,
+      attributes TEXT NOT NULL
+    );
+
+    CREATE TABLE lcsc_components (
+      lcsc INTEGER PRIMARY KEY,
+      fetched_at INTEGER NOT NULL,
+      manufacturer TEXT NOT NULL,
+      attributes TEXT NOT NULL,
+      image TEXT,
+      url_slug TEXT
+    );
+  `)
+
+  source
+    .query(
+      `INSERT INTO jlc_components (
+        lcsc, fetched_at, present, sync_seen, category, subcategory, mfr,
+        package, joints, manufacturer, library_type, preferred, last_on_stock,
+        description, datasheet, stock, price, attributes
+      ) VALUES (
+        12345, unixepoch(), 1, 1, 'Connectors',
+        'HDMI Connectors', 'HDMI-19P', 'SMD', 19, 'Example', 'base', 1,
+        unixepoch(), 'HDMI Female 19 Pins horizontal attachment', '', 250,
+        '1-9:1.25,10-:0.75',
+        '{"Connector Type":"HDMI","Number of Pins":"19"}'
+      )`,
+    )
+    .run()
+
+  source
+    .query(
+      `INSERT INTO lcsc_components (
+        lcsc, fetched_at, manufacturer, attributes, image, url_slug
+      ) VALUES (
+        12345, unixepoch(), 'Example Inc.',
+        '{"Gender":"Female","Mounting Style":"Surface Mount"}',
+        'example.jpg', 'hdmi-19p'
+      )`,
+    )
+    .run()
+  source.close()
+
+  return { sourcePath, outputPath }
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  )
+})
+
+describe("buildDerivedSyncDatabase", () => {
+  test("converts source-db-v2 rows into a populated HDMI derived table", async () => {
+    const { sourcePath, outputPath } = await createSourceDatabase()
+
+    await buildDerivedSyncDatabase({
+      sourcePath,
+      outputPath,
+      tableNames: ["hdmi_port"],
+      logger: () => {},
+    })
+
+    const output = new Database(outputPath, { readonly: true })
+    const row = output
+      .query(
+        `SELECT
+          lcsc, price1, number_of_pins, gender, mounting_style,
+          is_basic, is_preferred
+        FROM hdmi_port`,
+      )
+      .get() as Record<string, unknown>
+
+    expect(row).toEqual({
+      lcsc: 12345,
+      price1: 1.25,
+      number_of_pins: 19,
+      gender: "Female",
+      mounting_style: "Surface Mount",
+      is_basic: 1,
+      is_preferred: 1,
+    })
+    output.close()
+  })
+
+  test("rejects unknown derived tables", async () => {
+    const { sourcePath, outputPath } = await createSourceDatabase()
+
+    expect(
+      buildDerivedSyncDatabase({
+        sourcePath,
+        outputPath,
+        tableNames: ["not_a_table"],
+        logger: () => {},
+      }),
+    ).rejects.toThrow("Unknown derived table: not_a_table")
+  })
+})
+
+describe("extractMinQPrice", () => {
+  test("reads source-db-v2 price CSV", () => {
+    expect(extractMinQPrice("10-:0.75,1-9:1.25")).toBe(1.25)
+  })
+})


### PR DESCRIPTION
## Summary

- add a source-db-v2 compatibility builder for the current published jlcparts archive
- build a compact sync database containing only the requested derived tables instead of running legacy whole-database optimizations
- support source-db-v2 CSV price ranges while preserving legacy JSON prices
- let the D1 sync script upload already-prepared derived tables without trying to rebuild them from missing legacy source tables
- cache the compact derived database per table list and source date
- add source-db-v2 fixture coverage and document the production data path

## Root cause

The production run from #424 downloaded and extracted the current archive successfully, but the upstream cache format has changed from legacy `components`/`categories` tables to `source-db-v2` with `jlc_components` and `lcsc_components`. The legacy optimization step therefore failed with `SQLiteError: no such table: main.components` before any D1 upload occurred.

## Validation

- processed the current 5.58 GB published archive successfully
- produced a 284 KB sync database with 175 HDMI ports, including 171 in-stock parts
- `bun test` — 173 passing, including live API contract tests
- `bun run format:check`
- `bunx tsc --noEmit`
- `bunx tsc --noEmit --project cf-proxy/tsconfig.json`
- `bash -n cf-proxy/scripts/sync-db.sh`
- workflow YAML parse check
- `git diff --check`

## Production impact

After merge, the push-triggered workflow will rebuild `hdmi_port` from the current upstream database, upload it to D1, verify the remote row count, refresh the production cache, and fail unless the HDMI API returns at least one port.