### PR TITLE
Retry transient D1 sync failures

### DIFF
--- a/.github/workflows/d1-migrations.yml
+++ b/.github/workflows/d1-migrations.yml
@@ -12,7 +12,7 @@ on:
       - "package.json"
       - "bunfig.toml"
       - "cf-proxy/migrations/**"
-      - "cf-proxy/scripts/sync-db.sh"
+      - "cf-proxy/scripts/**"
       - "cf-proxy/wrangler.toml"
       - "cf-proxy/package.json"
       - "cf-proxy/bun.lock"
@@ -184,7 +184,7 @@ jobs:
 
       - name: Apply D1 migrations
         working-directory: cf-proxy
-        run: bunx wrangler d1 migrations apply jlcsearch --remote
+        run: bash scripts/retry-command.sh bunx wrangler d1 migrations apply jlcsearch --remote
 
       - name: Upload selected data to D1
         env:
@@ -194,25 +194,25 @@ jobs:
           SYNC_DERIVED_TABLES: ${{ env.SYNC_SCOPE == 'derived' && '1' || '0' }}
           SYNC_COMPONENT_CATALOG: ${{ env.SYNC_SCOPE == 'full_catalog' && '1' || '0' }}
           SYNC_SEARCH_INDEX: ${{ env.SYNC_SCOPE == 'full_catalog' && '1' || '0' }}
-        run: ./cf-proxy/scripts/sync-db.sh
+        run: bash ./cf-proxy/scripts/retry-command.sh ./cf-proxy/scripts/sync-db.sh
 
       - name: Verify migration status and remote row counts
         working-directory: cf-proxy
         run: |
-          bunx wrangler d1 migrations list jlcsearch --remote
+          bash scripts/retry-command.sh bunx wrangler d1 migrations list jlcsearch --remote
 
           if [[ "${SYNC_SCOPE}" == "full_catalog" ]]; then
-            bunx wrangler d1 execute jlcsearch --remote \
+            bash scripts/retry-command.sh bunx wrangler d1 execute jlcsearch --remote \
               --command "SELECT COUNT(*) AS row_count FROM component_catalog;"
-            bunx wrangler d1 execute jlcsearch --remote \
+            bash scripts/retry-command.sh bunx wrangler d1 execute jlcsearch --remote \
               --command "SELECT COUNT(*) AS row_count FROM search_index;"
-            bunx wrangler d1 execute jlcsearch --remote \
+            bash scripts/retry-command.sh bunx wrangler d1 execute jlcsearch --remote \
               --command "SELECT lcsc, mfr, stock FROM search_index WHERE lcsc=${SMOKE_TEST_LCSC};"
           else
             IFS=',' read -ra tables <<< "${DERIVED_TABLES_LIST}"
             for raw_table in "${tables[@]}"; do
               table="$(echo "${raw_table}" | xargs)"
-              bunx wrangler d1 execute jlcsearch --remote \
+              bash scripts/retry-command.sh bunx wrangler d1 execute jlcsearch --remote \
                 --command "SELECT COUNT(*) AS row_count FROM \"${table}\";"
             done
           fi
@@ -223,7 +223,8 @@ jobs:
         shell: bash
         run: |
           cache_keys_file="${RUNNER_TEMP}/jlcsearch-cache-keys.json"
-          bunx wrangler kv key list --binding CACHE_KV > "${cache_keys_file}"
+          bash scripts/retry-command.sh bunx wrangler kv key list \
+            --binding CACHE_KV > "${cache_keys_file}"
 
           cache_key_count="$(jq 'length' "${cache_keys_file}")"
           if [[ "${cache_key_count}" == "0" ]]; then
@@ -232,7 +233,8 @@ jobs:
           fi
 
           echo "Deleting ${cache_key_count} cached API responses."
-          bunx wrangler kv bulk delete "${cache_keys_file}" \
+          bash scripts/retry-command.sh bunx wrangler kv bulk delete \
+            "${cache_keys_file}" \
             --binding CACHE_KV \
             --force
 
@@ -255,6 +257,9 @@ jobs:
           fi
 
           curl --fail --silent --show-error \
+            --retry 3 \
+            --retry-all-errors \
+            --retry-delay 10 \
             "${CACHE_BUST_URL}${separator}cachebust=1" \
             --output /tmp/d1-sync-response.json
 

--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ snapshot is not hidden by an older response. On relevant merges to `main`, it
 downloads the current upstream source-db-v2 database, builds and verifies a
 compact `db.sqlite3` containing the requested derived tables, applies D1
 migrations, uploads those tables, and refreshes the affected production API
-cache. The workflow can also be run manually in `derived` or `full_catalog`
-mode. `derived` accepts a
+cache. Transient Cloudflare failures during migrations or upload are retried
+up to three times with incremental delays. The workflow can also be run
+manually in `derived` or `full_catalog` mode. `derived` accepts a
 comma-separated `derived_tables` input. `full_catalog` rebuilds and uploads the
 component catalog, search index, and FTS index from the current source-db-v2
 snapshot, and requires a numeric `smoke_test_lcsc` that must be present before

--- a/cf-proxy/scripts/retry-command.sh
+++ b/cf-proxy/scripts/retry-command.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+max_attempts="${RETRY_MAX_ATTEMPTS:-3}"
+base_delay_seconds="${RETRY_BASE_DELAY_SECONDS:-30}"
+
+if [[ "$#" == "0" ]]; then
+  echo "Usage: retry-command.sh <command> [args...]" >&2
+  exit 2
+fi
+
+if [[ ! "${max_attempts}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "RETRY_MAX_ATTEMPTS must be a positive integer." >&2
+  exit 2
+fi
+
+if [[ ! "${base_delay_seconds}" =~ ^[0-9]+$ ]]; then
+  echo "RETRY_BASE_DELAY_SECONDS must be a non-negative integer." >&2
+  exit 2
+fi
+
+attempt=1
+while true; do
+  if "$@"; then
+    exit 0
+  else
+    exit_code=$?
+  fi
+
+  if (( attempt >= max_attempts )); then
+    echo "::error::Command failed after ${attempt} attempts." >&2
+    exit "${exit_code}"
+  fi
+
+  delay_seconds=$((base_delay_seconds * attempt))
+  echo "::warning::Command failed on attempt ${attempt}/${max_attempts}; retrying in ${delay_seconds}s." >&2
+  sleep "${delay_seconds}"
+  attempt=$((attempt + 1))
+done


### PR DESCRIPTION
## Summary

- add a bounded command retry helper with three attempts and incremental delays
- retry D1 migrations, full sync uploads, remote verification queries, and KV cache operations
- retry the final production smoke-test request
- trigger the data workflow when any cf-proxy sync helper changes

## Context

The first manual full-catalog dispatch reached the D1 upload and failed with Cloudflare API code 7009 (upstream service unavailable). A retry then failed during migrations with code 7500 (internal error). The production database and cache remained intact, and the live D1 read-health endpoint continued to pass.

Failed run: https://github.com/tscircuit/jlcsearch/actions/runs/31231324688

## Verification

- 141 worker tests passed
- TypeScript check passed
- Biome format check passed
- retry helper success/failure behavior and Bash syntax verified
- workflow YAML parses successfully