### PR TITLE
Add minimum wavelength filter for Photo Diodes

### DIFF
--- a/cf-proxy/src/handlers/index.ts
+++ b/cf-proxy/src/handlers/index.ts
@@ -209,7 +209,11 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
   photo_diode: {
     filters: {
       package: { field: "package", type: "string" },
-      peak_wavelength_nm: { field: "peak_wavelength_nm", type: "number" },
+      wavelength_min: {
+        field: "peak_wavelength_nm",
+        type: "number",
+        operator: ">=",
+      },
       reverse_voltage_min: {
         field: "reverse_voltage",
         type: "number",

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -167,6 +167,7 @@ const COLUMN_LABELS: Record<string, string> = {
   current_rating_amp: "Current",
   voltage_rating_volt: "Voltage",
   wavelength_nm: "Wavelength",
+  wavelength_min: "Min Wavelength",
   peak_wavelength_nm: "Peak Wavelength",
   spectral_range_min_nm: "Spectral Range Min",
   spectral_range_max_nm: "Spectral Range Max",

--- a/cf-proxy/test/photo-diode-route.test.ts
+++ b/cf-proxy/test/photo-diode-route.test.ts
@@ -1,0 +1,52 @@
+import {
+  DummyDriver,
+  Kysely,
+  SqliteAdapter,
+  SqliteIntrospector,
+  SqliteQueryCompiler,
+  type CompiledQuery,
+  type DatabaseConnection,
+} from "kysely"
+import { describe, expect, it } from "vitest"
+import { getD1Handler } from "../src/d1-routes"
+import type { DB } from "../src/db/types"
+
+describe("Photo Diodes route", () => {
+  it("filters peak wavelength using a minimum threshold", async () => {
+    const compiledQueries: CompiledQuery[] = []
+    const driver = new DummyDriver()
+
+    driver.acquireConnection = async () =>
+      ({
+        executeQuery: async (compiledQuery: CompiledQuery) => {
+          compiledQueries.push(compiledQuery)
+          return { rows: [] }
+        },
+        streamQuery: async function* () {},
+      }) as DatabaseConnection
+
+    const db = new Kysely<DB>({
+      dialect: {
+        createAdapter: () => new SqliteAdapter(),
+        createDriver: () => driver,
+        createIntrospector: (database) => new SqliteIntrospector(database),
+        createQueryCompiler: () => new SqliteQueryCompiler(),
+      },
+    })
+
+    try {
+      const handler = getD1Handler("/photo_diodes/list")
+      expect(handler).not.toBeNull()
+
+      await handler!(db, { wavelength_min: "850" })
+
+      const partsQuery = compiledQueries.find((query) =>
+        query.sql.startsWith('SELECT * FROM "photo_diode"'),
+      )
+      expect(partsQuery?.sql).toContain('"peak_wavelength_nm" >= ?')
+      expect(partsQuery?.parameters).toEqual([850])
+    } finally {
+      await db.destroy()
+    }
+  })
+})

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -46,20 +46,21 @@ describe("render helpers", () => {
       },
       {
         package: "SMD-4P,2.7x3.2mm",
-        peak_wavelength_nm: "940",
+        wavelength_min: "850",
         reverse_voltage_min: "20",
         dark_current_max: "0.00000001",
       },
-      "https://jlcsearch.tscircuit.com/photo_diodes/list?package=SMD-4P%2C2.7x3.2mm&peak_wavelength_nm=940",
+      "https://jlcsearch.tscircuit.com/photo_diodes/list?package=SMD-4P%2C2.7x3.2mm&wavelength_min=850",
       {
         package: ["SMD-4P,2.7x3.2mm", "Plugin"],
-        peak_wavelength_nm: ["850", "940"],
+        wavelength_min: ["850", "940"],
       },
     )
 
     expect(html).toContain("<h2>Photo Diodes</h2>")
     expect(html).toContain('name="package"')
-    expect(html).toContain('name="peak_wavelength_nm"')
+    expect(html).toContain('name="wavelength_min"')
+    expect(html).toContain("Min Wavelength")
     expect(html).toContain('name="reverse_voltage_min"')
     expect(html).toContain('name="dark_current_max"')
     expect(html).toContain('name="is_basic"')


### PR DESCRIPTION
## Summary

- replace the exact peak-wavelength filter with a `wavelength_min` threshold
- query photodiodes using `peak_wavelength_nm >= wavelength_min`
- label the page input **Min Wavelength** and add route-level SQL coverage

## Why

The original Photo Diodes page only allowed an exact peak-wavelength match. Users need to find every photodiode at or above a requested wavelength.

## Validation

- `bun test` — 180 passed
- `bunx tsc --noEmit`
- `bunx tsc --noEmit --project cf-proxy/tsconfig.json`
- `bun run format:check`
- `bunx vitest run test/photo-diode-route.test.ts test/render.test.ts` — 13 passed