### PR TITLE
Add manufacturer filters to processor pages

### DIFF
--- a/cf-proxy/src/d1-routes.ts
+++ b/cf-proxy/src/d1-routes.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely"
+import { sql, type Kysely } from "kysely"
 import type { DB } from "./db/types"
 import {
   createDisplayDriverMaxResolutionResolver,
@@ -31,6 +31,19 @@ type D1Handler = (db: Kysely<DB>, params: QueryParams) => Promise<D1QueryResult>
 const PROCESSOR_INTERFACES = ["uart", "i2c", "spi", "can", "usb"] as const
 const MICROPHONE_SUBCATEGORIES = ["Microphones", "MEMS Microphones"] as const
 const LCD_DRIVER_SUBCATEGORY = "LCD Drivers"
+const PROCESSOR_MANUFACTURER = sql<string | null>`
+  CASE
+    WHEN json_valid(component_catalog.extra) THEN
+      CASE json_type(component_catalog.extra, '$.manufacturer')
+        WHEN 'text'
+          THEN json_extract(component_catalog.extra, '$.manufacturer')
+        WHEN 'object'
+          THEN json_extract(component_catalog.extra, '$.manufacturer.name')
+        ELSE NULL
+      END
+    ELSE NULL
+  END
+`
 
 const parseFiniteNumber = (value: string | undefined): number | null => {
   if (value === undefined || value === "") return null
@@ -82,61 +95,93 @@ const getMicrocontrollerListHandler = (
   return async (db, params) => {
     let query = db
       .selectFrom("microcontroller")
-      .selectAll()
+      .leftJoin(
+        "component_catalog",
+        "component_catalog.lcsc",
+        "microcontroller.lcsc",
+      )
+      .selectAll("microcontroller")
+      .select(PROCESSOR_MANUFACTURER.as("manufacturer"))
       .limit(100)
-      .orderBy("stock", "desc")
+      .orderBy("microcontroller.stock", "desc")
 
     query =
       coreFilter === "ARM%"
-        ? query.where("cpu_core", "like", coreFilter)
-        : query.where("cpu_core", "=", coreFilter)
+        ? query.where("microcontroller.cpu_core", "like", coreFilter)
+        : query.where("microcontroller.cpu_core", "=", coreFilter)
 
     if (params.package) {
-      query = query.where("package", "=", params.package)
+      query = query.where("microcontroller.package", "=", params.package)
+    }
+
+    if (params.manufacturer) {
+      query = query.where(PROCESSOR_MANUFACTURER, "=", params.manufacturer)
     }
 
     const flashMin = parseFiniteNumber(params.flash_min)
     if (flashMin !== null) {
-      query = query.where("flash_size_bytes", ">=", flashMin)
+      query = query.where("microcontroller.flash_size_bytes", ">=", flashMin)
     }
 
     const ramMin = parseFiniteNumber(params.ram_min)
     if (ramMin !== null) {
-      query = query.where("ram_size_bytes", ">=", ramMin)
+      query = query.where("microcontroller.ram_size_bytes", ">=", ramMin)
     }
 
     switch (params.interface) {
       case "uart":
-        query = query.where("has_uart", "=", 1)
+        query = query.where("microcontroller.has_uart", "=", 1)
         break
       case "i2c":
-        query = query.where("has_i2c", "=", 1)
+        query = query.where("microcontroller.has_i2c", "=", 1)
         break
       case "spi":
-        query = query.where("has_spi", "=", 1)
+        query = query.where("microcontroller.has_spi", "=", 1)
         break
       case "can":
-        query = query.where("has_can", "=", 1)
+        query = query.where("microcontroller.has_can", "=", 1)
         break
       case "usb":
-        query = query.where("has_usb", "=", 1)
+        query = query.where("microcontroller.has_usb", "=", 1)
         break
     }
 
     let packageQuery = db
       .selectFrom("microcontroller")
-      .select("package")
+      .select("microcontroller.package")
       .distinct()
-      .where("package", "is not", null)
-      .orderBy("package")
+      .where("microcontroller.package", "is not", null)
+      .orderBy("microcontroller.package")
 
     packageQuery =
       coreFilter === "ARM%"
-        ? packageQuery.where("cpu_core", "like", coreFilter)
-        : packageQuery.where("cpu_core", "=", coreFilter)
+        ? packageQuery.where("microcontroller.cpu_core", "like", coreFilter)
+        : packageQuery.where("microcontroller.cpu_core", "=", coreFilter)
 
-    const [packages, mcus] = await Promise.all([
+    let manufacturerQuery = db
+      .selectFrom("microcontroller")
+      .innerJoin(
+        "component_catalog",
+        "component_catalog.lcsc",
+        "microcontroller.lcsc",
+      )
+      .select(PROCESSOR_MANUFACTURER.as("manufacturer"))
+      .distinct()
+      .where(PROCESSOR_MANUFACTURER, "is not", null)
+      .orderBy(PROCESSOR_MANUFACTURER)
+
+    manufacturerQuery =
+      coreFilter === "ARM%"
+        ? manufacturerQuery.where(
+            "microcontroller.cpu_core",
+            "like",
+            coreFilter,
+          )
+        : manufacturerQuery.where("microcontroller.cpu_core", "=", coreFilter)
+
+    const [packages, manufacturers, mcus] = await Promise.all([
       packageQuery.execute(),
+      manufacturerQuery.execute(),
       query.execute(),
     ])
 
@@ -147,12 +192,17 @@ const getMicrocontrollerListHandler = (
           packages as Array<Record<string, string | null>>,
           "package",
         ),
+        manufacturer: getNonEmptyStrings(
+          manufacturers as Array<Record<string, string | null>>,
+          "manufacturer",
+        ),
         interface: [...PROCESSOR_INTERFACES],
       },
       data: {
         [responseKey]: mcus.map((m) => ({
           lcsc: m.lcsc ?? 0,
           mfr: m.mfr ?? "",
+          manufacturer: m.manufacturer ?? "",
           package: m.package ?? "",
           cpu_core: m.cpu_core ?? "",
           cpu_speed_hz: m.cpu_speed_hz ?? 0,

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -449,6 +449,7 @@ const renderCustomFilters = (
     case "/arm_processors/list":
     case "/risc_v_processors/list": {
       const packageOptions = filterOptions.package ?? []
+      const manufacturerOptions = filterOptions.manufacturer ?? []
       const packageListId = getSuggestionListId(
         pathname,
         "package",
@@ -460,6 +461,18 @@ const renderCustomFilters = (
           <label>Package:</label>
           <input type="text" name="package" value="${escapeHtml(params.package ?? "")}"${packageListId ? ` list="${escapeHtml(packageListId)}"` : ""} autocomplete="on" />
           ${renderFilterSuggestions(pathname, "package", packageOptions)}
+        </div>
+        <div>
+          <label>Manufacturer:</label>
+          <select name="manufacturer">
+            <option value="">All</option>
+            ${manufacturerOptions
+              .map(
+                (option) =>
+                  `<option value="${escapeHtml(option)}"${params.manufacturer === option ? " selected" : ""}>${escapeHtml(option)}</option>`,
+              )
+              .join("")}
+          </select>
         </div>
         <div>
           <label>Min Flash:</label>

--- a/cf-proxy/test/processor-routes.test.ts
+++ b/cf-proxy/test/processor-routes.test.ts
@@ -1,0 +1,118 @@
+import {
+  DummyDriver,
+  Kysely,
+  SqliteAdapter,
+  SqliteIntrospector,
+  SqliteQueryCompiler,
+  type CompiledQuery,
+  type DatabaseConnection,
+} from "kysely"
+import { describe, expect, it } from "vitest"
+import { getD1Handler } from "../src/d1-routes"
+import type { DB } from "../src/db/types"
+
+describe.each([
+  ["/arm_processors/list", "arm_processors", "ARM%"],
+  ["/risc_v_processors/list", "risc_v_processors", "RISC-V"],
+] as const)("%s", (pathname, responseKey, coreFilter) => {
+  it("filters processors by manufacturer and returns manufacturer options", async () => {
+    const compiledQueries: CompiledQuery[] = []
+    const driver = new DummyDriver()
+
+    driver.acquireConnection = async () =>
+      ({
+        executeQuery: async (compiledQuery: CompiledQuery) => {
+          compiledQueries.push(compiledQuery)
+
+          if (
+            compiledQuery.sql.startsWith("select distinct") &&
+            compiledQuery.sql.includes('as "manufacturer"')
+          ) {
+            return {
+              rows: [
+                { manufacturer: "NXP Semiconductors" },
+                { manufacturer: "STMicroelectronics" },
+              ],
+            }
+          }
+
+          if (
+            compiledQuery.sql.startsWith(
+              'select distinct "microcontroller"."package"',
+            )
+          ) {
+            return { rows: [{ package: "LQFP-64" }] }
+          }
+
+          return {
+            rows: [
+              {
+                lcsc: 123,
+                mfr: "STM32F401RCT6",
+                manufacturer: "STMicroelectronics",
+                package: "LQFP-64",
+                cpu_core: coreFilter === "ARM%" ? "ARM Cortex-M4" : "RISC-V",
+                cpu_speed_hz: 84_000_000,
+                flash_size_bytes: 262_144,
+                ram_size_bytes: 65_536,
+                eeprom_size_bytes: null,
+                gpio_count: 51,
+                has_uart: 1,
+                has_i2c: 1,
+                has_spi: 1,
+                has_can: 0,
+                has_usb: 1,
+                stock: 500,
+                price1: 3.25,
+              },
+            ],
+          }
+        },
+        streamQuery: async function* () {},
+      }) as DatabaseConnection
+
+    const db = new Kysely<DB>({
+      dialect: {
+        createAdapter: () => new SqliteAdapter(),
+        createDriver: () => driver,
+        createIntrospector: (database) => new SqliteIntrospector(database),
+        createQueryCompiler: () => new SqliteQueryCompiler(),
+      },
+    })
+
+    try {
+      const handler = getD1Handler(pathname)
+      expect(handler).not.toBeNull()
+
+      const result = await handler!(db, {
+        manufacturer: "STMicroelectronics",
+      })
+
+      expect(result.filterOptions?.manufacturer).toEqual([
+        "NXP Semiconductors",
+        "STMicroelectronics",
+      ])
+      expect(result.data[responseKey]).toEqual([
+        expect.objectContaining({
+          lcsc: 123,
+          manufacturer: "STMicroelectronics",
+          package: "LQFP-64",
+        }),
+      ])
+
+      const partsQuery = compiledQueries.find(
+        (query) =>
+          query.sql.includes('select "microcontroller".*') &&
+          query.sql.includes('as "manufacturer"'),
+      )
+      expect(partsQuery?.sql).toContain(
+        'left join "component_catalog" on "component_catalog"."lcsc" = "microcontroller"."lcsc"',
+      )
+      expect(partsQuery?.sql).toContain('"microcontroller"."cpu_core"')
+      expect(partsQuery?.sql).toContain("json_extract")
+      expect(partsQuery?.parameters).toContain("STMicroelectronics")
+    } finally {
+      await db.destroy()
+    }
+  })
+})

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -19,6 +19,42 @@ describe("render helpers", () => {
     expect(html).toContain("/hdmi_ports/list")
   })
 
+  it.each([
+    ["/arm_processors/list", "arm_processors", "ARM Processors"],
+    ["/risc_v_processors/list", "risc_v_processors", "RISC-V Processors"],
+  ])(
+    "renders the %s page with a manufacturer filter",
+    (pathname, responseKey, heading) => {
+      const html = renderD1TablePage(
+        pathname,
+        {
+          [responseKey]: [
+            {
+              lcsc: 123,
+              mfr: "STM32F401RCT6",
+              manufacturer: "STMicroelectronics",
+              package: "LQFP-64",
+            },
+          ],
+        },
+        { manufacturer: "STMicroelectronics" },
+        `https://jlcsearch.tscircuit.com${pathname}?manufacturer=STMicroelectronics`,
+        {
+          package: ["LQFP-64"],
+          manufacturer: ["NXP Semiconductors", "STMicroelectronics"],
+        },
+      )
+
+      expect(html).toContain(`<h2>${heading}</h2>`)
+      expect(html).toContain('name="manufacturer"')
+      expect(html).toContain(
+        'value="STMicroelectronics" selected>STMicroelectronics</option>',
+      )
+      expect(html).toContain(">Manufacturer</th>")
+      expect(html).toContain(`${pathname}.json?manufacturer=STMicroelectronics`)
+    },
+  )
+
   it("renders the HDMI ports page and JSON API link", () => {
     const pathname = "/hdmi_ports/list"
 


### PR DESCRIPTION
## Summary

- add manufacturer dropdowns to the ARM and RISC-V processor pages
- filter processor results by manufacturer through the existing component catalog
- include manufacturer names in processor HTML tables and JSON responses
- cover both processor families with route-query and rendering tests

## Why

The processor pages supported package, memory, and interface filters but did not expose the manufacturer names already available in the component catalog. This change joins that catalog data at query time and supports both manufacturer shapes present in existing catalog records.

## Validation

- `./node_modules/.bin/tsc --noEmit --project tsconfig.json`
- `bunx vitest run --exclude test/contracts.test.ts` (56 tests passed)
- `bunx vitest run test/processor-routes.test.ts test/render.test.ts` (15 tests passed after the final query adjustment)
- Biome formatting and `git diff --check`
