### PR TITLE
Add photodiode spectral selectivity filters

### DIFF
--- a/cf-proxy/src/handlers/index.ts
+++ b/cf-proxy/src/handlers/index.ts
@@ -11,20 +11,49 @@ interface FilterConfig {
     | "boolean"
     | "number_tolerance"
     | "number_range_contains"
+    | "number_distance_from_param"
+    | "number_excludes_ranges"
   operator?: "=" | ">=" | "<=" | ">" | "<"
   maxField?: string
   fallbackField?: string
+  relativeToParam?: string
+  placeholder?: string
+  helpText?: string
 }
 
 interface TableConfig {
   filters: Record<string, FilterConfig>
   paramAliases?: Record<string, string>
+  targetSort?: {
+    field: string
+    param: string
+  }
+  helpText?: string
 }
 
 export type FilterOptions = Record<string, string[]>
 
 // Allowed operators for sanitization
 const ALLOWED_OPERATORS = new Set(["=", ">=", "<=", ">", "<"])
+
+const parseNumberRanges = (value: string): Array<[number, number]> =>
+  value
+    .split(",")
+    .map((range) => range.trim())
+    .filter(Boolean)
+    .flatMap((range): Array<[number, number]> => {
+      const rangeMatch = range.match(
+        /^(\d+(?:\.\d+)?)\s*(?:-|–|—|\.\.)\s*(\d+(?:\.\d+)?)$/,
+      )
+      if (rangeMatch) {
+        const first = Number(rangeMatch[1])
+        const second = Number(rangeMatch[2])
+        return [[Math.min(first, second), Math.max(first, second)]]
+      }
+
+      const singleValue = Number(range)
+      return Number.isFinite(singleValue) ? [[singleValue, singleValue]] : []
+    })
 
 const isBooleanLikeField = (field: string): boolean =>
   field === "in_stock" ||
@@ -67,7 +96,14 @@ export async function queryTable(
     const value = params[paramName]
     if (value === undefined || value === "" || value === "All") continue
 
-    const { field, type, operator = "=", maxField, fallbackField } = fieldConfig
+    const {
+      field,
+      type,
+      operator = "=",
+      maxField,
+      fallbackField,
+      relativeToParam,
+    } = fieldConfig
 
     // Validate operator
     if (!ALLOWED_OPERATORS.has(operator)) {
@@ -134,19 +170,46 @@ export async function queryTable(
           )
         }
       }
+    } else if (type === "number_distance_from_param") {
+      const maxDistance = parseFloat(value)
+      const relativeValue = relativeToParam
+        ? parseFloat(params[relativeToParam] ?? "")
+        : Number.NaN
+      if (
+        Number.isFinite(maxDistance) &&
+        maxDistance >= 0 &&
+        Number.isFinite(relativeValue)
+      ) {
+        conditions.push(sql`${column} IS NOT NULL`)
+        conditions.push(sql`${column} >= ${relativeValue - maxDistance}`)
+        conditions.push(sql`${column} <= ${relativeValue + maxDistance}`)
+      }
+    } else if (type === "number_excludes_ranges") {
+      for (const [rangeMin, rangeMax] of parseNumberRanges(value)) {
+        conditions.push(
+          sql`${column} IS NOT NULL AND (${column} < ${rangeMin} OR ${column} > ${rangeMax})`,
+        )
+      }
     }
   }
 
   // Build the final query
   const table = sql.id(tableName)
+  const targetSortValue = config.targetSort
+    ? parseFloat(params[config.targetSort.param] ?? "")
+    : Number.NaN
+  const orderBy =
+    config.targetSort && Number.isFinite(targetSortValue)
+      ? sql`${sql.id(config.targetSort.field)} IS NULL ASC, ABS(${sql.id(config.targetSort.field)} - ${targetSortValue}) ASC, stock DESC`
+      : sql`stock DESC`
   let query: RawBuilder<unknown>
 
   if (conditions.length === 0) {
-    query = sql`SELECT * FROM ${table} ORDER BY stock DESC LIMIT 100`
+    query = sql`SELECT * FROM ${table} ORDER BY ${orderBy} LIMIT 100`
   } else {
     // Join conditions with AND
     const whereClause = sql.join(conditions, sql` AND `)
-    query = sql`SELECT * FROM ${table} WHERE ${whereClause} ORDER BY stock DESC LIMIT 100`
+    query = sql`SELECT * FROM ${table} WHERE ${whereClause} ORDER BY ${orderBy} LIMIT 100`
   }
 
   const result = await query.execute(db)
@@ -163,7 +226,9 @@ export async function queryFilterOptions(
   for (const [paramName, fieldConfig] of Object.entries(config.filters)) {
     if (
       fieldConfig.type === "boolean" ||
-      fieldConfig.type === "number_range_contains"
+      fieldConfig.type === "number_range_contains" ||
+      fieldConfig.type === "number_distance_from_param" ||
+      fieldConfig.type === "number_excludes_ranges"
     )
       continue
 
@@ -243,6 +308,9 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
   },
   photo_diode: {
     paramAliases: { wavelength_min: "wavelength" },
+    targetSort: { field: "peak_wavelength_nm", param: "wavelength" },
+    helpText:
+      "These filters use catalog peak wavelength and advertised spectral range, not a full responsivity curve. Verify the datasheet; optical filtering may be needed for out-of-band rejection.",
     filters: {
       package: { field: "package", type: "string" },
       wavelength: {
@@ -250,6 +318,24 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
         maxField: "spectral_range_max_nm",
         fallbackField: "peak_wavelength_nm",
         type: "number_range_contains",
+        placeholder: "355",
+        helpText:
+          "Must be inside the published spectral range. Results are ranked by closeness to peak response.",
+      },
+      peak_distance_max: {
+        field: "peak_wavelength_nm",
+        type: "number_distance_from_param",
+        relativeToParam: "wavelength",
+        placeholder: "100",
+        helpText:
+          "Optional maximum distance between the target and peak wavelengths.",
+      },
+      excluded_peak_bands: {
+        field: "peak_wavelength_nm",
+        type: "number_excludes_ranges",
+        placeholder: "700-1100, 532",
+        helpText:
+          "Comma-separated wavelengths or ranges whose peak response should be excluded.",
       },
       reverse_voltage_min: {
         field: "reverse_voltage",

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -168,7 +168,9 @@ const COLUMN_LABELS: Record<string, string> = {
   current_rating_amp: "Current",
   voltage_rating_volt: "Voltage",
   wavelength_nm: "Wavelength",
-  wavelength: "Desired Wavelength",
+  wavelength: "Target Wavelength (nm)",
+  peak_distance_max: "Max Distance from Peak (nm)",
+  excluded_peak_bands: "Excluded Peak Bands (nm)",
   peak_wavelength_nm: "Peak Wavelength",
   spectral_range_min_nm: "Spectral Range Min",
   spectral_range_max_nm: "Spectral Range Max",
@@ -643,18 +645,28 @@ const renderGenericFilters = (
       }
       const isNumberFilter =
         fieldConfig.type === "number" ||
-        fieldConfig.type === "number_range_contains"
+        fieldConfig.type === "number_range_contains" ||
+        fieldConfig.type === "number_distance_from_param"
       const inputType = isNumberFilter ? "number" : "text"
       const step = isNumberFilter ? ' step="any"' : ""
+      const placeholder = fieldConfig.placeholder
+        ? ` placeholder="${escapeHtml(fieldConfig.placeholder)}"`
+        : ""
+      const helpText = fieldConfig.helpText
+        ? `<small class="block text-gray-600">${escapeHtml(fieldConfig.helpText)}</small>`
+        : ""
       const listId =
         mergedSuggestions.length > 0
           ? `${pathname.replaceAll("/", "-")}-${paramName}-options`
           : ""
-      return `<div><label>${escapeHtml(label)}:</label><input type="${inputType}" name="${escapeHtml(paramName)}" value="${escapeHtml(normalizedParams[paramName] ?? "")}"${step}${listId ? ` list="${escapeHtml(listId)}"` : ""} autocomplete="on" />${renderFilterSuggestions(pathname, paramName, mergedSuggestions)}</div>`
+      return `<div><label>${escapeHtml(label)}:</label><input type="${inputType}" name="${escapeHtml(paramName)}" value="${escapeHtml(normalizedParams[paramName] ?? "")}"${step}${placeholder}${listId ? ` list="${escapeHtml(listId)}"` : ""} autocomplete="on" />${helpText}${renderFilterSuggestions(pathname, paramName, mergedSuggestions)}</div>`
     })
     .join("")
 
-  return `<form method="GET" class="flex flex-row gap-4">${inputs}<button type="submit">Filter</button></form>`
+  const helpText = config.helpText
+    ? `<p class="mt-2 text-sm text-gray-600">${escapeHtml(config.helpText)}</p>`
+    : ""
+  return `<form method="GET" class="flex flex-row gap-4">${inputs}<button type="submit">Filter</button></form>${helpText}`
 }
 
 const renderComponentsFilters = (

--- a/cf-proxy/test/photo-diode-route.test.ts
+++ b/cf-proxy/test/photo-diode-route.test.ts
@@ -48,7 +48,8 @@ describe("Photo Diodes route", () => {
       expect(partsQuery?.sql).toContain('"spectral_range_min_nm" <= ?')
       expect(partsQuery?.sql).toContain('"spectral_range_max_nm" >= ?')
       expect(partsQuery?.sql).toContain('"peak_wavelength_nm" = ?')
-      expect(partsQuery?.parameters).toEqual([300, 300, 300])
+      expect(partsQuery?.sql).toContain('ABS("peak_wavelength_nm" - ?) ASC')
+      expect(partsQuery?.parameters).toEqual([300, 300, 300, 300])
 
       compiledQueries.length = 0
       await handler!(db, { wavelength_min: "300" })
@@ -56,7 +57,24 @@ describe("Photo Diodes route", () => {
         query.sql.startsWith('SELECT * FROM "photo_diode"'),
       )
       expect(legacyPartsQuery?.sql).toBe(partsQuery?.sql)
-      expect(legacyPartsQuery?.parameters).toEqual([300, 300, 300])
+      expect(legacyPartsQuery?.parameters).toEqual([300, 300, 300, 300])
+
+      compiledQueries.length = 0
+      await handler!(db, {
+        wavelength: "355",
+        peak_distance_max: "100",
+        excluded_peak_bands: "700-1100, 532",
+      })
+      const bandFilteredQuery = compiledQueries.find((query) =>
+        query.sql.startsWith('SELECT * FROM "photo_diode"'),
+      )
+      expect(bandFilteredQuery?.sql).toContain('"peak_wavelength_nm" >= ?')
+      expect(bandFilteredQuery?.sql).toContain(
+        '("peak_wavelength_nm" < ? OR "peak_wavelength_nm" > ?)',
+      )
+      expect(bandFilteredQuery?.parameters).toEqual([
+        355, 355, 355, 255, 455, 700, 1100, 532, 532, 355,
+      ])
     } finally {
       await db.destroy()
     }

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -47,6 +47,8 @@ describe("render helpers", () => {
       {
         package: "SMD-4P,2.7x3.2mm",
         wavelength: "850",
+        peak_distance_max: "100",
+        excluded_peak_bands: "900-1100",
         reverse_voltage_min: "20",
         dark_current_max: "0.00000001",
       },
@@ -60,7 +62,13 @@ describe("render helpers", () => {
     expect(html).toContain('name="package"')
     expect(html).toContain('name="wavelength"')
     expect(html).not.toContain('name="wavelength_min"')
-    expect(html).toContain("Desired Wavelength")
+    expect(html).toContain("Target Wavelength (nm)")
+    expect(html).toContain('name="peak_distance_max"')
+    expect(html).toContain("Max Distance from Peak (nm)")
+    expect(html).toContain('name="excluded_peak_bands"')
+    expect(html).toContain("Excluded Peak Bands (nm)")
+    expect(html).toContain("700-1100, 532")
+    expect(html).toContain("optical filtering may be needed")
     expect(html).toContain('name="reverse_voltage_min"')
     expect(html).toContain('name="dark_current_max"')
     expect(html).toContain('name="is_basic"')

--- a/tests/lib/photo-diode-route-filter.test.ts
+++ b/tests/lib/photo-diode-route-filter.test.ts
@@ -29,7 +29,9 @@ test("photo diode wavelength filter matches detection ranges", async () => {
       (1, 'IR_ONLY', 400, 'SMD', 940, 840, 1100, 20, 1e-9, 0, 0),
       (2, 'UV_TO_IR', 300, 'SMD', 940, 300, 1100, 20, 1e-9, 0, 0),
       (3, 'PEAK_300_ONLY', 200, 'SMD', 300, NULL, NULL, 20, 1e-9, 0, 0),
-      (4, 'UNKNOWN_RANGE', 100, 'SMD', 940, NULL, NULL, 20, 1e-9, 0, 0);
+      (4, 'UNKNOWN_RANGE', 100, 'SMD', 940, NULL, NULL, 20, 1e-9, 0, 0),
+      (5, 'UV_PEAK', 50, 'SMD', 360, 300, 400, 20, 1e-9, 0, 0),
+      (6, 'BLUE_PEAK', 40, 'SMD', 420, 300, 950, 20, 1e-9, 0, 0);
   `)
 
   const db = new Kysely<any>({
@@ -46,14 +48,29 @@ test("photo diode wavelength filter matches detection ranges", async () => {
       mfr: string
     }>
 
-    expect(rows.map((row) => row.lcsc)).toEqual([2, 3])
-    expect(rows.map((row) => row.mfr)).toEqual(["UV_TO_IR", "PEAK_300_ONLY"])
+    expect(rows.map((row) => row.lcsc)).toEqual([3, 5, 6, 2])
+    expect(rows.map((row) => row.mfr)).toEqual([
+      "PEAK_300_ONLY",
+      "UV_PEAK",
+      "BLUE_PEAK",
+      "UV_TO_IR",
+    ])
+
+    const selectiveResult = await handler!(db as any, {
+      wavelength: "355",
+      peak_distance_max: "100",
+      excluded_peak_bands: "400-500, 700-1100",
+    })
+    const selectiveRows = selectiveResult.data.photo_diodes as Array<{
+      lcsc: number
+    }>
+    expect(selectiveRows.map((row) => row.lcsc)).toEqual([5])
 
     const legacyResult = await handler!(db as any, {
       wavelength_min: "300",
     })
     const legacyRows = legacyResult.data.photo_diodes as Array<{ lcsc: number }>
-    expect(legacyRows.map((row) => row.lcsc)).toEqual([2, 3])
+    expect(legacyRows.map((row) => row.lcsc)).toEqual([3, 5, 6, 2])
   } finally {
     await db.destroy()
   }


### PR DESCRIPTION
## Summary

- rank target-wavelength matches by distance from their peak wavelength, then by stock
- add `peak_distance_max` to keep the target near a device's peak response
- add `excluded_peak_bands` for comma-separated peak wavelengths or ranges such as `700-1100, 532`
- add field guidance and explain that catalog metadata is not a full spectral-responsivity curve

Example for a 355 nm search that rejects IR-peaking devices:

```text
/photo_diodes/list?wavelength=355&peak_distance_max=100&excluded_peak_bands=700-1100
```

## Why

The catalog only exposes peak wavelength and advertised spectral-range endpoints. A range containing 355 nm does not mean the device responds strongly there, which caused 820–950 nm-peaking parts to dominate the results. Peak proximity is the most defensible available proxy for target sensitivity, while excluded peak bands let users remove parts optimized for unwanted regions without pretending the catalog contains full responsivity curves.

This builds on #433, which renamed the canonical target parameter to `wavelength`.

## Validation

- `bun test` — 181 passed
- `bunx tsc --noEmit`
- `bunx tsc --noEmit --project cf-proxy/tsconfig.json`
- `bun run format:check`
