### PR TITLE
Add Photo Diodes category

### DIFF
--- a/.github/workflows/d1-migrations.yml
+++ b/.github/workflows/d1-migrations.yml
@@ -27,7 +27,7 @@ on:
       derived_tables:
         description: Comma-separated derived tables to rebuild and upload
         required: true
-        default: hdmi_port
+        default: photo_diode
         type: string
       cache_bust_url:
         description: Production URL to refresh after the D1 upload
@@ -56,7 +56,7 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       SYNC_SCOPE: ${{ inputs.sync_scope || 'derived' }}
-      DERIVED_TABLES_LIST: ${{ inputs.derived_tables || 'hdmi_port' }}
+      DERIVED_TABLES_LIST: ${{ inputs.derived_tables || 'photo_diode' }}
       SMOKE_TEST_LCSC: ${{ inputs.smoke_test_lcsc || '7512' }}
 
     steps:
@@ -223,7 +223,7 @@ jobs:
             if [[ "${SYNC_SCOPE}" == "full_catalog" ]]; then
               CACHE_BUST_URL="https://jlcsearch.tscircuit.com/components/list?search=C${SMOKE_TEST_LCSC}&json=true"
             else
-              CACHE_BUST_URL="https://jlcsearch.tscircuit.com/hdmi_ports/list.json"
+              CACHE_BUST_URL="https://jlcsearch.tscircuit.com/photo_diodes/list.json"
             fi
           fi
 

--- a/cf-proxy/migrations/0003_photo_diode.sql
+++ b/cf-proxy/migrations/0003_photo_diode.sql
@@ -1,0 +1,35 @@
+CREATE TABLE IF NOT EXISTS photo_diode (
+  lcsc INTEGER PRIMARY KEY,
+  mfr TEXT,
+  description TEXT,
+  stock INTEGER,
+  price1 REAL,
+  in_stock BOOLEAN,
+  package TEXT,
+  peak_wavelength_nm REAL,
+  spectral_range_min_nm REAL,
+  spectral_range_max_nm REAL,
+  reverse_voltage REAL,
+  dark_current_a REAL,
+  reception_angle_deg REAL,
+  operating_temp_min REAL,
+  operating_temp_max REAL,
+  is_basic BOOLEAN,
+  is_preferred BOOLEAN,
+  attributes TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_photo_diode_stock
+  ON photo_diode (stock);
+CREATE INDEX IF NOT EXISTS idx_photo_diode_package_stock
+  ON photo_diode (package, stock);
+CREATE INDEX IF NOT EXISTS idx_photo_diode_peak_wavelength_stock
+  ON photo_diode (peak_wavelength_nm, stock);
+CREATE INDEX IF NOT EXISTS idx_photo_diode_reverse_voltage_stock
+  ON photo_diode (reverse_voltage, stock);
+CREATE INDEX IF NOT EXISTS idx_photo_diode_dark_current_stock
+  ON photo_diode (dark_current_a, stock);
+CREATE INDEX IF NOT EXISTS idx_photo_diode_is_basic_stock
+  ON photo_diode (is_basic, stock);
+CREATE INDEX IF NOT EXISTS idx_photo_diode_is_preferred_stock
+  ON photo_diode (is_preferred, stock);

--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -56,6 +56,7 @@ DERIVED_TABLES=(
   mosfet
   oled_display
   pcie_m2_connector
+  photo_diode
   potentiometer
   relay
   resistor

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -710,6 +710,27 @@ export interface PcieM2Connector {
   stock: number | null
 }
 
+export interface PhotoDiode {
+  attributes: string | null
+  dark_current_a: number | null
+  description: string | null
+  in_stock: number | null
+  is_basic: number | null
+  is_preferred: number | null
+  lcsc: Generated<number | null>
+  mfr: string | null
+  operating_temp_max: number | null
+  operating_temp_min: number | null
+  package: string | null
+  peak_wavelength_nm: number | null
+  price1: number | null
+  reception_angle_deg: number | null
+  reverse_voltage: number | null
+  spectral_range_max_nm: number | null
+  spectral_range_min_nm: number | null
+  stock: number | null
+}
+
 export interface Potentiometer {
   attributes: string | null
   description: string | null
@@ -1001,6 +1022,7 @@ export interface DB {
   mosfet: Mosfet
   oled_display: OledDisplay
   pcie_m2_connector: PcieM2Connector
+  photo_diode: PhotoDiode
   potentiometer: Potentiometer
   relay: Relay
   resistor: Resistor

--- a/cf-proxy/src/handlers/index.ts
+++ b/cf-proxy/src/handlers/index.ts
@@ -206,6 +206,24 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       diode_type: { field: "diode_type", type: "string" },
     },
   },
+  photo_diode: {
+    filters: {
+      package: { field: "package", type: "string" },
+      peak_wavelength_nm: { field: "peak_wavelength_nm", type: "number" },
+      reverse_voltage_min: {
+        field: "reverse_voltage",
+        type: "number",
+        operator: ">=",
+      },
+      dark_current_max: {
+        field: "dark_current_a",
+        type: "number",
+        operator: "<=",
+      },
+      is_basic: { field: "is_basic", type: "boolean" },
+      is_preferred: { field: "is_preferred", type: "boolean" },
+    },
+  },
   dimm_connector: {
     filters: {
       package: { field: "package", type: "string" },
@@ -534,6 +552,7 @@ export const ROUTE_TO_TABLE: Record<string, string> = {
   "/ldos/list": "ldo",
   "/leds/list": "led",
   "/diodes/list": "diode",
+  "/photo_diodes/list": "photo_diode",
   "/mosfets/list": "mosfet",
   "/switches/list": "switch",
   "/headers/list": "header",
@@ -582,6 +601,7 @@ export const TABLE_RESPONSE_KEY: Record<string, string> = {
   ldo: "ldos",
   led: "leds",
   diode: "diodes",
+  photo_diode: "photo_diodes",
   mosfet: "mosfets",
   switch: "switches",
   header: "headers",

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -45,6 +45,7 @@ const routeLabels: Record<string, string> = {
   "/hdmi_ports/list": "HDMI Ports",
   "/microphones/list": "Microphones",
   "/diodes/list": "Diodes",
+  "/photo_diodes/list": "Photo Diodes",
   "/dacs/list": "DACs",
   "/wifi_modules/list": "WiFi Modules",
   "/microcontrollers/list": "Microcontrollers",
@@ -166,6 +167,13 @@ const COLUMN_LABELS: Record<string, string> = {
   current_rating_amp: "Current",
   voltage_rating_volt: "Voltage",
   wavelength_nm: "Wavelength",
+  peak_wavelength_nm: "Peak Wavelength",
+  spectral_range_min_nm: "Spectral Range Min",
+  spectral_range_max_nm: "Spectral Range Max",
+  reverse_voltage_min: "Min Reverse Voltage",
+  dark_current_a: "Dark Current",
+  dark_current_max: "Max Dark Current",
+  reception_angle_deg: "Reception Angle",
   luminous_intensity_mcd: "Intensity",
   number_of_contacts: "Contacts",
   number_of_pins: "Pins",
@@ -268,6 +276,9 @@ const formatDisplayValue = (column: string, value: unknown): string | null => {
     case "data_rate_mbps":
       return withUnit(value, "Mbps")
     case "wavelength_nm":
+    case "peak_wavelength_nm":
+    case "spectral_range_min_nm":
+    case "spectral_range_max_nm":
       return withUnit(value, "nm")
     case "luminous_intensity_mcd":
       return withUnit(value, "mcd")
@@ -292,6 +303,7 @@ const formatDisplayValue = (column: string, value: unknown): string | null => {
     case "current_rating_a":
     case "current_rating_amp":
     case "forward_current":
+    case "dark_current_a":
     case "collector_current":
     case "continuous_drain_current":
     case "output_current_max":
@@ -329,6 +341,8 @@ const formatDisplayValue = (column: string, value: unknown): string | null => {
     case "operating_temperature_min":
     case "operating_temperature_max":
       return withUnit(value, "°C")
+    case "reception_angle_deg":
+      return withUnit(value, "°")
     default:
       return null
   }

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -17,6 +17,58 @@ describe("render helpers", () => {
     expect(html).toContain("/dimm_connectors/list")
     expect(html).toContain("/sodimm_connectors/list")
     expect(html).toContain("/hdmi_ports/list")
+    expect(html).toContain("/photo_diodes/list")
+  })
+
+  it("renders the Photo Diodes page and JSON API link", () => {
+    const pathname = "/photo_diodes/list"
+
+    expect(D1_ROUTES).toContain(pathname)
+    expect(getD1Handler(pathname)).toBeTypeOf("function")
+
+    const html = renderD1TablePage(
+      pathname,
+      {
+        photo_diodes: [
+          {
+            lcsc: 161211,
+            mfr: "PD15-22B/TR8",
+            package: "SMD-4P,2.7x3.2mm",
+            peak_wavelength_nm: 940,
+            spectral_range_min_nm: 730,
+            spectral_range_max_nm: 1100,
+            reverse_voltage: 32,
+            dark_current_a: 10e-9,
+            reception_angle_deg: 60,
+            stock: 47803,
+          },
+        ],
+      },
+      {
+        package: "SMD-4P,2.7x3.2mm",
+        peak_wavelength_nm: "940",
+        reverse_voltage_min: "20",
+        dark_current_max: "0.00000001",
+      },
+      "https://jlcsearch.tscircuit.com/photo_diodes/list?package=SMD-4P%2C2.7x3.2mm&peak_wavelength_nm=940",
+      {
+        package: ["SMD-4P,2.7x3.2mm", "Plugin"],
+        peak_wavelength_nm: ["850", "940"],
+      },
+    )
+
+    expect(html).toContain("<h2>Photo Diodes</h2>")
+    expect(html).toContain('name="package"')
+    expect(html).toContain('name="peak_wavelength_nm"')
+    expect(html).toContain('name="reverse_voltage_min"')
+    expect(html).toContain('name="dark_current_max"')
+    expect(html).toContain('name="is_basic"')
+    expect(html).toContain('name="is_preferred"')
+    expect(html).toContain("PD15-22B/TR8")
+    expect(html).toContain("940nm")
+    expect(html).toContain("10nA")
+    expect(html).toContain("60°")
+    expect(html).toContain("/photo_diodes/list.json")
   })
 
   it("renders the HDMI ports page and JSON API link", () => {

--- a/lib/db/derivedtables/photo-diode.ts
+++ b/lib/db/derivedtables/photo-diode.ts
@@ -1,0 +1,196 @@
+import { BaseComponent } from "lib/db/derivedtables/component-base"
+import type { DerivedTableSpec } from "lib/db/derivedtables/types"
+import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+
+export interface PhotoDiode extends BaseComponent {
+  package: string
+  peak_wavelength_nm: number | null
+  spectral_range_min_nm: number | null
+  spectral_range_max_nm: number | null
+  reverse_voltage: number | null
+  dark_current_a: number | null
+  reception_angle_deg: number | null
+  operating_temp_min: number | null
+  operating_temp_max: number | null
+}
+
+const SI_MULTIPLIERS: Record<string, number> = {
+  p: 1e-12,
+  n: 1e-9,
+  u: 1e-6,
+  µ: 1e-6,
+  μ: 1e-6,
+  m: 1e-3,
+  "": 1,
+  k: 1e3,
+  M: 1e6,
+}
+
+const parseSiValue = (
+  value: string | undefined,
+  unit: "A" | "V",
+): number | null => {
+  if (!value || value.trim() === "-") return null
+  const match = value.match(
+    new RegExp(`(-?\\d+(?:\\.\\d+)?)\\s*([pnuµμmkM]?)${unit}\\b`),
+  )
+  if (!match) return null
+
+  const parsed = Number.parseFloat(match[1]) * SI_MULTIPLIERS[match[2]]
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const parseWavelength = (value: string | undefined): number | null => {
+  if (!value || value.trim() === "-") return null
+  const match = value.match(/(\d+(?:\.\d+)?)\s*nm\b/i)
+  if (!match) return null
+
+  const parsed = Number.parseFloat(match[1])
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const parseSpectralRange = (
+  value: string | undefined,
+): [number | null, number | null] => {
+  if (!value || value.trim() === "-") return [null, null]
+  const match = value.match(
+    /(\d+(?:\.\d+)?)\s*nm\s*(?:~|～|to)\s*(\d+(?:\.\d+)?)\s*nm/i,
+  )
+  if (!match) return [null, null]
+
+  const min = Number.parseFloat(match[1])
+  const max = Number.parseFloat(match[2])
+  return [Number.isFinite(min) ? min : null, Number.isFinite(max) ? max : null]
+}
+
+const parseAngle = (value: string | undefined): number | null => {
+  if (!value || value.trim() === "-") return null
+  const match = value.match(/(?:±\s*)?(\d+(?:\.\d+)?)\s*°/)
+  if (!match) return null
+
+  const parsed = Number.parseFloat(match[1])
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const parseTemperatureRange = (
+  value: string | undefined,
+): [number | null, number | null] => {
+  if (!value || value.trim() === "-") return [null, null]
+  const match = value.match(
+    /(-?\d+(?:\.\d+)?)\s*(?:℃|°C)\s*(?:~|～|to)\s*\+?(-?\d+(?:\.\d+)?)\s*(?:℃|°C)/i,
+  )
+  if (!match) return [null, null]
+
+  const min = Number.parseFloat(match[1])
+  const max = Number.parseFloat(match[2])
+  return [Number.isFinite(min) ? min : null, Number.isFinite(max) ? max : null]
+}
+
+export const photoDiodeTableSpec: DerivedTableSpec<PhotoDiode> = {
+  tableName: "photo_diode",
+  extraColumns: [
+    { name: "package", type: "text" },
+    { name: "peak_wavelength_nm", type: "real" },
+    { name: "spectral_range_min_nm", type: "real" },
+    { name: "spectral_range_max_nm", type: "real" },
+    { name: "reverse_voltage", type: "real" },
+    { name: "dark_current_a", type: "real" },
+    { name: "reception_angle_deg", type: "real" },
+    { name: "operating_temp_min", type: "real" },
+    { name: "operating_temp_max", type: "real" },
+    { name: "is_basic", type: "boolean" },
+    { name: "is_preferred", type: "boolean" },
+  ],
+  indexes: [
+    { name: "idx_photo_diode_stock", columns: ["stock"] },
+    {
+      name: "idx_photo_diode_package_stock",
+      columns: ["package", "stock"],
+    },
+    {
+      name: "idx_photo_diode_peak_wavelength_stock",
+      columns: ["peak_wavelength_nm", "stock"],
+    },
+    {
+      name: "idx_photo_diode_reverse_voltage_stock",
+      columns: ["reverse_voltage", "stock"],
+    },
+    {
+      name: "idx_photo_diode_dark_current_stock",
+      columns: ["dark_current_a", "stock"],
+    },
+    {
+      name: "idx_photo_diode_is_basic_stock",
+      columns: ["is_basic", "stock"],
+    },
+    {
+      name: "idx_photo_diode_is_preferred_stock",
+      columns: ["is_preferred", "stock"],
+    },
+  ],
+  listCandidateComponents: (db) =>
+    db
+      .selectFrom("components")
+      .innerJoin("categories", "components.category_id", "categories.id")
+      .selectAll()
+      .where("categories.subcategory", "=", "Photodiodes"),
+  mapToTable: (components) =>
+    components.map((component) => {
+      try {
+        const extra = component.extra ? JSON.parse(component.extra) : {}
+        const attrs: Record<string, string> = extra.attributes || {}
+        const description = String(component.description || "")
+        const spectralRange =
+          attrs["Spectral Range"] ??
+          description.match(
+            /\d+(?:\.\d+)?\s*nm\s*(?:~|～|to)\s*\d+(?:\.\d+)?\s*nm/i,
+          )?.[0]
+        const [spectralRangeMin, spectralRangeMax] =
+          parseSpectralRange(spectralRange)
+        const operatingTemperature =
+          attrs["Operating Temperature"] ??
+          description.match(
+            /-?\d+(?:\.\d+)?\s*(?:℃|°C)\s*(?:~|～|to)\s*\+?-?\d+(?:\.\d+)?\s*(?:℃|°C)/i,
+          )?.[0]
+        const [operatingTempMin, operatingTempMax] =
+          parseTemperatureRange(operatingTemperature)
+        const peakWavelengthSource =
+          attrs["Peak Wavelength"] ??
+          attrs["Peak  Wavelength"] ??
+          description.replace(spectralRange ?? "", "")
+
+        return {
+          lcsc: Number(component.lcsc),
+          mfr: String(component.mfr || ""),
+          description,
+          stock: Number(component.stock || 0),
+          price1: extractMinQPrice(component.price),
+          in_stock: Boolean((component.stock || 0) > 0),
+          is_basic: Boolean(component.basic),
+          is_preferred: Boolean(component.preferred),
+          package: String(component.package || ""),
+          peak_wavelength_nm: parseWavelength(peakWavelengthSource),
+          spectral_range_min_nm: spectralRangeMin,
+          spectral_range_max_nm: spectralRangeMax,
+          reverse_voltage: parseSiValue(
+            attrs["DC Reverse Voltage"] ??
+              attrs["Reverse Voltage"] ??
+              description,
+            "V",
+          ),
+          dark_current_a: parseSiValue(
+            attrs["Dark Current"] ?? attrs["Current Dark"] ?? description,
+            "A",
+          ),
+          reception_angle_deg: parseAngle(
+            attrs["Reception Angle"] ?? attrs["Viewing Angle"],
+          ),
+          operating_temp_min: operatingTempMin,
+          operating_temp_max: operatingTempMax,
+          attributes: attrs,
+        }
+      } catch {
+        return null
+      }
+    }),
+}

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -36,6 +36,7 @@ import { microcontrollerTableSpec } from "lib/db/derivedtables/microcontroller"
 import { mosfetTableSpec } from "lib/db/derivedtables/mosfet"
 import { oledDisplayTableSpec } from "lib/db/derivedtables/oled_display"
 import { pcieM2ConnectorTableSpec } from "lib/db/derivedtables/pcie_m2_connector"
+import { photoDiodeTableSpec } from "lib/db/derivedtables/photo-diode"
 import { potentiometerTableSpec } from "lib/db/derivedtables/potentiometer"
 import { relayTableSpec } from "lib/db/derivedtables/relay"
 import { resistorArrayTableSpec } from "lib/db/derivedtables/resistor_array"
@@ -89,6 +90,7 @@ export const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   fpcConnectorTableSpec,
   usbCConnectorTableSpec,
   pcieM2ConnectorTableSpec,
+  photoDiodeTableSpec,
   jstConnectorTableSpec,
   wireToBoardConnectorTableSpec,
   springClampTerminalBlockTableSpec,

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -803,6 +803,27 @@ export interface PcieM2Connector {
   stock: number | null;
 }
 
+export interface PhotoDiode {
+  attributes: string | null;
+  dark_current_a: number | null;
+  description: string | null;
+  in_stock: number | null;
+  is_basic: number | null;
+  is_preferred: number | null;
+  lcsc: Generated<number | null>;
+  mfr: string | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  package: string | null;
+  peak_wavelength_nm: number | null;
+  price1: number | null;
+  reception_angle_deg: number | null;
+  reverse_voltage: number | null;
+  spectral_range_max_nm: number | null;
+  spectral_range_min_nm: number | null;
+  stock: number | null;
+}
+
 export interface Potentiometer {
   attributes: string | null;
   description: string | null;
@@ -1061,6 +1082,7 @@ export interface DB {
   mosfet: Mosfet;
   oled_display: OledDisplay;
   pcie_m2_connector: PcieM2Connector;
+  photo_diode: PhotoDiode;
   potentiometer: Potentiometer;
   relay: Relay;
   resistor: Resistor;

--- a/tests/lib/photo-diode-derived-table.test.ts
+++ b/tests/lib/photo-diode-derived-table.test.ts
@@ -1,0 +1,184 @@
+import { Database } from "bun:sqlite"
+import { expect, test } from "bun:test"
+import { Kysely } from "kysely"
+import { BunSqliteDialect } from "kysely-bun-sqlite"
+import { photoDiodeTableSpec } from "lib/db/derivedtables/photo-diode"
+import { setupDerivedTables } from "lib/db/derivedtables/setup-derived-tables"
+
+const makeComponent = (overrides: Record<string, unknown> = {}) =>
+  ({
+    lcsc: 161211,
+    mfr: "PD15-22B/TR8",
+    description:
+      "32V 940nm 730nm~1100nm 10nA SMD-4P,2.7x3.2mm Photodiodes ROHS",
+    stock: 47803,
+    basic: 0,
+    preferred: 1,
+    price: JSON.stringify([{ qFrom: 1, qTo: null, price: 0.080724638 }]),
+    package: "SMD-4P,2.7x3.2mm",
+    extra: JSON.stringify({
+      title: "Everlight Elec PD15-22B/TR8",
+      attributes: {
+        "Reception Angle": "60°",
+        "Operating Temperature": "-40℃~+85℃",
+        "Spectral Range": "730nm~1100nm",
+        "DC Reverse Voltage": "32V",
+        "Current Dark": "10nA",
+        "Peak  Wavelength": "940nm",
+      },
+    }),
+    ...overrides,
+  }) as any
+
+const EXPECTED_INDEX_COLUMNS = [
+  "stock",
+  "package,stock",
+  "peak_wavelength_nm,stock",
+  "reverse_voltage,stock",
+  "dark_current_a,stock",
+  "is_basic,stock",
+  "is_preferred,stock",
+]
+
+test("photo diode table maps optical and electrical attributes", () => {
+  const [photoDiode] = photoDiodeTableSpec.mapToTable([makeComponent()])
+
+  expect(photoDiode).toMatchObject({
+    lcsc: 161211,
+    mfr: "PD15-22B/TR8",
+    package: "SMD-4P,2.7x3.2mm",
+    peak_wavelength_nm: 940,
+    spectral_range_min_nm: 730,
+    spectral_range_max_nm: 1100,
+    reverse_voltage: 32,
+    dark_current_a: 10e-9,
+    reception_angle_deg: 60,
+    operating_temp_min: -40,
+    operating_temp_max: 85,
+    is_preferred: true,
+    price1: 0.080724638,
+  })
+})
+
+test("photo diode table falls back to description data", () => {
+  const [photoDiode] = photoDiodeTableSpec.mapToTable([
+    makeComponent({
+      extra: null,
+      description: "32V 940nm 730nm~1100nm 10nA Plugin Photodiodes ROHS",
+      package: "Plugin",
+    }),
+  ])
+
+  expect(photoDiode).toMatchObject({
+    package: "Plugin",
+    peak_wavelength_nm: 940,
+    spectral_range_min_nm: 730,
+    spectral_range_max_nm: 1100,
+    reverse_voltage: 32,
+    dark_current_a: 10e-9,
+  })
+})
+
+test("photo diode table selects the Photodiodes subcategory", async () => {
+  const database = new Database(":memory:")
+  const db = new Kysely<any>({
+    dialect: new BunSqliteDialect({ database }),
+  })
+
+  try {
+    await db.schema
+      .createTable("categories")
+      .addColumn("id", "integer", (column) => column.primaryKey())
+      .addColumn("subcategory", "text", (column) => column.notNull())
+      .execute()
+    await db.schema
+      .createTable("components")
+      .addColumn("lcsc", "integer", (column) => column.primaryKey())
+      .addColumn("category_id", "integer", (column) => column.notNull())
+      .execute()
+
+    await db
+      .insertInto("categories")
+      .values([
+        { id: 1, subcategory: "Photodiodes" },
+        { id: 2, subcategory: "Phototransistors" },
+        { id: 3, subcategory: "Laser Diodes" },
+      ])
+      .execute()
+    await db
+      .insertInto("components")
+      .values([
+        { lcsc: 1, category_id: 1 },
+        { lcsc: 2, category_id: 2 },
+        { lcsc: 3, category_id: 3 },
+      ])
+      .execute()
+
+    const candidates = await photoDiodeTableSpec
+      .listCandidateComponents(db)
+      .execute()
+
+    expect(candidates.map((candidate) => candidate.lcsc)).toEqual([1])
+  } finally {
+    await db.destroy()
+  }
+})
+
+test("photo diode schema and migration create query indexes idempotently", async () => {
+  expect(
+    photoDiodeTableSpec.indexes?.map((index) => index.columns.join(",")),
+  ).toEqual(EXPECTED_INDEX_COLUMNS)
+
+  const database = new Database(":memory:")
+  const db = new Kysely<any>({
+    dialect: new BunSqliteDialect({ database }),
+  })
+
+  try {
+    await setupDerivedTables({ db, populate: false })
+
+    const table = database
+      .query(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'photo_diode'",
+      )
+      .get()
+    const indexes = database
+      .query(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'photo_diode' AND name NOT LIKE 'sqlite_%'",
+      )
+      .all()
+
+    expect(table).not.toBeNull()
+    expect(indexes).toHaveLength(EXPECTED_INDEX_COLUMNS.length)
+  } finally {
+    await db.destroy()
+  }
+
+  const migrationDatabase = new Database(":memory:")
+  const migrationPath = new URL(
+    "../../cf-proxy/migrations/0003_photo_diode.sql",
+    import.meta.url,
+  )
+  const migration = await Bun.file(migrationPath).text()
+
+  try {
+    migrationDatabase.exec(migration)
+    migrationDatabase.exec(migration)
+
+    const table = migrationDatabase
+      .query(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'photo_diode'",
+      )
+      .get()
+    const indexes = migrationDatabase
+      .query(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'photo_diode' AND name NOT LIKE 'sqlite_%'",
+      )
+      .all()
+
+    expect(table).not.toBeNull()
+    expect(indexes).toHaveLength(EXPECTED_INDEX_COLUMNS.length)
+  } finally {
+    migrationDatabase.close()
+  }
+})


### PR DESCRIPTION
## Summary

- add a **Photo Diodes** category at `/photo_diodes/list` with JSON API support
- build a `photo_diode` derived table from JLCPCB's `Photodiodes` subcategory, including optical/electrical attributes and filters
- add the D1 schema, production sync wiring, generated types, homepage link, and focused coverage

## User impact

Users can browse and filter in-stock photodiodes by package, peak wavelength, minimum reverse voltage, maximum dark current, and JLCPCB assembly status.

## Validation

- `bun test` — 179 passed
- `bunx tsc --noEmit`
- `bunx tsc --noEmit --project cf-proxy/tsconfig.json`
- `bun run format:check`