### PR TITLE
Fix ARM processor flash and RAM unit parsing

### DIFF
--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -235,8 +235,12 @@ const withUnit = (value: unknown, unit: string): string => {
 const formatByteSize = (value: unknown): string => {
   const num = typeof value === "number" ? value : Number(value)
   if (!Number.isFinite(num)) return ""
-  if (num >= 1024 * 1024) return `${(num / (1024 * 1024)).toFixed(1)}MB`
-  if (num >= 1024) return `${(num / 1024).toFixed(1)}KB`
+  if (num >= 1024 * 1024) {
+    return `${(num / (1024 * 1024)).toFixed(1).replace(/\.0$/, "")}MB`
+  }
+  if (num >= 1024) {
+    return `${(num / 1024).toFixed(1).replace(/\.0$/, "")}KB`
+  }
   return `${num}B`
 }
 

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -139,6 +139,34 @@ describe("render helpers", () => {
     expect(html).toContain("/hdmi_ports/list.json")
   })
 
+  it("renders ARM processor memory sizes with byte units", () => {
+    const html = renderD1TablePage(
+      "/arm_processors/list",
+      {
+        arm_processors: [
+          {
+            lcsc: 8734,
+            mfr: "STM32F103C8T6",
+            package: "LQFP-48(7x7)",
+            cpu_core: "ARM-M3",
+            cpu_speed_hz: 72_000_000,
+            flash_size_bytes: 64 * 1024,
+            ram_size_bytes: 20 * 1024,
+            eeprom_size_bytes: 4,
+            gpio_count: 37,
+            stock: 214596,
+          },
+        ],
+      },
+      {},
+      "https://jlcsearch.tscircuit.com/arm_processors/list",
+    )
+
+    expect(html).toContain("64KB")
+    expect(html).toContain("20KB")
+    expect(html).toContain("4B")
+  })
+
   it.each([
     [
       "/dimm_connectors/list",

--- a/lib/util/parse-and-convert-si-unit.ts
+++ b/lib/util/parse-and-convert-si-unit.ts
@@ -113,6 +113,23 @@ const unitMappings: Record<
       mil: 0.0254,
     },
   },
+  B: {
+    baseUnit: "B",
+    variants: {
+      B: 1,
+      Byte: 1,
+      Bytes: 1,
+      KB: 1024,
+      KByte: 1024,
+      KBytes: 1024,
+      MB: 1024 * 1024,
+      MByte: 1024 * 1024,
+      MBytes: 1024 * 1024,
+      GB: 1024 * 1024 * 1024,
+      GByte: 1024 * 1024 * 1024,
+      GBytes: 1024 * 1024 * 1024,
+    },
+  },
 }
 
 function getBaseTscircuitUnit(unit: string): UnitInfo {
@@ -165,6 +182,7 @@ type BaseTscircuitUnit =
   | "Ω"
   | "F"
   | "H"
+  | "B"
 
 export const parseAndConvertSiUnit = <
   T extends

--- a/tests/lib/parse-and-convert-si-unit.test.ts
+++ b/tests/lib/parse-and-convert-si-unit.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+
+describe("parseAndConvertSiUnit byte values", () => {
+  test.each([
+    ["64Byte", 64],
+    ["64KB", 64 * 1024],
+    ["2.25KB", 2.25 * 1024],
+    ["1MB", 1024 * 1024],
+  ])("converts %s to bytes", (rawValue, expectedValue) => {
+    expect(parseAndConvertSiUnit(rawValue)).toEqual({
+      parsedUnit: rawValue.replace(/[\d.]/g, ""),
+      unitOfValue: "B",
+      value: expectedValue,
+    })
+  })
+})


### PR DESCRIPTION
Summary:
- Convert JLC memory attributes such as 64KB, 2.25KB, 1MB, and 64Byte into byte counts before storing derived microcontroller data.
- Render byte-backed memory values without misleading trailing .0 decimals.
- Add parser and ARM processor page rendering regression tests.

Tests:
- bun test tests
- bun test (cf-proxy)
- bunx tsc --noEmit
- bunx tsc --noEmit --project cf-proxy/tsconfig.json
- bun run format:check

Deployment note: after merge, rebuild and upload the microcontroller derived table and refresh /arm_processors/list.json so existing D1 rows are corrected.
