### PR TITLE
Skip FTS setup for derived-only syncs

### DIFF
--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -481,7 +481,7 @@ main() {
     import_table_in_batches search_index "${SEARCH_INDEX_BATCH_ROWS}"
   fi
 
-  if [[ -f "${SCRIPT_DIR}/setup-fts5.sql" ]]; then
+  if [[ "${SYNC_SEARCH_INDEX}" == "1" && -f "${SCRIPT_DIR}/setup-fts5.sql" ]]; then
     echo "Setting up FTS5..."
     rebuild_remote_search_fts_index
   fi


### PR DESCRIPTION
## Summary

Guard FTS setup behind `SYNC_SEARCH_INDEX=1` so a derived-table-only D1 upload does not try to rebuild a search index that was not prepared.

## Root cause

The production run from #425 successfully built and uploaded all 175 `hdmi_port` rows. It then failed because `sync-db.sh` unconditionally called the FTS setup whenever `setup-fts5.sql` existed, even though `SYNC_SEARCH_INDEX=0`. That attempted to query a nonexistent local `search_index` table and prevented the workflow's verification and cache-refresh steps from running.

## Production status

The HDMI cache has been manually refreshed and the production API is now serving 100 results on the first page from D1. This change prevents the same false failure on future workflow runs.

## Validation

- `bash -n cf-proxy/scripts/sync-db.sh`
- `bun run format:check`
- `bunx tsc --noEmit --project cf-proxy/tsconfig.json`
- `git diff --check`