### PR TITLE
Speed up full catalog D1 sync

### DIFF
--- a/.github/workflows/d1-migrations.yml
+++ b/.github/workflows/d1-migrations.yml
@@ -54,7 +54,7 @@ jobs:
   sync:
     name: Build database and sync production
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 180
     env:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -194,6 +194,8 @@ jobs:
           SYNC_DERIVED_TABLES: ${{ env.SYNC_SCOPE == 'derived' && '1' || '0' }}
           SYNC_COMPONENT_CATALOG: ${{ env.SYNC_SCOPE == 'full_catalog' && '1' || '0' }}
           SYNC_SEARCH_INDEX: ${{ env.SYNC_SCOPE == 'full_catalog' && '1' || '0' }}
+          COMPONENT_CATALOG_BATCH_ROWS: ${{ env.SYNC_SCOPE == 'full_catalog' && '1000' || '250' }}
+          SEARCH_INDEX_BATCH_ROWS: ${{ env.SYNC_SCOPE == 'full_catalog' && '1000' || '250' }}
         run: bash ./cf-proxy/scripts/retry-command.sh ./cf-proxy/scripts/sync-db.sh
 
       - name: Verify migration status and remote row counts

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ downloads the current upstream source-db-v2 database, builds and verifies a
 compact `db.sqlite3` containing the requested derived tables, applies D1
 migrations, uploads those tables, and refreshes the affected production API
 cache. Transient Cloudflare failures during migrations or upload are retried
-up to three times with incremental delays. The workflow can also be run
+up to three times with incremental delays. Full-catalog uploads use 1,000-row
+batches and a three-hour job timeout so the component catalog and search index
+can finish before the next upstream refresh. The workflow can also be run
 manually in `derived` or `full_catalog` mode. `derived` accepts a
 comma-separated `derived_tables` input. `full_catalog` rebuilds and uploads the
 component catalog, search index, and FTS index from the current source-db-v2


### PR DESCRIPTION
## Summary
- upload component_catalog and search_index in 1,000-row batches during full-catalog runs
- extend the sync job timeout from two to three hours
- document the full-catalog performance settings

## Why
The first production full-catalog run timed out after two hours. Its successful upload attempt spent about 108 minutes on component_catalog at 250 rows per request, then reached only 50,000 of 730,289 search_index rows before the job ceiling. Cloudflare recommends batching large D1 operations at about 1,000 rows.

## Validation
- 141 worker tests pass
- TypeScript check passes
- workflow YAML parses
- git diff --check passes