### PR TITLE
Harden full catalog FTS sync

### DIFF
--- a/.github/workflows/d1-migrations.yml
+++ b/.github/workflows/d1-migrations.yml
@@ -196,6 +196,9 @@ jobs:
           SYNC_SEARCH_INDEX: ${{ env.SYNC_SCOPE == 'full_catalog' && '1' || '0' }}
           COMPONENT_CATALOG_BATCH_ROWS: ${{ env.SYNC_SCOPE == 'full_catalog' && '1000' || '250' }}
           SEARCH_INDEX_BATCH_ROWS: ${{ env.SYNC_SCOPE == 'full_catalog' && '1000' || '250' }}
+          FTS_BATCH_ROWS: ${{ env.SYNC_SCOPE == 'full_catalog' && '5000' || '25000' }}
+          RETRY_MAX_ATTEMPTS: ${{ env.SYNC_SCOPE == 'full_catalog' && '6' || '3' }}
+          RETRY_BASE_DELAY_SECONDS: ${{ env.SYNC_SCOPE == 'full_catalog' && '20' || '30' }}
         run: bash ./cf-proxy/scripts/sync-db.sh
 
       - name: Verify migration status and remote row counts

--- a/README.md
+++ b/README.md
@@ -72,11 +72,12 @@ downloads the current upstream source-db-v2 database, builds and verifies a
 compact `db.sqlite3` containing the requested derived tables, applies D1
 migrations, uploads those tables, and refreshes the affected production API
 cache. Transient Cloudflare failures during migrations or upload are retried
-up to three times per D1 command with incremental delays. Upload batches are
+per D1 command with incremental delays. Upload batches are
 idempotent, so a lost import-status response can be retried without duplicating
 rows or restarting completed work. Full-catalog uploads use 1,000-row batches
-and a three-hour job timeout so the component catalog and search index can
-finish before the next upstream refresh. The workflow can also be run
+for catalog tables, 5,000-row batches for FTS, up to six attempts per D1
+command, and a three-hour job timeout so the component catalog and search index
+can finish before the next upstream refresh. The workflow can also be run
 manually in `derived` or `full_catalog` mode. `derived` accepts a
 comma-separated `derived_tables` input. `full_catalog` rebuilds and uploads the
 component catalog, search index, and FTS index from the current source-db-v2

--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -13,7 +13,7 @@ DB_NAME="${DB_NAME:-jlcsearch}"
 BATCH_ROWS="${BATCH_ROWS:-250}"
 COMPONENT_CATALOG_BATCH_ROWS="${COMPONENT_CATALOG_BATCH_ROWS:-${BATCH_ROWS}}"
 SEARCH_INDEX_BATCH_ROWS="${SEARCH_INDEX_BATCH_ROWS:-${BATCH_ROWS}}"
-FTS_BATCH_ROWS="${FTS_BATCH_ROWS:-25000}"
+FTS_BATCH_ROWS="${FTS_BATCH_ROWS:-5000}"
 SYNC_DERIVED_TABLES="${SYNC_DERIVED_TABLES:-1}"
 SYNC_COMPONENT_CATALOG="${SYNC_COMPONENT_CATALOG:-0}"
 SYNC_SEARCH_INDEX="${SYNC_SEARCH_INDEX:-0}"
@@ -113,8 +113,10 @@ rebuild_remote_search_fts_index() {
     "
   done
 
+  # FTS5 optimize is optional maintenance and can exceed D1's per-query work
+  # limit on the full catalog. The incrementally built index is ready to query
+  # as soon as every range has been inserted.
   run_wrangler d1 execute "${DB_NAME}" --remote --command "
-    INSERT INTO search_index_fts(search_index_fts) VALUES('optimize');
     UPDATE search_index_fts_meta SET value = '1' WHERE key = 'ready';
   "
 }


### PR DESCRIPTION
## Summary
- reduce full-catalog FTS writes from 25000 to 5000 rows per D1 command
- allow six bounded retries for idempotent full-catalog commands
- mark FTS ready after all ranges are populated without requiring the optional global optimize operation

## Why
Production run 31240275880 retained progress and recovered from several individual transient errors, proving per-command retries work. One late command then failed three consecutive attempts. Smaller FTS ranges reduce per-command work, the larger retry budget tolerates a longer Cloudflare disturbance, and skipping global optimize avoids making optional maintenance a correctness gate.

## Validation
- shell syntax checks pass
- TypeScript check passes
- formatting passes
- workflow YAML parses
- git diff --check passes