### PR TITLE
Filter Photo Diodes by detection range

### DIFF
--- a/cf-proxy/src/handlers/index.ts
+++ b/cf-proxy/src/handlers/index.ts
@@ -5,8 +5,15 @@ export type QueryParams = Record<string, string>
 
 interface FilterConfig {
   field: string
-  type: "string" | "number" | "boolean" | "number_tolerance"
+  type:
+    | "string"
+    | "number"
+    | "boolean"
+    | "number_tolerance"
+    | "number_range_contains"
   operator?: "=" | ">=" | "<=" | ">" | "<"
+  maxField?: string
+  fallbackField?: string
 }
 
 interface TableConfig {
@@ -59,7 +66,7 @@ export async function queryTable(
     const value = params[paramName]
     if (value === undefined || value === "" || value === "All") continue
 
-    const { field, type, operator = "=" } = fieldConfig
+    const { field, type, operator = "=", maxField, fallbackField } = fieldConfig
 
     // Validate operator
     if (!ALLOWED_OPERATORS.has(operator)) {
@@ -103,6 +110,29 @@ export async function queryTable(
         conditions.push(sql`${column} >= ${numValue - delta}`)
         conditions.push(sql`${column} <= ${numValue + delta}`)
       }
+    } else if (type === "number_range_contains") {
+      const numValue = parseFloat(value)
+      if (!isNaN(numValue)) {
+        if (!maxField) {
+          throw new Error(`Missing maxField for range filter: ${paramName}`)
+        }
+
+        const maxColumn = sql.id(maxField)
+        if (fallbackField) {
+          const fallbackColumn = sql.id(fallbackField)
+          conditions.push(sql`(
+            (${column} IS NOT NULL AND ${maxColumn} IS NOT NULL
+              AND ${column} <= ${numValue} AND ${maxColumn} >= ${numValue})
+            OR
+            ((${column} IS NULL OR ${maxColumn} IS NULL)
+              AND ${fallbackColumn} = ${numValue})
+          )`)
+        } else {
+          conditions.push(
+            sql`${column} <= ${numValue} AND ${maxColumn} >= ${numValue}`,
+          )
+        }
+      }
     }
   }
 
@@ -130,7 +160,11 @@ export async function queryFilterOptions(
   const options: FilterOptions = {}
 
   for (const [paramName, fieldConfig] of Object.entries(config.filters)) {
-    if (fieldConfig.type === "boolean") continue
+    if (
+      fieldConfig.type === "boolean" ||
+      fieldConfig.type === "number_range_contains"
+    )
+      continue
 
     const field = sql.id(fieldConfig.field)
     const table = sql.id(tableName)
@@ -210,9 +244,10 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     filters: {
       package: { field: "package", type: "string" },
       wavelength_min: {
-        field: "peak_wavelength_nm",
-        type: "number",
-        operator: ">=",
+        field: "spectral_range_min_nm",
+        maxField: "spectral_range_max_nm",
+        fallbackField: "peak_wavelength_nm",
+        type: "number_range_contains",
       },
       reverse_voltage_min: {
         field: "reverse_voltage",

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -167,7 +167,7 @@ const COLUMN_LABELS: Record<string, string> = {
   current_rating_amp: "Current",
   voltage_rating_volt: "Voltage",
   wavelength_nm: "Wavelength",
-  wavelength_min: "Min Wavelength",
+  wavelength_min: "Desired Wavelength",
   peak_wavelength_nm: "Peak Wavelength",
   spectral_range_min_nm: "Spectral Range Min",
   spectral_range_max_nm: "Spectral Range Max",
@@ -639,8 +639,11 @@ const renderGenericFilters = (
       if (fieldConfig.type === "boolean") {
         return `<div><label>${escapeHtml(label)}:</label><select name="${escapeHtml(paramName)}"><option value="">All</option><option value="true"${params[paramName] === "true" ? " selected" : ""}>Yes</option><option value="false"${params[paramName] === "false" ? " selected" : ""}>No</option></select></div>`
       }
-      const inputType = fieldConfig.type === "number" ? "number" : "text"
-      const step = fieldConfig.type === "number" ? ' step="any"' : ""
+      const isNumberFilter =
+        fieldConfig.type === "number" ||
+        fieldConfig.type === "number_range_contains"
+      const inputType = isNumberFilter ? "number" : "text"
+      const step = isNumberFilter ? ' step="any"' : ""
       const listId =
         mergedSuggestions.length > 0
           ? `${pathname.replaceAll("/", "-")}-${paramName}-options`

--- a/cf-proxy/test/photo-diode-route.test.ts
+++ b/cf-proxy/test/photo-diode-route.test.ts
@@ -12,7 +12,7 @@ import { getD1Handler } from "../src/d1-routes"
 import type { DB } from "../src/db/types"
 
 describe("Photo Diodes route", () => {
-  it("filters peak wavelength using a minimum threshold", async () => {
+  it("filters by whether the desired wavelength is in the detection range", async () => {
     const compiledQueries: CompiledQuery[] = []
     const driver = new DummyDriver()
 
@@ -38,13 +38,17 @@ describe("Photo Diodes route", () => {
       const handler = getD1Handler("/photo_diodes/list")
       expect(handler).not.toBeNull()
 
-      await handler!(db, { wavelength_min: "850" })
+      await handler!(db, { wavelength_min: "300" })
 
       const partsQuery = compiledQueries.find((query) =>
         query.sql.startsWith('SELECT * FROM "photo_diode"'),
       )
-      expect(partsQuery?.sql).toContain('"peak_wavelength_nm" >= ?')
-      expect(partsQuery?.parameters).toEqual([850])
+      expect(partsQuery?.sql).toContain('"spectral_range_min_nm" IS NOT NULL')
+      expect(partsQuery?.sql).toContain('"spectral_range_max_nm" IS NOT NULL')
+      expect(partsQuery?.sql).toContain('"spectral_range_min_nm" <= ?')
+      expect(partsQuery?.sql).toContain('"spectral_range_max_nm" >= ?')
+      expect(partsQuery?.sql).toContain('"peak_wavelength_nm" = ?')
+      expect(partsQuery?.parameters).toEqual([300, 300, 300])
     } finally {
       await db.destroy()
     }

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -53,14 +53,13 @@ describe("render helpers", () => {
       "https://jlcsearch.tscircuit.com/photo_diodes/list?package=SMD-4P%2C2.7x3.2mm&wavelength_min=850",
       {
         package: ["SMD-4P,2.7x3.2mm", "Plugin"],
-        wavelength_min: ["850", "940"],
       },
     )
 
     expect(html).toContain("<h2>Photo Diodes</h2>")
     expect(html).toContain('name="package"')
     expect(html).toContain('name="wavelength_min"')
-    expect(html).toContain("Min Wavelength")
+    expect(html).toContain("Desired Wavelength")
     expect(html).toContain('name="reverse_voltage_min"')
     expect(html).toContain('name="dark_current_max"')
     expect(html).toContain('name="is_basic"')

--- a/tests/lib/photo-diode-route-filter.test.ts
+++ b/tests/lib/photo-diode-route-filter.test.ts
@@ -1,0 +1,54 @@
+import { Database } from "bun:sqlite"
+import { expect, test } from "bun:test"
+import { Kysely } from "kysely"
+import { BunSqliteDialect } from "kysely-bun-sqlite"
+import { getD1Handler } from "../../cf-proxy/src/d1-routes"
+
+test("photo diode wavelength filter matches detection ranges", async () => {
+  const database = new Database(":memory:")
+  database.exec(`
+    CREATE TABLE photo_diode (
+      lcsc INTEGER PRIMARY KEY,
+      mfr TEXT,
+      stock INTEGER,
+      package TEXT,
+      peak_wavelength_nm REAL,
+      spectral_range_min_nm REAL,
+      spectral_range_max_nm REAL,
+      reverse_voltage REAL,
+      dark_current_a REAL,
+      is_basic BOOLEAN,
+      is_preferred BOOLEAN
+    );
+
+    INSERT INTO photo_diode (
+      lcsc, mfr, stock, package, peak_wavelength_nm,
+      spectral_range_min_nm, spectral_range_max_nm,
+      reverse_voltage, dark_current_a, is_basic, is_preferred
+    ) VALUES
+      (1, 'IR_ONLY', 400, 'SMD', 940, 840, 1100, 20, 1e-9, 0, 0),
+      (2, 'UV_TO_IR', 300, 'SMD', 940, 300, 1100, 20, 1e-9, 0, 0),
+      (3, 'PEAK_300_ONLY', 200, 'SMD', 300, NULL, NULL, 20, 1e-9, 0, 0),
+      (4, 'UNKNOWN_RANGE', 100, 'SMD', 940, NULL, NULL, 20, 1e-9, 0, 0);
+  `)
+
+  const db = new Kysely<any>({
+    dialect: new BunSqliteDialect({ database }),
+  })
+
+  try {
+    const handler = getD1Handler("/photo_diodes/list")
+    expect(handler).not.toBeNull()
+
+    const result = await handler!(db as any, { wavelength_min: "300" })
+    const rows = result.data.photo_diodes as Array<{
+      lcsc: number
+      mfr: string
+    }>
+
+    expect(rows.map((row) => row.lcsc)).toEqual([2, 3])
+    expect(rows.map((row) => row.mfr)).toEqual(["UV_TO_IR", "PEAK_300_ONLY"])
+  } finally {
+    await db.destroy()
+  }
+})


### PR DESCRIPTION
## Summary

- make the existing `wavelength_min` parameter represent a desired wavelength
- match photodiodes whose published spectral range contains that wavelength
- fall back to an exact peak-wavelength match only when a part has no complete spectral range
- relabel the UI field from **Min Wavelength** to **Desired Wavelength**

## Root cause

The previous filter compared the requested value only to `peak_wavelength_nm` using `>=`. A request for 300 nm therefore returned IR-only parts with 940 nm peaks and 840–1100 nm detection ranges.

The new predicate is:

```text
spectral_range_min_nm <= desired_wavelength <= spectral_range_max_nm
```

For incomplete range data, `peak_wavelength_nm = desired_wavelength` is used as a conservative fallback.

## Validation

- `bun test` — 181 passed
- `bunx tsc --noEmit`
- `bunx tsc --noEmit --project cf-proxy/tsconfig.json`
- `bun run format:check`
- integration coverage verifies that 840–1100 nm is excluded for 300 nm, while 300–1100 nm is included