### PR TITLE
Fix stale deployment caches

### DIFF
--- a/cf-proxy/src/cache-entry.ts
+++ b/cf-proxy/src/cache-entry.ts
@@ -16,27 +16,23 @@ export interface CacheEntry {
 }
 
 // Cache freshness thresholds in milliseconds
+const FIVE_MINUTES_MS = 5 * 60 * 1000
 const ONE_DAY_MS = 24 * 60 * 60 * 1000
-const TWO_WEEKS_MS = 14 * ONE_DAY_MS
-const ONE_MONTH_MS = 30 * ONE_DAY_MS
 
-export const CACHE_FRESH_SECONDS = 14 * 24 * 60 * 60
-export const CACHE_STALE_WHILE_REVALIDATE_SECONDS =
-  30 * 24 * 60 * 60 - CACHE_FRESH_SECONDS
+export const CACHE_STALE_IF_ERROR_SECONDS = 24 * 60 * 60
 
-// KV TTL in seconds (1 month)
-export const KV_TTL_SECONDS = 30 * 24 * 60 * 60
+// KV TTL in seconds (1 day)
+export const KV_TTL_SECONDS = 24 * 60 * 60
 
 export const CACHE_CONTROL_HEADER_VALUE = [
   "public",
-  `max-age=${CACHE_FRESH_SECONDS}`,
-  `s-maxage=${CACHE_FRESH_SECONDS}`,
-  `stale-while-revalidate=${CACHE_STALE_WHILE_REVALIDATE_SECONDS}`,
-  `stale-if-error=${CACHE_STALE_WHILE_REVALIDATE_SECONDS}`,
+  "max-age=0",
+  "must-revalidate",
+  `stale-if-error=${CACHE_STALE_IF_ERROR_SECONDS}`,
 ].join(", ")
 
 /**
- * Checks if a cached entry is fresh (less than 2 weeks old).
+ * Checks if a cached entry is fresh (less than 5 minutes old).
  */
 export function isFresh(
   metadata: CacheMetadata,
@@ -44,11 +40,11 @@ export function isFresh(
 ): boolean {
   const cachedAt = new Date(metadata.cachedAt)
   const age = now.getTime() - cachedAt.getTime()
-  return age < TWO_WEEKS_MS
+  return age < FIVE_MINUTES_MS
 }
 
 /**
- * Checks if a cached entry is usable as stale (less than 1 month old).
+ * Checks if a cached entry is usable as stale (less than 1 day old).
  */
 export function isUsableStale(
   metadata: CacheMetadata,
@@ -56,7 +52,7 @@ export function isUsableStale(
 ): boolean {
   const cachedAt = new Date(metadata.cachedAt)
   const age = now.getTime() - cachedAt.getTime()
-  return age < ONE_MONTH_MS
+  return age < ONE_DAY_MS
 }
 
 /**

--- a/cf-proxy/src/cache-key.ts
+++ b/cf-proxy/src/cache-key.ts
@@ -3,10 +3,15 @@ const CACHE_CONTROL_QUERY_PARAMS = new Set(["cachebust"])
 /**
  * Generates a cache key from a URL by hashing the normalized path and sorted query params.
  */
-export async function generateCacheKey(url: URL): Promise<string> {
+export async function generateCacheKey(
+  url: URL,
+  namespace = "",
+): Promise<string> {
   const normalized = normalizeUrl(url)
   const encoder = new TextEncoder()
-  const data = encoder.encode(normalized)
+  const data = encoder.encode(
+    namespace ? `${namespace}:${normalized}` : normalized,
+  )
   const hashBuffer = await crypto.subtle.digest("SHA-256", data)
   const hashArray = Array.from(new Uint8Array(hashBuffer))
   return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("")

--- a/cf-proxy/src/cache-service.ts
+++ b/cf-proxy/src/cache-service.ts
@@ -18,13 +18,16 @@ export type CacheResult =
  * Service for caching responses in KV store.
  */
 export class CacheService {
-  constructor(private kv: KVNamespace) {}
+  constructor(
+    private kv: KVNamespace,
+    private namespace = "",
+  ) {}
 
   /**
    * Gets a cached response, indicating whether it's fresh, stale, or a miss.
    */
   async get(url: URL): Promise<CacheResult> {
-    const key = await generateCacheKey(url)
+    const key = await generateCacheKey(url, this.namespace)
     const result = await this.kv.getWithMetadata<CacheMetadata>(key, "text")
 
     if (!result.value || !result.metadata) {
@@ -51,7 +54,7 @@ export class CacheService {
    * Stores a response in the cache.
    */
   async put(url: URL, response: Response): Promise<CacheEntry> {
-    const key = await generateCacheKey(url)
+    const key = await generateCacheKey(url, this.namespace)
     const body = await response.text()
     const metadata = createMetadata(response)
 
@@ -67,7 +70,7 @@ export class CacheService {
    * Deletes a cached response if it exists.
    */
   async delete(url: URL): Promise<void> {
-    const key = await generateCacheKey(url)
+    const key = await generateCacheKey(url, this.namespace)
     await this.kv.delete(key)
   }
 
@@ -76,7 +79,7 @@ export class CacheService {
    */
   buildResponse(
     entry: CacheEntry,
-    cacheStatus: "HIT" | "MISS" | "STALE" | "BUST",
+    cacheStatus: "HIT" | "MISS" | "REFRESH" | "STALE" | "BUST",
     origin: string | null,
     options: {
       noStore?: boolean
@@ -90,6 +93,9 @@ export class CacheService {
     )
     headers.set("x-cache", cacheStatus)
     headers.set("x-cached-at", entry.metadata.cachedAt)
+    if (this.namespace) {
+      headers.set("x-cache-version", this.namespace)
+    }
     if (options.cacheBust) {
       headers.set("x-cache-bust", "1")
     }

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -9,16 +9,13 @@ export interface Env {
   CACHE_KV: KVNamespace
   DB: D1Database
   USE_D1: string
+  VERSION: WorkerVersionMetadata
 }
 
 const CACHE_BUST_QUERY_PARAM = "cachebust"
-const HOME_PAGE_CACHE_MAX_AGE_SECONDS = 60 * 60
-const HOME_PAGE_CACHE_CONTROL = [
-  "public",
-  `max-age=${HOME_PAGE_CACHE_MAX_AGE_SECONDS}`,
-  `s-maxage=${HOME_PAGE_CACHE_MAX_AGE_SECONDS}`,
-  "must-revalidate",
-].join(", ")
+const HOME_PAGE_CACHE_CONTROL = ["public", "max-age=0", "must-revalidate"].join(
+  ", ",
+)
 
 const extractSmallQuantityPrice = (price: string | null): string | number => {
   if (!price) return ""
@@ -168,7 +165,7 @@ export default {
   async fetch(
     request: Request,
     env: Env,
-    ctx: ExecutionContext,
+    _ctx: ExecutionContext,
   ): Promise<Response> {
     const requestUrl = new URL(request.url)
     const url = stripInternalQueryParams(requestUrl)
@@ -196,7 +193,7 @@ export default {
       )
     }
 
-    const cache = new CacheService(env.CACHE_KV)
+    const cache = new CacheService(env.CACHE_KV, env.VERSION.id)
 
     // Check if this is a JSON API request that can be handled by D1
     if (env.USE_D1 === "true") {
@@ -205,7 +202,6 @@ export default {
         request,
         env,
         origin,
-        ctx,
         cache,
         cacheBust,
       )
@@ -221,25 +217,9 @@ export default {
   },
 }
 
-async function refreshStaleD1Entry(
-  cacheUrl: URL,
-  producer: () => Promise<Response>,
-  cache: CacheService,
-): Promise<void> {
-  try {
-    const response = await producer()
-    if (response.ok) {
-      await cache.put(cacheUrl, response)
-    }
-  } catch (error) {
-    console.warn("Background D1 cache refresh failed:", error)
-  }
-}
-
 async function handleCachedD1Response(
   cacheUrl: URL,
   origin: string | null,
-  ctx: ExecutionContext,
   cache: CacheService,
   producer: () => Promise<Response>,
   options: {
@@ -269,7 +249,15 @@ async function handleCachedD1Response(
 
   const staleEntry = cacheResult.type === "stale" ? cacheResult.entry : null
   if (staleEntry) {
-    ctx.waitUntil(refreshStaleD1Entry(cacheUrl, producer, cache))
+    try {
+      const response = await producer()
+      if (response.ok) {
+        const entry = await cache.put(cacheUrl, response)
+        return cache.buildResponse(entry, "REFRESH", origin)
+      }
+    } catch (error) {
+      console.warn("D1 cache refresh failed:", error)
+    }
     return cache.buildResponse(staleEntry, "STALE", origin)
   }
 
@@ -291,7 +279,6 @@ async function tryD1Route(
   request: Request,
   env: Env,
   origin: string | null,
-  ctx: ExecutionContext,
   cache: CacheService,
   cacheBust = false,
 ): Promise<Response | null> {
@@ -314,7 +301,6 @@ async function tryD1Route(
     return handleCachedD1Response(
       url,
       origin,
-      ctx,
       cache,
       async () => handleD1Search(url, env, origin),
       { cacheBust },
@@ -325,7 +311,6 @@ async function tryD1Route(
     return handleCachedD1Response(
       getD1RepresentationCacheUrl(url, isJsonRequest),
       origin,
-      ctx,
       cache,
       async () => handleD1ComponentsList(url, isJsonRequest, env, origin),
       { cacheBust },
@@ -346,7 +331,6 @@ async function tryD1Route(
   return handleCachedD1Response(
     getD1RepresentationCacheUrl(url, isJsonRequest),
     origin,
-    ctx,
     cache,
     async () => handleD1TableRoute(pathname, url, isJsonRequest, env, origin),
     { cacheBust },

--- a/cf-proxy/test/cache-key.test.ts
+++ b/cf-proxy/test/cache-key.test.ts
@@ -60,6 +60,13 @@ describe("generateCacheKey", () => {
     expect(key1).not.toBe(key2)
   })
 
+  it("generates different hashes for different deployment namespaces", async () => {
+    const url = new URL("https://example.com/path")
+    const key1 = await generateCacheKey(url, "deployment-1")
+    const key2 = await generateCacheKey(url, "deployment-2")
+    expect(key1).not.toBe(key2)
+  })
+
   it("generates same hash regardless of query param order", async () => {
     const url1 = new URL("https://example.com/search?a=1&b=2")
     const url2 = new URL("https://example.com/search?b=2&a=1")

--- a/cf-proxy/test/cache-service.test.ts
+++ b/cf-proxy/test/cache-service.test.ts
@@ -9,20 +9,20 @@ import { CacheService } from "../src/cache-service"
 import { createTestEnv } from "./test-env"
 
 describe("isFresh", () => {
-  it("returns true for entries less than 2 weeks old", () => {
-    const now = new Date("2024-01-15T00:00:00Z")
+  it("returns true for entries less than 5 minutes old", () => {
+    const now = new Date("2024-01-03T12:04:00Z")
     const metadata: CacheMetadata = {
-      cachedAt: "2024-01-03T12:00:00Z", // 11.5 days ago
+      cachedAt: "2024-01-03T12:00:00Z",
       status: 200,
       headers: {},
     }
     expect(isFresh(metadata, now)).toBe(true)
   })
 
-  it("returns false for entries 2 weeks or older", () => {
-    const now = new Date("2024-01-18T00:00:00Z")
+  it("returns false for entries 5 minutes or older", () => {
+    const now = new Date("2024-01-03T12:05:00Z")
     const metadata: CacheMetadata = {
-      cachedAt: "2024-01-03T12:00:00Z", // 14.5 days ago
+      cachedAt: "2024-01-03T12:00:00Z",
       status: 200,
       headers: {},
     }
@@ -31,20 +31,20 @@ describe("isFresh", () => {
 })
 
 describe("isUsableStale", () => {
-  it("returns true for entries less than 1 month old", () => {
-    const now = new Date("2024-01-23T00:00:00Z")
+  it("returns true for entries less than 1 day old", () => {
+    const now = new Date("2024-01-03T12:00:00Z")
     const metadata: CacheMetadata = {
-      cachedAt: "2024-01-03T00:00:00Z", // 20 days ago
+      cachedAt: "2024-01-03T00:00:00Z",
       status: 200,
       headers: {},
     }
     expect(isUsableStale(metadata, now)).toBe(true)
   })
 
-  it("returns false for entries 1 month or older", () => {
-    const now = new Date("2024-02-03T00:00:00Z")
+  it("returns false for entries 1 day or older", () => {
+    const now = new Date("2024-01-04T00:00:00Z")
     const metadata: CacheMetadata = {
-      cachedAt: "2024-01-03T00:00:00Z", // 31 days ago
+      cachedAt: "2024-01-03T00:00:00Z",
       status: 200,
       headers: {},
     }
@@ -86,6 +86,18 @@ describe("CacheService", () => {
         )
       }
     })
+
+    it("isolates entries by deployment namespace", async () => {
+      const env = createTestEnv()
+      const oldDeploymentCache = new CacheService(env.CACHE_KV, "old")
+      const newDeploymentCache = new CacheService(env.CACHE_KV, "new")
+      const url = new URL("https://example.com/test")
+
+      await oldDeploymentCache.put(url, new Response("old response"))
+
+      expect((await oldDeploymentCache.get(url)).type).toBe("fresh")
+      expect((await newDeploymentCache.get(url)).type).toBe("miss")
+    })
   })
 
   describe("buildResponse", () => {
@@ -106,8 +118,30 @@ describe("CacheService", () => {
       expect(response.headers.get("cache-control")).toBe(
         CACHE_CONTROL_HEADER_VALUE,
       )
+      expect(response.headers.get("cache-control")).toContain("max-age=0")
+      expect(response.headers.get("cache-control")).not.toContain(
+        "stale-while-revalidate",
+      )
+      expect(response.headers.get("cache-control")).not.toContain("s-maxage")
       expect(response.headers.get("content-type")).toBe("text/plain")
       expect(response.status).toBe(200)
+    })
+
+    it("exposes the deployment cache namespace", () => {
+      const env = createTestEnv()
+      const versionedCache = new CacheService(env.CACHE_KV, "deployment-123")
+      const entry = {
+        body: "test body",
+        metadata: {
+          cachedAt: "2024-01-15T00:00:00Z",
+          status: 200,
+          headers: {},
+        },
+      }
+
+      const response = versionedCache.buildResponse(entry, "HIT", null)
+
+      expect(response.headers.get("x-cache-version")).toBe("deployment-123")
     })
 
     it("builds response with STALE header", () => {

--- a/cf-proxy/test/test-env.ts
+++ b/cf-proxy/test/test-env.ts
@@ -75,6 +75,11 @@ export const createTestEnv = () => ({
   CACHE_KV: new MemoryKV(),
   USE_D1: "false",
   DB: {} as D1Database,
+  VERSION: {
+    id: "test-worker-version",
+    tag: "",
+    timestamp: "2026-01-01T00:00:00.000Z",
+  } satisfies WorkerVersionMetadata,
 })
 
 export const createSelf = (env: ReturnType<typeof createTestEnv>) => ({

--- a/cf-proxy/test/worker.test.ts
+++ b/cf-proxy/test/worker.test.ts
@@ -5,6 +5,8 @@ import { createSelf, createTestEnv } from "./test-env"
 describe("Worker integration", () => {
   const env = createTestEnv()
   const SELF = createSelf(env)
+  const generateWorkerCacheKey = (url: URL) =>
+    generateCacheKey(url, env.VERSION.id)
 
   beforeEach(async () => {
     env.USE_D1 = "false"
@@ -81,7 +83,7 @@ describe("Worker integration", () => {
       "https://example.com/microcontrollers/list?package=QFN48",
     )
     url.searchParams.set("__format", "html")
-    const cacheKey = await generateCacheKey(url)
+    const cacheKey = await generateWorkerCacheKey(url)
 
     const metadata = {
       cachedAt: new Date().toISOString(),
@@ -114,7 +116,7 @@ describe("Worker integration", () => {
       "https://example.com/risc_v_processors/list?package=QFN48",
     )
     url.searchParams.set("__format", "html")
-    const cacheKey = await generateCacheKey(url)
+    const cacheKey = await generateWorkerCacheKey(url)
 
     await env.CACHE_KV.put(
       cacheKey,
@@ -144,12 +146,12 @@ describe("Worker integration", () => {
   it("serves stale cached D1 derived-table HTML when refresh fails", async () => {
     env.USE_D1 = "true"
 
-    const staleAt = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000)
+    const staleAt = new Date(Date.now() - 10 * 60 * 1000)
     const url = new URL(
       "https://example.com/microcontrollers/list?package=QFN48",
     )
     url.searchParams.set("__format", "html")
-    const cacheKey = await generateCacheKey(url)
+    const cacheKey = await generateWorkerCacheKey(url)
 
     await env.CACHE_KV.put(
       cacheKey,
@@ -183,7 +185,7 @@ describe("Worker integration", () => {
 
     const url = new URL("https://example.com/components/list?search=TYPEC")
     url.searchParams.set("__format", "html")
-    const cacheKey = await generateCacheKey(url)
+    const cacheKey = await generateWorkerCacheKey(url)
 
     const metadata = {
       cachedAt: new Date().toISOString(),
@@ -208,7 +210,7 @@ describe("Worker integration", () => {
 
     const url = new URL("https://example.com/components/list?search=TYPEC")
     url.searchParams.set("__format", "json")
-    const cacheKey = await generateCacheKey(url)
+    const cacheKey = await generateWorkerCacheKey(url)
 
     const metadata = {
       cachedAt: new Date().toISOString(),
@@ -229,11 +231,11 @@ describe("Worker integration", () => {
     expect(await response.text()).toBe(testBody)
   })
 
-  it("serves the homepage with one-hour caching without using KV", async () => {
+  it("serves the homepage without browser caching or KV", async () => {
     env.USE_D1 = "true"
 
     const url = new URL("https://example.com/")
-    const cacheKey = await generateCacheKey(url)
+    const cacheKey = await generateWorkerCacheKey(url)
     const staleBody = "<html><body>stale home page</body></html>"
 
     await env.CACHE_KV.put(cacheKey, staleBody, {
@@ -249,7 +251,7 @@ describe("Worker integration", () => {
 
     expect(response.headers.get("x-cache")).toBe("D1")
     expect(response.headers.get("cache-control")).toBe(
-      "public, max-age=3600, s-maxage=3600, must-revalidate",
+      "public, max-age=0, must-revalidate",
     )
     expect(body).not.toContain(staleBody)
     expect(body).toContain("JLCPCB In-Stock Parts Engine")
@@ -275,8 +277,8 @@ describe("Worker integration", () => {
     const url2 = new URL("https://example.com/components/list?search=other")
     url2.searchParams.set("__format", "json")
 
-    const cacheKey1 = await generateCacheKey(url1)
-    const cacheKey2 = await generateCacheKey(url2)
+    const cacheKey1 = await generateWorkerCacheKey(url1)
+    const cacheKey2 = await generateWorkerCacheKey(url2)
 
     await env.CACHE_KV.put(cacheKey1, '{"q":"test"}', {
       metadata: {

--- a/cf-proxy/wrangler.toml
+++ b/cf-proxy/wrangler.toml
@@ -10,6 +10,9 @@ routes = [
 [vars]
 USE_D1 = "true"  # Feature flag for gradual D1 rollout
 
+[version_metadata]
+binding = "VERSION"
+
 # KV namespace binding - run `wrangler kv:namespace create CACHE_KV` to create
 # Then update the id below with the generated ID
 [[kv_namespaces]]
@@ -30,6 +33,9 @@ routes = []
 
 [env.staging.vars]
 USE_D1 = "true"
+
+[env.staging.version_metadata]
+binding = "VERSION"
 
 [[env.staging.kv_namespaces]]
 binding = "CACHE_KV"


### PR DESCRIPTION
## Summary

- namespace KV cache keys by the Cloudflare Worker deployment ID so each deploy starts with logically fresh entries
- stop browsers and shared caches from retaining HTML/JSON responses; requests now revalidate through the Worker
- reduce internal KV freshness from 14 days to 5 minutes and retention from 30 days to 1 day
- synchronously refresh expired entries and return refreshed data; use stale data only when D1 refresh fails
- expose `x-cache-version` alongside the existing cache diagnostics

## Root cause

The Worker marked query results fresh for 14 days and sent the same two-week `max-age` to browsers. A deployed route or filtering change could therefore be hidden by both browser caching and an older KV response. The existing `cachebust=1` escape hatch worked, but users should not need it after every deployment.

## Live verification before this patch

The merged photodiode band filters are working in production:

```text
/photo_diodes/list.json?wavelength=355&peak_distance_max=100&excluded_peak_bands=700-1100
```

The live response returned nine 420 nm-peak devices, excluded the 700–1100 nm peak band, and reported `x-cache: MISS`; the same query with `cachebust=1` reported `x-cache: BUST`. Production also confirmed the problematic two-week cache-control header.

## Validation

- `bun test` — 184 passed
- `bunx tsc --noEmit`
- `bunx tsc --noEmit --project cf-proxy/tsconfig.json`
- `bun run format:check`
- `bunx wrangler deploy --dry-run --outdir /tmp/jlcsearch-cache-dry-run` — version metadata binding recognized
