### PR TITLE
Add nightly full-catalog stock sync

### DIFF
--- a/.github/workflows/d1-migrations.yml
+++ b/.github/workflows/d1-migrations.yml
@@ -1,6 +1,9 @@
 name: Build and Sync D1
 
 on:
+  schedule:
+    # Runs after the upstream jlcparts 03:00 UTC refresh has completed.
+    - cron: "0 5 * * *"
   push:
     branches: [main]
     paths:
@@ -55,7 +58,7 @@ jobs:
     env:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      SYNC_SCOPE: ${{ inputs.sync_scope || 'derived' }}
+      SYNC_SCOPE: ${{ github.event_name == 'schedule' && 'full_catalog' || inputs.sync_scope || 'derived' }}
       DERIVED_TABLES_LIST: ${{ inputs.derived_tables || 'photo_diode' }}
       SMOKE_TEST_LCSC: ${{ inputs.smoke_test_lcsc || '7512' }}
 
@@ -213,6 +216,25 @@ jobs:
                 --command "SELECT COUNT(*) AS row_count FROM \"${table}\";"
             done
           fi
+
+      - name: Clear production API cache
+        if: env.SYNC_SCOPE == 'full_catalog'
+        working-directory: cf-proxy
+        shell: bash
+        run: |
+          cache_keys_file="${RUNNER_TEMP}/jlcsearch-cache-keys.json"
+          bunx wrangler kv key list --binding CACHE_KV > "${cache_keys_file}"
+
+          cache_key_count="$(jq 'length' "${cache_keys_file}")"
+          if [[ "${cache_key_count}" == "0" ]]; then
+            echo "Production API cache is already empty."
+            exit 0
+          fi
+
+          echo "Deleting ${cache_key_count} cached API responses."
+          bunx wrangler kv bulk delete "${cache_keys_file}" \
+            --binding CACHE_KV \
+            --force
 
       - name: Refresh and verify the production API cache
         env:

--- a/README.md
+++ b/README.md
@@ -64,11 +64,15 @@ worker. Use `cf-proxy/scripts/sync-db.sh` to rebuild and synchronize derived
 table data from a prepared local SQLite database.
 
 Production D1 data is populated by the **Build and Sync D1** GitHub Actions
-workflow. On relevant merges to `main`, it downloads the current upstream
-source-db-v2 database, builds and verifies a compact `db.sqlite3` containing
-the requested derived tables, applies D1 migrations, uploads those tables, and
-refreshes the affected production API cache. The workflow can also be run
-manually in `derived` or `full_catalog` mode. `derived` accepts a
+workflow. Every night at 05:00 UTC, after the upstream jlcparts refresh, it
+performs a `full_catalog` sync and clears the production response cache. API
+clients are instructed to revalidate within 24 hours so the nightly stock
+snapshot is not hidden by an older response. On relevant merges to `main`, it
+downloads the current upstream source-db-v2 database, builds and verifies a
+compact `db.sqlite3` containing the requested derived tables, applies D1
+migrations, uploads those tables, and refreshes the affected production API
+cache. The workflow can also be run manually in `derived` or `full_catalog`
+mode. `derived` accepts a
 comma-separated `derived_tables` input. `full_catalog` rebuilds and uploads the
 component catalog, search index, and FTS index from the current source-db-v2
 snapshot, and requires a numeric `smoke_test_lcsc` that must be present before

--- a/cf-proxy/src/cache-entry.ts
+++ b/cf-proxy/src/cache-entry.ts
@@ -20,19 +20,22 @@ const ONE_DAY_MS = 24 * 60 * 60 * 1000
 const TWO_WEEKS_MS = 14 * ONE_DAY_MS
 const ONE_MONTH_MS = 30 * ONE_DAY_MS
 
-export const CACHE_FRESH_SECONDS = 14 * 24 * 60 * 60
-export const CACHE_STALE_WHILE_REVALIDATE_SECONDS =
-  30 * 24 * 60 * 60 - CACHE_FRESH_SECONDS
+// Clients revalidate daily so a nightly stock sync is not hidden by an old
+// browser or intermediary cache. The longer KV lifetime below still protects
+// D1 from repeated queries between catalog syncs.
+export const CLIENT_CACHE_MAX_AGE_SECONDS = 24 * 60 * 60
+export const CLIENT_CACHE_STALE_WHILE_REVALIDATE_SECONDS = 60 * 60
+export const CLIENT_CACHE_STALE_IF_ERROR_SECONDS = 24 * 60 * 60
 
 // KV TTL in seconds (1 month)
 export const KV_TTL_SECONDS = 30 * 24 * 60 * 60
 
 export const CACHE_CONTROL_HEADER_VALUE = [
   "public",
-  `max-age=${CACHE_FRESH_SECONDS}`,
-  `s-maxage=${CACHE_FRESH_SECONDS}`,
-  `stale-while-revalidate=${CACHE_STALE_WHILE_REVALIDATE_SECONDS}`,
-  `stale-if-error=${CACHE_STALE_WHILE_REVALIDATE_SECONDS}`,
+  `max-age=${CLIENT_CACHE_MAX_AGE_SECONDS}`,
+  `s-maxage=${CLIENT_CACHE_MAX_AGE_SECONDS}`,
+  `stale-while-revalidate=${CLIENT_CACHE_STALE_WHILE_REVALIDATE_SECONDS}`,
+  `stale-if-error=${CLIENT_CACHE_STALE_IF_ERROR_SECONDS}`,
 ].join(", ")
 
 /**

--- a/cf-proxy/test/cache-service.test.ts
+++ b/cf-proxy/test/cache-service.test.ts
@@ -1,10 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest"
-import {
-  CACHE_CONTROL_HEADER_VALUE,
-  type CacheMetadata,
-  isFresh,
-  isUsableStale,
-} from "../src/cache-entry"
+import { type CacheMetadata, isFresh, isUsableStale } from "../src/cache-entry"
 import { CacheService } from "../src/cache-service"
 import { createTestEnv } from "./test-env"
 
@@ -104,7 +99,7 @@ describe("CacheService", () => {
       expect(response.headers.get("x-cache")).toBe("HIT")
       expect(response.headers.get("x-cached-at")).toBe("2024-01-15T00:00:00Z")
       expect(response.headers.get("cache-control")).toBe(
-        CACHE_CONTROL_HEADER_VALUE,
+        "public, max-age=86400, s-maxage=86400, stale-while-revalidate=3600, stale-if-error=86400",
       )
       expect(response.headers.get("content-type")).toBe("text/plain")
       expect(response.status).toBe(200)


### PR DESCRIPTION
## Summary

- run a full-catalog D1 sync nightly at 05:00 UTC, after the upstream 03:00 UTC jlcparts refresh
- clear cached API responses after successful full-catalog syncs so refreshed stock is served
- reduce client cache freshness from 14 days to 24 hours while retaining the longer internal KV lifetime
- document the nightly production-data workflow

## Verification

- bun run test: 141 tests passed
- bunx tsc --noEmit --project cf-proxy/tsconfig.json
- workflow YAML parses successfully
- Wrangler KV list command verified against local storage