### PR TITLE
Add full catalog sync workflow

### DIFF
--- a/.github/workflows/d1-migrations.yml
+++ b/.github/workflows/d1-migrations.yml
@@ -16,6 +16,14 @@ on:
       - ".github/workflows/d1-migrations.yml"
   workflow_dispatch:
     inputs:
+      sync_scope:
+        description: Data set to rebuild and upload
+        required: true
+        default: derived
+        type: choice
+        options:
+          - derived
+          - full_catalog
       derived_tables:
         description: Comma-separated derived tables to rebuild and upload
         required: true
@@ -24,7 +32,12 @@ on:
       cache_bust_url:
         description: Production URL to refresh after the D1 upload
         required: false
-        default: https://jlcsearch.tscircuit.com/hdmi_ports/list.json
+        default: ""
+        type: string
+      smoke_test_lcsc:
+        description: LCSC number that must exist after a full catalog sync
+        required: true
+        default: "7512"
         type: string
 
 permissions:
@@ -42,7 +55,9 @@ jobs:
     env:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      SYNC_SCOPE: ${{ inputs.sync_scope || 'derived' }}
       DERIVED_TABLES_LIST: ${{ inputs.derived_tables || 'hdmi_port' }}
+      SMOKE_TEST_LCSC: ${{ inputs.smoke_test_lcsc || '7512' }}
 
     steps:
       - name: Checkout code
@@ -63,8 +78,16 @@ jobs:
             echo "::error::Missing CLOUDFLARE_API_TOKEN repository secret."
             exit 1
           fi
-          if [[ -z "${DERIVED_TABLES_LIST}" ]]; then
+          if [[ "${SYNC_SCOPE}" != "derived" && "${SYNC_SCOPE}" != "full_catalog" ]]; then
+            echo "::error::Unknown sync scope: ${SYNC_SCOPE}"
+            exit 1
+          fi
+          if [[ "${SYNC_SCOPE}" == "derived" && -z "${DERIVED_TABLES_LIST}" ]]; then
             echo "::error::At least one derived table is required."
+            exit 1
+          fi
+          if [[ "${SYNC_SCOPE}" == "full_catalog" && ! "${SMOKE_TEST_LCSC}" =~ ^[0-9]+$ ]]; then
+            echo "::error::smoke_test_lcsc must be numeric."
             exit 1
           fi
 
@@ -84,7 +107,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: db.sqlite3
-          key: derived-db-${{ runner.os }}-${{ env.DERIVED_TABLES_LIST }}-${{ steps.cache-date.outputs.bucket }}-${{ hashFiles('package.json', 'bunfig.toml', 'scripts/**', 'lib/**') }}
+          key: prepared-db-${{ runner.os }}-${{ env.SYNC_SCOPE }}-${{ env.DERIVED_TABLES_LIST }}-${{ steps.cache-date.outputs.bucket }}-${{ hashFiles('package.json', 'bunfig.toml', 'scripts/**', 'lib/**') }}
 
       - name: Build prepared SQLite database
         if: steps.cache-database.outputs.cache-hit != 'true'
@@ -92,7 +115,11 @@ jobs:
           bun run setup:7z
           bun run setup:download-cache-fragments
           bun run setup:extract-db
-          bun run setup:derived-sync-db
+          if [[ "${SYNC_SCOPE}" == "full_catalog" ]]; then
+            INCLUDE_COMPONENT_CATALOG=1 bun run setup:derived-sync-db
+          else
+            bun run setup:derived-sync-db
+          fi
           rm -f cache.sqlite3
           rm -rf .buildtmp
 
@@ -109,36 +136,61 @@ jobs:
             exit 1
           fi
 
-          IFS=',' read -ra tables <<< "${DERIVED_TABLES_LIST}"
-          for raw_table in "${tables[@]}"; do
-            table="$(echo "${raw_table}" | xargs)"
-            if [[ ! "${table}" =~ ^[a-z0-9_]+$ ]]; then
-              echo "::error::Invalid derived table name: ${table}"
+          if [[ "${SYNC_SCOPE}" == "full_catalog" ]]; then
+            catalog_exists="$(sqlite3 db.sqlite3 "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='component_catalog');")"
+            if [[ "${catalog_exists}" != "1" ]]; then
+              echo "::error::Prepared database does not contain component_catalog."
               exit 1
             fi
 
-            table_exists="$(sqlite3 db.sqlite3 "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='${table}');")"
-            if [[ "${table_exists}" != "1" ]]; then
-              echo "::error::Prepared database does not contain ${table}."
+            catalog_count="$(sqlite3 db.sqlite3 "SELECT COUNT(*) FROM component_catalog;")"
+            if [[ "${catalog_count}" == "0" ]]; then
+              echo "::error::Refusing to replace component_catalog with an empty table."
               exit 1
             fi
 
-            row_count="$(sqlite3 db.sqlite3 "SELECT COUNT(*) FROM \"${table}\";")"
-            if [[ "${row_count}" == "0" ]]; then
-              echo "::error::Refusing to replace ${table} with an empty table."
+            smoke_test_count="$(sqlite3 db.sqlite3 "SELECT COUNT(*) FROM component_catalog WHERE lcsc=${SMOKE_TEST_LCSC};")"
+            if [[ "${smoke_test_count}" != "1" ]]; then
+              echo "::error::Prepared catalog does not contain C${SMOKE_TEST_LCSC}."
               exit 1
             fi
-            echo "${table}: ${row_count} prepared rows"
-          done
+            echo "component_catalog: ${catalog_count} prepared rows"
+          else
+            IFS=',' read -ra tables <<< "${DERIVED_TABLES_LIST}"
+            for raw_table in "${tables[@]}"; do
+              table="$(echo "${raw_table}" | xargs)"
+              if [[ ! "${table}" =~ ^[a-z0-9_]+$ ]]; then
+                echo "::error::Invalid derived table name: ${table}"
+                exit 1
+              fi
+
+              table_exists="$(sqlite3 db.sqlite3 "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='${table}');")"
+              if [[ "${table_exists}" != "1" ]]; then
+                echo "::error::Prepared database does not contain ${table}."
+                exit 1
+              fi
+
+              row_count="$(sqlite3 db.sqlite3 "SELECT COUNT(*) FROM \"${table}\";")"
+              if [[ "${row_count}" == "0" ]]; then
+                echo "::error::Refusing to replace ${table} with an empty table."
+                exit 1
+              fi
+              echo "${table}: ${row_count} prepared rows"
+            done
+          fi
 
       - name: Apply D1 migrations
         working-directory: cf-proxy
         run: bunx wrangler d1 migrations apply jlcsearch --remote
 
-      - name: Upload derived tables to D1
+      - name: Upload selected data to D1
         env:
           SOURCE_DB_PATH: ${{ github.workspace }}/db.sqlite3
           REBUILD_DERIVED_TABLES: "0"
+          REBUILD_COMPONENT_CATALOG: "0"
+          SYNC_DERIVED_TABLES: ${{ env.SYNC_SCOPE == 'derived' && '1' || '0' }}
+          SYNC_COMPONENT_CATALOG: ${{ env.SYNC_SCOPE == 'full_catalog' && '1' || '0' }}
+          SYNC_SEARCH_INDEX: ${{ env.SYNC_SCOPE == 'full_catalog' && '1' || '0' }}
         run: ./cf-proxy/scripts/sync-db.sh
 
       - name: Verify migration status and remote row counts
@@ -146,21 +198,33 @@ jobs:
         run: |
           bunx wrangler d1 migrations list jlcsearch --remote
 
-          IFS=',' read -ra tables <<< "${DERIVED_TABLES_LIST}"
-          for raw_table in "${tables[@]}"; do
-            table="$(echo "${raw_table}" | xargs)"
+          if [[ "${SYNC_SCOPE}" == "full_catalog" ]]; then
             bunx wrangler d1 execute jlcsearch --remote \
-              --command "SELECT COUNT(*) AS row_count FROM \"${table}\";"
-          done
+              --command "SELECT COUNT(*) AS row_count FROM component_catalog;"
+            bunx wrangler d1 execute jlcsearch --remote \
+              --command "SELECT COUNT(*) AS row_count FROM search_index;"
+            bunx wrangler d1 execute jlcsearch --remote \
+              --command "SELECT lcsc, mfr, stock FROM search_index WHERE lcsc=${SMOKE_TEST_LCSC};"
+          else
+            IFS=',' read -ra tables <<< "${DERIVED_TABLES_LIST}"
+            for raw_table in "${tables[@]}"; do
+              table="$(echo "${raw_table}" | xargs)"
+              bunx wrangler d1 execute jlcsearch --remote \
+                --command "SELECT COUNT(*) AS row_count FROM \"${table}\";"
+            done
+          fi
 
       - name: Refresh and verify the production API cache
         env:
-          CACHE_BUST_URL: ${{ inputs.cache_bust_url || 'https://jlcsearch.tscircuit.com/hdmi_ports/list.json' }}
+          CACHE_BUST_URL: ${{ inputs.cache_bust_url }}
         shell: bash
         run: |
           if [[ -z "${CACHE_BUST_URL}" ]]; then
-            echo "No cache-bust URL supplied; skipping production API refresh."
-            exit 0
+            if [[ "${SYNC_SCOPE}" == "full_catalog" ]]; then
+              CACHE_BUST_URL="https://jlcsearch.tscircuit.com/components/list?search=C${SMOKE_TEST_LCSC}&json=true"
+            else
+              CACHE_BUST_URL="https://jlcsearch.tscircuit.com/hdmi_ports/list.json"
+            fi
           fi
 
           separator="?"
@@ -180,4 +244,14 @@ jobs:
               exit 1
             fi
             echo "Production HDMI API returned ${hdmi_port_count} ports."
+          fi
+
+          if [[ "${SYNC_SCOPE}" == "full_catalog" ]]; then
+            component_count="$(jq '.components | length' /tmp/d1-sync-response.json)"
+            if [[ "${component_count}" == "0" || "${component_count}" == "null" ]]; then
+              echo "::error::Production component API did not return C${SMOKE_TEST_LCSC}."
+              cat /tmp/d1-sync-response.json
+              exit 1
+            fi
+            echo "Production component API returned C${SMOKE_TEST_LCSC}."
           fi

--- a/README.md
+++ b/README.md
@@ -68,9 +68,13 @@ workflow. On relevant merges to `main`, it downloads the current upstream
 source-db-v2 database, builds and verifies a compact `db.sqlite3` containing
 the requested derived tables, applies D1 migrations, uploads those tables, and
 refreshes the affected production API cache. The workflow can also be run
-manually with a comma-separated `derived_tables` input and an optional
-`cache_bust_url`. It requires the `CLOUDFLARE_ACCOUNT_ID` and
-`CLOUDFLARE_API_TOKEN` repository secrets.
+manually in `derived` or `full_catalog` mode. `derived` accepts a
+comma-separated `derived_tables` input. `full_catalog` rebuilds and uploads the
+component catalog, search index, and FTS index from the current source-db-v2
+snapshot, and requires a numeric `smoke_test_lcsc` that must be present before
+and after the upload. Both modes accept an optional `cache_bust_url`. The
+workflow requires the `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`
+repository secrets.
 
 ## How Does It work?
 As a developer new to this codebase, or a curious user, you may have some questions about the flow of data through the scripts and automations inside this repo.  It all starts with the [jlcparts](https://github.com/yaqwsx/jlcparts) project, which compiles a massive **11GB** sqlite3 database of *everything* [JLCPCB](https://jlcpcb.com) has to offer.  As you can imagine, this would be very resource-intensive and slow to search, so the next steps are scripts that optimize it heavily, although it's more accurate to say that they rebuild it entirely. 

--- a/cf-proxy/scripts/rebuild-search-index-batched.sh
+++ b/cf-proxy/scripts/rebuild-search-index-batched.sh
@@ -87,6 +87,17 @@ SELECT
   price,
   CASE
     WHEN json_valid(price) THEN CAST(json_extract(price, '$[0].price') AS REAL)
+    WHEN instr(price, ':') > 0 THEN CAST(
+      substr(
+        price,
+        instr(price, ':') + 1,
+        CASE
+          WHEN instr(price, ',') > 0
+          THEN instr(price, ',') - instr(price, ':') - 1
+          ELSE length(price) - instr(price, ':')
+        END
+      ) AS REAL
+    )
     ELSE NULL
   END AS price1,
   basic,

--- a/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
+++ b/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
@@ -10,6 +10,17 @@ SELECT
   price,
   CASE
     WHEN json_valid(price) THEN CAST(json_extract(price, '$[0].price') AS REAL)
+    WHEN instr(price, ':') > 0 THEN CAST(
+      substr(
+        price,
+        instr(price, ':') + 1,
+        CASE
+          WHEN instr(price, ',') > 0
+          THEN instr(price, ',') - instr(price, ':') - 1
+          ELSE length(price) - instr(price, ':')
+        END
+      ) AS REAL
+    )
     ELSE NULL
   END AS price1,
   basic,

--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -19,6 +19,8 @@ SYNC_COMPONENT_CATALOG="${SYNC_COMPONENT_CATALOG:-0}"
 SYNC_SEARCH_INDEX="${SYNC_SEARCH_INDEX:-0}"
 DERIVED_TABLES_LIST="${DERIVED_TABLES_LIST:-}"
 REBUILD_DERIVED_TABLES="${REBUILD_DERIVED_TABLES:-1}"
+REBUILD_COMPONENT_CATALOG="${REBUILD_COMPONENT_CATALOG:-1}"
+REBUILD_SEARCH_INDEX="${REBUILD_SEARCH_INDEX:-1}"
 
 DERIVED_TABLES=(
   accelerometer
@@ -315,7 +317,9 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basi
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA
+}
 
+write_component_catalog_schema() {
   cat > component_catalog_schema.sql <<'COMPONENT_CATALOG_SCHEMA_EXPORT'
 DROP TABLE IF EXISTS component_catalog;
 CREATE TABLE component_catalog (
@@ -353,6 +357,17 @@ SELECT
   price,
   CASE
     WHEN json_valid(price) THEN CAST(json_extract(price, '$[0].price') AS REAL)
+    WHEN instr(price, ':') > 0 THEN CAST(
+      substr(
+        price,
+        instr(price, ':') + 1,
+        CASE
+          WHEN instr(price, ',') > 0
+          THEN instr(price, ',') - instr(price, ':') - 1
+          ELSE length(price) - instr(price, ':')
+        END
+      ) AS REAL
+    )
     ELSE NULL
   END AS price1,
   basic,
@@ -399,7 +414,9 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, s
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
 SEARCH_INDEX_SCHEMA
+}
 
+write_search_index_schema() {
   cat > search_index_schema.sql <<'SEARCH_INDEX_SCHEMA_EXPORT'
 DROP TABLE IF EXISTS search_index;
 CREATE TABLE search_index (
@@ -462,20 +479,32 @@ main() {
 
   if [[ "${SYNC_COMPONENT_CATALOG}" == "1" || "${SYNC_SEARCH_INDEX}" == "1" ]]; then
     write_cleanup_sql
-    materialize_component_catalog
+    if [[ "${REBUILD_COMPONENT_CATALOG}" == "1" ]]; then
+      materialize_component_catalog
+    else
+      echo "Using component_catalog already prepared in the source database."
+      require_table component_catalog
+    fi
 
     echo "Importing cleanup SQL to D1..."
     run_wrangler d1 execute "${DB_NAME}" --remote --file=cleanup_obsolete_objects.sql
   fi
 
   if [[ "${SYNC_COMPONENT_CATALOG}" == "1" ]]; then
+    write_component_catalog_schema
     echo "Importing component catalog schema to D1..."
     run_wrangler d1 execute "${DB_NAME}" --remote --file=component_catalog_schema.sql
     import_table_in_batches component_catalog "${COMPONENT_CATALOG_BATCH_ROWS}"
   fi
 
   if [[ "${SYNC_SEARCH_INDEX}" == "1" ]]; then
-    materialize_search_index
+    if [[ "${REBUILD_SEARCH_INDEX}" == "1" ]]; then
+      materialize_search_index
+    else
+      echo "Using search_index already prepared in the source database."
+      require_table search_index
+    fi
+    write_search_index_schema
     echo "Importing search index schema to D1..."
     run_wrangler d1 execute "${DB_NAME}" --remote --file=search_index_schema.sql
     import_table_in_batches search_index "${SEARCH_INDEX_BATCH_ROWS}"

--- a/cf-proxy/src/d1-routes.ts
+++ b/cf-proxy/src/d1-routes.ts
@@ -44,7 +44,10 @@ const extractSmallQuantityPrice = (price: string | null): number => {
     const priceObj = JSON.parse(price)
     return Number(priceObj[0]?.price ?? 0) || 0
   } catch {
-    return 0
+    const firstTier = price.split(",", 1)[0]
+    const separatorIndex = firstTier.indexOf(":")
+    if (separatorIndex === -1) return 0
+    return Number(firstTier.slice(separatorIndex + 1)) || 0
   }
 }
 

--- a/cf-proxy/test/lcd-drivers-route.test.ts
+++ b/cf-proxy/test/lcd-drivers-route.test.ts
@@ -54,7 +54,7 @@ describe("LCD driver route", () => {
                 package: "SSOP-48-300mil",
                 description: "LCD driver",
                 stock: 18416,
-                price: '[{"qFrom":1,"price":0.464285714}]',
+                price: "1-9:0.464285714,10-:0.4",
                 basic: 0,
                 preferred: 1,
                 extra:

--- a/scripts/build-derived-sync-db.ts
+++ b/scripts/build-derived-sync-db.ts
@@ -23,11 +23,13 @@ export const buildDerivedSyncDatabase = async ({
   sourcePath,
   outputPath,
   tableNames,
+  includeComponentCatalog = false,
   logger = console.log,
 }: {
   sourcePath: string
   outputPath: string
   tableNames?: string[]
+  includeComponentCatalog?: boolean
   logger?: (message: string) => void
 }) => {
   const resolvedSourcePath = path.resolve(sourcePath)
@@ -121,6 +123,66 @@ export const buildDerivedSyncDatabase = async ({
       AND j.last_on_stock >= unixepoch('now', '-1 year');
   `)
 
+  if (includeComponentCatalog) {
+    database.exec(`
+      CREATE TABLE component_catalog AS
+      SELECT
+        j.lcsc,
+        j.category,
+        j.subcategory,
+        j.mfr,
+        j.package,
+        CASE WHEN j.library_type = 'base' THEN 1 ELSE 0 END AS basic,
+        j.preferred,
+        j.description,
+        j.stock,
+        j.price,
+        json_object(
+          'number', 'C' || j.lcsc,
+          'manufacturer', json_object(
+            'name', coalesce(
+              NULLIF(l.manufacturer, ''),
+              NULLIF(j.manufacturer, '')
+            )
+          ),
+          'title', trim(
+            coalesce(
+              NULLIF(l.manufacturer, ''),
+              NULLIF(j.manufacturer, ''),
+              ''
+            ) || ' ' || j.mfr
+          ),
+          'mpn', j.mfr,
+          'package', j.package,
+          'attributes', json(
+            json_patch(
+              CASE
+                WHEN json_valid(j.attributes) THEN j.attributes
+                ELSE '{}'
+              END,
+              CASE
+                WHEN json_valid(l.attributes) THEN l.attributes
+                ELSE '{}'
+              END
+            )
+          ),
+          'description', j.description,
+          'url', CASE
+            WHEN l.url_slug IS NOT NULL AND l.url_slug != ''
+            THEN 'https://lcsc.com/product-detail/' || l.url_slug || '_C' || j.lcsc || '.html'
+            ELSE NULL
+          END
+        ) AS extra
+      FROM source.jlc_components AS j
+      LEFT JOIN source.lcsc_components AS l ON l.lcsc = j.lcsc
+      WHERE j.present = 1
+        AND j.last_on_stock >= unixepoch('now', '-1 year');
+
+      CREATE INDEX idx_component_catalog_lcsc ON component_catalog(lcsc);
+      CREATE INDEX idx_component_catalog_stock ON component_catalog(stock DESC);
+    `)
+  }
+
   const db = new Kysely<DB>({
     dialect: new BunSqliteDialect({ database }),
   })
@@ -145,11 +207,14 @@ const main = async () => {
   const configuredTables = process.env.DERIVED_TABLES_LIST?.split(",")
     .map((table) => table.trim())
     .filter(Boolean)
+  const includeComponentCatalog =
+    process.env.INCLUDE_COMPONENT_CATALOG?.trim() === "1"
 
   await buildDerivedSyncDatabase({
     sourcePath,
     outputPath,
     tableNames: configuredTables?.length ? configuredTables : undefined,
+    includeComponentCatalog,
   })
 }
 

--- a/tests/build-derived-sync-db.test.ts
+++ b/tests/build-derived-sync-db.test.ts
@@ -132,6 +132,44 @@ describe("buildDerivedSyncDatabase", () => {
       }),
     ).rejects.toThrow("Unknown derived table: not_a_table")
   })
+
+  test("materializes a component catalog from source-db-v2", async () => {
+    const { sourcePath, outputPath } = await createSourceDatabase()
+
+    await buildDerivedSyncDatabase({
+      sourcePath,
+      outputPath,
+      tableNames: ["hdmi_port"],
+      includeComponentCatalog: true,
+      logger: () => {},
+    })
+
+    const output = new Database(outputPath, { readonly: true })
+    const row = output
+      .query(
+        `SELECT
+          lcsc, mfr, category, subcategory, basic, preferred, stock,
+          json_extract(extra, '$.manufacturer.name') AS manufacturer,
+          json_extract(extra, '$.mpn') AS mpn,
+          json_extract(extra, '$.attributes.Gender') AS gender
+        FROM component_catalog`,
+      )
+      .get() as Record<string, unknown>
+
+    expect(row).toEqual({
+      lcsc: 12345,
+      mfr: "HDMI-19P",
+      category: "Connectors",
+      subcategory: "HDMI Connectors",
+      basic: 1,
+      preferred: 1,
+      stock: 250,
+      manufacturer: "Example Inc.",
+      mpn: "HDMI-19P",
+      gender: "Female",
+    })
+    output.close()
+  })
 })
 
 describe("extractMinQPrice", () => {


### PR DESCRIPTION
## What changed

- add a `full_catalog` mode to the production D1 workflow
- materialize `component_catalog` directly from the current source-db-v2 schema
- rebuild and upload the search and FTS indexes in full-catalog mode
- require an exact LCSC preflight and production API smoke test
- support source-db-v2 CSV price tiers in catalog routes and every search-index rebuild path

## Why

The deployed component catalog was stale. Recent workflow repairs only restored derived-table uploads, while the component and search-index sync flags remained disabled. The old full build also depended on the removed `components` table, so current JLC entries such as AM62L / C52091703 never reached production search.

## Impact

Maintainers can manually run the existing workflow in `full_catalog` mode against the current upstream snapshot. Normal pushes and derived-table runs retain their existing behavior.

## Validation

- `bun test` — 174 passed
- `bun run test` in `cf-proxy` — 138 passed
- `bunx tsc --noEmit --project cf-proxy/tsconfig.json`
- shell syntax checks for both modified sync scripts
- workflow YAML parse
- real upstream snapshot: 730,174 catalog rows, including C52091703