### PR TITLE
Add nightly stock-only D1 sync

### DIFF
--- a/.github/workflows/d1-migrations.yml
+++ b/.github/workflows/d1-migrations.yml
@@ -20,12 +20,13 @@ on:
   workflow_dispatch:
     inputs:
       sync_scope:
-        description: Data set to rebuild and upload
+        description: Data set to synchronize
         required: true
-        default: derived
+        default: stock_only
         type: choice
         options:
           - derived
+          - stock_only
           - full_catalog
       derived_tables:
         description: Comma-separated derived tables to rebuild and upload
@@ -38,7 +39,7 @@ on:
         default: ""
         type: string
       smoke_test_lcsc:
-        description: LCSC number that must exist after a full catalog sync
+        description: LCSC number used to verify catalog and stock syncs
         required: true
         default: "7512"
         type: string
@@ -58,7 +59,7 @@ jobs:
     env:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      SYNC_SCOPE: ${{ github.event_name == 'schedule' && 'full_catalog' || inputs.sync_scope || 'derived' }}
+      SYNC_SCOPE: ${{ github.event_name == 'schedule' && 'stock_only' || inputs.sync_scope || 'derived' }}
       DERIVED_TABLES_LIST: ${{ inputs.derived_tables || 'photo_diode' }}
       SMOKE_TEST_LCSC: ${{ inputs.smoke_test_lcsc || '7512' }}
 
@@ -81,7 +82,7 @@ jobs:
             echo "::error::Missing CLOUDFLARE_API_TOKEN repository secret."
             exit 1
           fi
-          if [[ "${SYNC_SCOPE}" != "derived" && "${SYNC_SCOPE}" != "full_catalog" ]]; then
+          if [[ "${SYNC_SCOPE}" != "derived" && "${SYNC_SCOPE}" != "stock_only" && "${SYNC_SCOPE}" != "full_catalog" ]]; then
             echo "::error::Unknown sync scope: ${SYNC_SCOPE}"
             exit 1
           fi
@@ -89,7 +90,7 @@ jobs:
             echo "::error::At least one derived table is required."
             exit 1
           fi
-          if [[ "${SYNC_SCOPE}" == "full_catalog" && ! "${SMOKE_TEST_LCSC}" =~ ^[0-9]+$ ]]; then
+          if [[ "${SYNC_SCOPE}" != "derived" && ! "${SMOKE_TEST_LCSC}" =~ ^[0-9]+$ ]]; then
             echo "::error::smoke_test_lcsc must be numeric."
             exit 1
           fi
@@ -120,6 +121,8 @@ jobs:
           bun run setup:extract-db
           if [[ "${SYNC_SCOPE}" == "full_catalog" ]]; then
             INCLUDE_COMPONENT_CATALOG=1 bun run setup:derived-sync-db
+          elif [[ "${SYNC_SCOPE}" == "stock_only" ]]; then
+            INCLUDE_STOCK_SNAPSHOT=1 bun run setup:derived-sync-db
           else
             bun run setup:derived-sync-db
           fi
@@ -158,6 +161,25 @@ jobs:
               exit 1
             fi
             echo "component_catalog: ${catalog_count} prepared rows"
+          elif [[ "${SYNC_SCOPE}" == "stock_only" ]]; then
+            stock_snapshot_exists="$(sqlite3 db.sqlite3 "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='component_stock');")"
+            if [[ "${stock_snapshot_exists}" != "1" ]]; then
+              echo "::error::Prepared database does not contain component_stock."
+              exit 1
+            fi
+
+            stock_snapshot_count="$(sqlite3 db.sqlite3 "SELECT COUNT(*) FROM component_stock;")"
+            if [[ "${stock_snapshot_count}" == "0" ]]; then
+              echo "::error::Refusing to sync an empty stock snapshot."
+              exit 1
+            fi
+
+            smoke_test_count="$(sqlite3 db.sqlite3 "SELECT COUNT(*) FROM component_stock WHERE lcsc=${SMOKE_TEST_LCSC};")"
+            if [[ "${smoke_test_count}" != "1" ]]; then
+              echo "::error::Prepared stock snapshot does not contain C${SMOKE_TEST_LCSC}."
+              exit 1
+            fi
+            echo "component_stock: ${stock_snapshot_count} prepared rows"
           else
             IFS=',' read -ra tables <<< "${DERIVED_TABLES_LIST}"
             for raw_table in "${tables[@]}"; do
@@ -187,6 +209,7 @@ jobs:
         run: bash scripts/retry-command.sh bunx wrangler d1 migrations apply jlcsearch --remote
 
       - name: Upload selected data to D1
+        if: env.SYNC_SCOPE != 'stock_only'
         env:
           SOURCE_DB_PATH: ${{ github.workspace }}/db.sqlite3
           REBUILD_DERIVED_TABLES: "0"
@@ -201,6 +224,15 @@ jobs:
           RETRY_BASE_DELAY_SECONDS: ${{ env.SYNC_SCOPE == 'full_catalog' && '20' || '30' }}
         run: bash ./cf-proxy/scripts/sync-db.sh
 
+      - name: Sync stock quantities to D1
+        if: env.SYNC_SCOPE == 'stock_only'
+        env:
+          SOURCE_DB_PATH: ${{ github.workspace }}/db.sqlite3
+          STOCK_BATCH_ROWS: "1000"
+          RETRY_MAX_ATTEMPTS: "6"
+          RETRY_BASE_DELAY_SECONDS: "20"
+        run: bash ./cf-proxy/scripts/sync-stock.sh
+
       - name: Verify migration status and remote row counts
         working-directory: cf-proxy
         run: |
@@ -211,8 +243,25 @@ jobs:
               --command "SELECT COUNT(*) AS row_count FROM component_catalog;"
             bash scripts/retry-command.sh bunx wrangler d1 execute jlcsearch --remote \
               --command "SELECT COUNT(*) AS row_count FROM search_index;"
-            bash scripts/retry-command.sh bunx wrangler d1 execute jlcsearch --remote \
-              --command "SELECT lcsc, mfr, stock FROM search_index WHERE lcsc=${SMOKE_TEST_LCSC};"
+          fi
+
+          if [[ "${SYNC_SCOPE}" != "derived" ]]; then
+            source_stock_table="component_catalog"
+            if [[ "${SYNC_SCOPE}" == "stock_only" ]]; then
+              source_stock_table="component_stock"
+            fi
+            expected_stock="$(sqlite3 ../db.sqlite3 "SELECT stock FROM ${source_stock_table} WHERE lcsc=${SMOKE_TEST_LCSC};")"
+            remote_result_file="${RUNNER_TEMP}/jlcsearch-remote-stock.json"
+            bash scripts/retry-command.sh bunx wrangler d1 execute jlcsearch --remote --json \
+              --command "SELECT lcsc, mfr, stock FROM search_index WHERE lcsc=${SMOKE_TEST_LCSC};" \
+              > "${remote_result_file}"
+            remote_stock="$(jq -r '.[0].results[0].stock // empty' "${remote_result_file}")"
+            if [[ -z "${expected_stock}" || "${remote_stock}" != "${expected_stock}" ]]; then
+              echo "::error::Remote C${SMOKE_TEST_LCSC} stock ${remote_stock:-missing} did not match source stock ${expected_stock:-missing}."
+              cat "${remote_result_file}"
+              exit 1
+            fi
+            echo "Remote C${SMOKE_TEST_LCSC} stock matches source: ${expected_stock}."
           else
             IFS=',' read -ra tables <<< "${DERIVED_TABLES_LIST}"
             for raw_table in "${tables[@]}"; do
@@ -223,7 +272,7 @@ jobs:
           fi
 
       - name: Clear production API cache
-        if: env.SYNC_SCOPE == 'full_catalog'
+        if: env.SYNC_SCOPE != 'derived'
         working-directory: cf-proxy
         shell: bash
         run: |
@@ -249,7 +298,7 @@ jobs:
         shell: bash
         run: |
           if [[ -z "${CACHE_BUST_URL}" ]]; then
-            if [[ "${SYNC_SCOPE}" == "full_catalog" ]]; then
+            if [[ "${SYNC_SCOPE}" != "derived" ]]; then
               CACHE_BUST_URL="https://jlcsearch.tscircuit.com/components/list?search=C${SMOKE_TEST_LCSC}&json=true"
             else
               CACHE_BUST_URL="https://jlcsearch.tscircuit.com/photo_diodes/list.json"
@@ -278,12 +327,38 @@ jobs:
             echo "Production HDMI API returned ${hdmi_port_count} ports."
           fi
 
-          if [[ "${SYNC_SCOPE}" == "full_catalog" ]]; then
+          if [[ "${SYNC_SCOPE}" != "derived" ]]; then
             component_count="$(jq '.components | length' /tmp/d1-sync-response.json)"
             if [[ "${component_count}" == "0" || "${component_count}" == "null" ]]; then
               echo "::error::Production component API did not return C${SMOKE_TEST_LCSC}."
               cat /tmp/d1-sync-response.json
               exit 1
             fi
-            echo "Production component API returned C${SMOKE_TEST_LCSC}."
+            source_stock_table="component_catalog"
+            if [[ "${SYNC_SCOPE}" == "stock_only" ]]; then
+              source_stock_table="component_stock"
+            fi
+            expected_stock="$(sqlite3 db.sqlite3 "SELECT stock FROM ${source_stock_table} WHERE lcsc=${SMOKE_TEST_LCSC};")"
+            api_stock="$(jq -r '.components[0].stock // empty' /tmp/d1-sync-response.json)"
+            if [[ -z "${expected_stock}" || "${api_stock}" != "${expected_stock}" ]]; then
+              echo "::error::Production C${SMOKE_TEST_LCSC} stock ${api_stock:-missing} did not match source stock ${expected_stock:-missing}."
+              cat /tmp/d1-sync-response.json
+              exit 1
+            fi
+            echo "Cache-busted production API returned expected C${SMOKE_TEST_LCSC} stock ${expected_stock}."
+
+            curl --fail --silent --show-error \
+              --retry 3 \
+              --retry-all-errors \
+              --retry-delay 10 \
+              "${CACHE_BUST_URL}" \
+              --output /tmp/d1-sync-cached-response.json
+
+            cached_api_stock="$(jq -r '.components[0].stock // empty' /tmp/d1-sync-cached-response.json)"
+            if [[ "${cached_api_stock}" != "${expected_stock}" ]]; then
+              echo "::error::Cached production C${SMOKE_TEST_LCSC} stock ${cached_api_stock:-missing} did not match source stock ${expected_stock}."
+              cat /tmp/d1-sync-cached-response.json
+              exit 1
+            fi
+            echo "Cached production API returned expected C${SMOKE_TEST_LCSC} stock ${expected_stock}."
           fi

--- a/README.md
+++ b/README.md
@@ -65,9 +65,13 @@ table data from a prepared local SQLite database.
 
 Production D1 data is populated by the **Build and Sync D1** GitHub Actions
 workflow. Every night at 05:00 UTC, after the upstream jlcparts refresh, it
-performs a `full_catalog` sync and clears the production response cache. API
-clients are instructed to revalidate within 24 hours so the nightly stock
-snapshot is not hidden by an older response. On relevant merges to `main`, it
+performs a `stock_only` sync and clears the production response cache. The
+stock-only path updates changed values in `component_catalog` and `search_index`
+without rebuilding either table or the FTS index. Its compact stock snapshot
+also sets recently removed parts to zero instead of leaving stale quantities.
+API clients are instructed to revalidate within 24 hours so the nightly stock
+snapshot is not hidden by an older response. On relevant merges to `main`, the
+workflow
 downloads the current upstream source-db-v2 database, builds and verifies a
 compact `db.sqlite3` containing the requested derived tables, applies D1
 migrations, uploads those tables, and refreshes the affected production API
@@ -78,13 +82,14 @@ rows or restarting completed work. Full-catalog uploads use 1,000-row batches
 for catalog tables, 5,000-row batches for FTS, up to six attempts per D1
 command, and a three-hour job timeout so the component catalog and search index
 can finish before the next upstream refresh. The workflow can also be run
-manually in `derived` or `full_catalog` mode. `derived` accepts a
-comma-separated `derived_tables` input. `full_catalog` rebuilds and uploads the
-component catalog, search index, and FTS index from the current source-db-v2
-snapshot, and requires a numeric `smoke_test_lcsc` that must be present before
-and after the upload. Both modes accept an optional `cache_bust_url`. The
-workflow requires the `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`
-repository secrets.
+manually in `derived`, `stock_only`, or `full_catalog` mode. `derived` accepts a
+comma-separated `derived_tables` input. `stock_only` performs the same in-place
+stock refresh used by the nightly schedule. `full_catalog` rebuilds and uploads
+the component catalog, search index, and FTS index from the current source-db-v2
+snapshot. Catalog and stock syncs require a numeric `smoke_test_lcsc` whose
+remote stock must match the prepared source database. All modes accept an
+optional `cache_bust_url`. The workflow requires the
+`CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` repository secrets.
 
 ## How Does It work?
 As a developer new to this codebase, or a curious user, you may have some questions about the flow of data through the scripts and automations inside this repo.  It all starts with the [jlcparts](https://github.com/yaqwsx/jlcparts) project, which compiles a massive **11GB** sqlite3 database of *everything* [JLCPCB](https://jlcpcb.com) has to offer.  As you can imagine, this would be very resource-intensive and slow to search, so the next steps are scripts that optimize it heavily, although it's more accurate to say that they rebuild it entirely. 

--- a/cf-proxy/scripts/sync-stock.sh
+++ b/cf-proxy/scripts/sync-stock.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+DB_NAME="${DB_NAME:-jlcsearch}"
+SOURCE_DB_PATH="${SOURCE_DB_PATH:-${REPO_ROOT}/db.sqlite3}"
+STOCK_BATCH_ROWS="${STOCK_BATCH_ROWS:-1000}"
+STOCK_SYNC_TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/jlcsearch-stock-sync.XXXXXX")"
+
+if command -v bunx >/dev/null 2>&1; then
+  WRANGLER_CMD=(bunx wrangler)
+else
+  WRANGLER_CMD=(npx wrangler)
+fi
+
+run_wrangler() {
+  bash "${SCRIPT_DIR}/retry-command.sh" "${WRANGLER_CMD[@]}" "$@"
+}
+
+cleanup() {
+  if [[ "${KEEP_SYNC_TEMP:-0}" != "1" ]]; then
+    rm -rf "${STOCK_SYNC_TEMP_DIR}"
+  fi
+}
+
+trap cleanup EXIT
+
+if [[ ! -s "${SOURCE_DB_PATH}" ]]; then
+  echo "Source database does not exist or is empty: ${SOURCE_DB_PATH}" >&2
+  exit 1
+fi
+
+if [[ ! "${STOCK_BATCH_ROWS}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "STOCK_BATCH_ROWS must be a positive integer." >&2
+  exit 1
+fi
+
+echo "Generating stock-only D1 update batches..."
+(
+  cd "${REPO_ROOT}"
+  SOURCE_DB_PATH="${SOURCE_DB_PATH}" \
+    STOCK_SYNC_OUTPUT_DIR="${STOCK_SYNC_TEMP_DIR}" \
+    STOCK_BATCH_ROWS="${STOCK_BATCH_ROWS}" \
+    bun run scripts/generate-stock-sync-sql.ts
+)
+
+shopt -s nullglob
+batch_files=("${STOCK_SYNC_TEMP_DIR}"/batch-*.sql)
+if [[ "${#batch_files[@]}" -eq 0 ]]; then
+  echo "Stock sync did not generate any update batches." >&2
+  exit 1
+fi
+
+batch_count="${#batch_files[@]}"
+batch_number=0
+for batch_file in "${batch_files[@]}"; do
+  batch_number=$((batch_number + 1))
+  batch_sql="$(<"${batch_file}")"
+  echo "Updating stock batch ${batch_number}/${batch_count}..."
+  run_wrangler d1 execute "${DB_NAME}" --remote --command "${batch_sql}"
+done
+
+echo "Stock-only sync complete."

--- a/scripts/build-derived-sync-db.ts
+++ b/scripts/build-derived-sync-db.ts
@@ -24,12 +24,14 @@ export const buildDerivedSyncDatabase = async ({
   outputPath,
   tableNames,
   includeComponentCatalog = false,
+  includeStockSnapshot = false,
   logger = console.log,
 }: {
   sourcePath: string
   outputPath: string
   tableNames?: string[]
   includeComponentCatalog?: boolean
+  includeStockSnapshot?: boolean
   logger?: (message: string) => void
 }) => {
   const resolvedSourcePath = path.resolve(sourcePath)
@@ -183,6 +185,22 @@ export const buildDerivedSyncDatabase = async ({
     `)
   }
 
+  if (includeStockSnapshot) {
+    database.exec(`
+      CREATE TABLE component_stock (
+        lcsc INTEGER PRIMARY KEY,
+        stock INTEGER NOT NULL
+      );
+
+      INSERT INTO component_stock(lcsc, stock)
+      SELECT
+        lcsc,
+        CASE WHEN present = 1 THEN coalesce(stock, 0) ELSE 0 END
+      FROM source.jlc_components
+      WHERE last_on_stock >= unixepoch('now', '-1 year');
+    `)
+  }
+
   const db = new Kysely<DB>({
     dialect: new BunSqliteDialect({ database }),
   })
@@ -209,12 +227,15 @@ const main = async () => {
     .filter(Boolean)
   const includeComponentCatalog =
     process.env.INCLUDE_COMPONENT_CATALOG?.trim() === "1"
+  const includeStockSnapshot =
+    process.env.INCLUDE_STOCK_SNAPSHOT?.trim() === "1"
 
   await buildDerivedSyncDatabase({
     sourcePath,
     outputPath,
     tableNames: configuredTables?.length ? configuredTables : undefined,
     includeComponentCatalog,
+    includeStockSnapshot,
   })
 }
 

--- a/scripts/generate-stock-sync-sql.ts
+++ b/scripts/generate-stock-sync-sql.ts
@@ -1,0 +1,161 @@
+import { Database } from "bun:sqlite"
+import { existsSync } from "node:fs"
+import { mkdir, rm } from "node:fs/promises"
+import path from "node:path"
+
+interface StockRow {
+  lcsc: number
+  stock: number | null
+}
+
+interface CatalogStats {
+  row_count: number
+  unique_lcsc_count: number
+  null_lcsc_count: number
+}
+
+const STOCK_TABLES = ["component_catalog", "search_index"] as const
+
+const integerLiteral = (value: number | null, label: string): string => {
+  if (value === null) return "NULL"
+  if (!Number.isSafeInteger(value)) {
+    throw new Error(`${label} must be a safe integer, received ${value}`)
+  }
+  return String(value)
+}
+
+const createStockUpdateStatement = (
+  table: (typeof STOCK_TABLES)[number],
+  rows: StockRow[],
+) => {
+  const values = rows
+    .map(
+      ({ lcsc, stock }) =>
+        `(${integerLiteral(lcsc, "lcsc")},${integerLiteral(stock, "stock")})`,
+    )
+    .join(",")
+
+  return `WITH stock_updates(lcsc, stock) AS (VALUES ${values})
+UPDATE ${table} AS target
+SET stock = stock_updates.stock
+FROM stock_updates
+WHERE target.lcsc = stock_updates.lcsc
+  AND target.stock IS NOT stock_updates.stock;`
+}
+
+export const createStockSyncBatchSql = (rows: StockRow[]): string => {
+  if (rows.length === 0) {
+    throw new Error("Cannot create an empty stock sync batch")
+  }
+
+  return STOCK_TABLES.map((table) =>
+    createStockUpdateStatement(table, rows),
+  ).join("\n")
+}
+
+export const writeStockSyncBatches = async ({
+  sourcePath,
+  outputDirectory,
+  batchSize = 1000,
+}: {
+  sourcePath: string
+  outputDirectory: string
+  batchSize?: number
+}) => {
+  if (!Number.isSafeInteger(batchSize) || batchSize <= 0) {
+    throw new Error("batchSize must be a positive integer")
+  }
+
+  const resolvedSourcePath = path.resolve(sourcePath)
+  const resolvedOutputDirectory = path.resolve(outputDirectory)
+  if (!existsSync(resolvedSourcePath)) {
+    throw new Error(`Source database does not exist: ${resolvedSourcePath}`)
+  }
+
+  await rm(resolvedOutputDirectory, { recursive: true, force: true })
+  await mkdir(resolvedOutputDirectory, { recursive: true })
+
+  const database = new Database(resolvedSourcePath, { readonly: true })
+  try {
+    const stats = database
+      .query<CatalogStats, []>(
+        `SELECT
+          COUNT(*) AS row_count,
+          COUNT(DISTINCT lcsc) AS unique_lcsc_count,
+          COUNT(*) FILTER (WHERE lcsc IS NULL) AS null_lcsc_count
+        FROM component_stock`,
+      )
+      .get()
+
+    if (!stats || stats.row_count === 0) {
+      throw new Error("component_stock is empty")
+    }
+    if (
+      stats.null_lcsc_count !== 0 ||
+      stats.unique_lcsc_count !== stats.row_count
+    ) {
+      throw new Error("component_stock.lcsc must be unique and non-null")
+    }
+
+    const rows = database
+      .query<StockRow, []>(
+        `SELECT lcsc, stock
+         FROM component_stock
+         ORDER BY rowid`,
+      )
+      .iterate()
+
+    let batch: StockRow[] = []
+    let batchCount = 0
+    for (const row of rows) {
+      batch.push(row)
+      if (batch.length < batchSize) continue
+
+      batchCount += 1
+      const filename = `batch-${String(batchCount).padStart(6, "0")}.sql`
+      await Bun.write(
+        path.join(resolvedOutputDirectory, filename),
+        createStockSyncBatchSql(batch),
+      )
+      batch = []
+    }
+
+    if (batch.length > 0) {
+      batchCount += 1
+      const filename = `batch-${String(batchCount).padStart(6, "0")}.sql`
+      await Bun.write(
+        path.join(resolvedOutputDirectory, filename),
+        createStockSyncBatchSql(batch),
+      )
+    }
+
+    return { rowCount: stats.row_count, batchCount }
+  } finally {
+    database.close()
+  }
+}
+
+const main = async () => {
+  const sourcePath =
+    process.env.SOURCE_DB_PATH?.trim() || path.resolve("db.sqlite3")
+  const outputDirectory =
+    process.env.STOCK_SYNC_OUTPUT_DIR?.trim() ||
+    path.resolve(".stock-sync-batches")
+  const batchSize = Number.parseInt(
+    process.env.STOCK_BATCH_ROWS?.trim() || "1000",
+    10,
+  )
+
+  const result = await writeStockSyncBatches({
+    sourcePath,
+    outputDirectory,
+    batchSize,
+  })
+  console.log(
+    `Generated ${result.batchCount} stock batches for ${result.rowCount} components.`,
+  )
+}
+
+if (import.meta.main) {
+  await main()
+}

--- a/tests/build-derived-sync-db.test.ts
+++ b/tests/build-derived-sync-db.test.ts
@@ -170,6 +170,44 @@ describe("buildDerivedSyncDatabase", () => {
     })
     output.close()
   })
+
+  test("materializes a stock snapshot with zeroes for absent parts", async () => {
+    const { sourcePath, outputPath } = await createSourceDatabase()
+    const source = new Database(sourcePath)
+    source
+      .query(
+        `INSERT INTO jlc_components (
+          lcsc, fetched_at, present, sync_seen, category, subcategory, mfr,
+          package, joints, manufacturer, library_type, preferred, last_on_stock,
+          description, datasheet, stock, price, attributes
+        ) VALUES (
+          54321, unixepoch(), 0, 1, 'Connectors',
+          'HDMI Connectors', 'REMOVED', 'SMD', 19, 'Example', 'base', 0,
+          unixepoch(), 'No longer listed', '', 125, '1-:1.00', '{}'
+        )`,
+      )
+      .run()
+    source.close()
+
+    await buildDerivedSyncDatabase({
+      sourcePath,
+      outputPath,
+      tableNames: ["hdmi_port"],
+      includeStockSnapshot: true,
+      logger: () => {},
+    })
+
+    const output = new Database(outputPath, { readonly: true })
+    expect(
+      output
+        .query("SELECT lcsc, stock FROM component_stock ORDER BY lcsc")
+        .all(),
+    ).toEqual([
+      { lcsc: 12345, stock: 250 },
+      { lcsc: 54321, stock: 0 },
+    ])
+    output.close()
+  })
 })
 
 describe("extractMinQPrice", () => {

--- a/tests/generate-stock-sync-sql.test.ts
+++ b/tests/generate-stock-sync-sql.test.ts
@@ -1,0 +1,119 @@
+import { Database } from "bun:sqlite"
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import {
+  createStockSyncBatchSql,
+  writeStockSyncBatches,
+} from "../scripts/generate-stock-sync-sql"
+
+const tempDirectories: string[] = []
+
+const createTempDirectory = async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "jlcsearch-stock-sync-"))
+  tempDirectories.push(directory)
+  return directory
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  )
+})
+
+describe("stock sync SQL generation", () => {
+  test("updates only changed stock in existing catalog and search rows", async () => {
+    const directory = await createTempDirectory()
+    const sourcePath = path.join(directory, "source.sqlite3")
+    const outputDirectory = path.join(directory, "batches")
+    const source = new Database(sourcePath, { create: true })
+    source.exec(`
+      CREATE TABLE component_stock (lcsc INTEGER, stock INTEGER);
+      INSERT INTO component_stock(lcsc, stock) VALUES
+        (1, 10),
+        (2, NULL),
+        (3, 0),
+        (4, 40);
+    `)
+    source.close()
+
+    const result = await writeStockSyncBatches({
+      sourcePath,
+      outputDirectory,
+      batchSize: 2,
+    })
+    expect(result).toEqual({ rowCount: 4, batchCount: 2 })
+
+    const target = new Database(":memory:")
+    target.exec(`
+      CREATE TABLE component_catalog (lcsc INTEGER UNIQUE, stock INTEGER);
+      CREATE TABLE search_index (lcsc INTEGER UNIQUE, stock INTEGER);
+      INSERT INTO component_catalog(lcsc, stock) VALUES
+        (1, 1), (2, NULL), (3, 3), (99, 99);
+      INSERT INTO search_index(lcsc, stock) VALUES
+        (1, 1), (2, NULL), (3, 3), (99, 99);
+    `)
+
+    const batchFiles = (await readdir(outputDirectory)).sort()
+    for (const batchFile of batchFiles) {
+      target.exec(await readFile(path.join(outputDirectory, batchFile), "utf8"))
+    }
+
+    for (const table of ["component_catalog", "search_index"]) {
+      expect(
+        target.query(`SELECT lcsc, stock FROM ${table} ORDER BY lcsc`).all(),
+      ).toEqual([
+        { lcsc: 1, stock: 10 },
+        { lcsc: 2, stock: null },
+        { lcsc: 3, stock: 0 },
+        { lcsc: 99, stock: 99 },
+      ])
+    }
+
+    const changesBeforeRetry = target
+      .query<{ changes: number }, []>("SELECT total_changes() AS changes")
+      .get()?.changes
+    for (const batchFile of batchFiles) {
+      target.exec(await readFile(path.join(outputDirectory, batchFile), "utf8"))
+    }
+    const changesAfterRetry = target
+      .query<{ changes: number }, []>("SELECT total_changes() AS changes")
+      .get()?.changes
+    expect(changesAfterRetry).toBe(changesBeforeRetry)
+    target.close()
+  })
+
+  test("rejects duplicate component identifiers", async () => {
+    const directory = await createTempDirectory()
+    const sourcePath = path.join(directory, "source.sqlite3")
+    const source = new Database(sourcePath, { create: true })
+    source.exec(`
+      CREATE TABLE component_stock (lcsc INTEGER, stock INTEGER);
+      INSERT INTO component_stock(lcsc, stock) VALUES (1, 10), (1, 20);
+    `)
+    source.close()
+
+    expect(
+      writeStockSyncBatches({
+        sourcePath,
+        outputDirectory: path.join(directory, "batches"),
+      }),
+    ).rejects.toThrow("component_stock.lcsc must be unique and non-null")
+  })
+
+  test("keeps 1,000-row statements below D1's query-size limit", () => {
+    const rows = Array.from({ length: 1000 }, (_, index) => ({
+      lcsc: 9_000_000 + index,
+      stock: 999_999_999,
+    }))
+    const statements = createStockSyncBatchSql(rows).split(";\n")
+
+    expect(statements).toHaveLength(2)
+    for (const statement of statements) {
+      expect(Buffer.byteLength(statement)).toBeLessThan(100_000)
+    }
+  })
+})


### PR DESCRIPTION
## What changed

- add a dispatchable `stock_only` mode and make it the 05:00 UTC scheduled sync
- build a compact stock snapshot that records absent recent parts as zero-stock tombstones
- update `component_catalog` and `search_index` in 1,000-row D1 query batches, writing only changed values
- keep table schemas, row IDs, and the FTS index intact
- verify remote, cache-busted, and normal cached API stock against the prepared source snapshot

## Why

Full catalog rebuilds repeatedly failed while recreating the search index through Cloudflare D1's import service. A nightly stock refresh does not need to rebuild catalog metadata or FTS data.

## Validation

- `bun test` — 190 passing
- `bun test --cwd cf-proxy` — 141 passing
- root and worker TypeScript checks
- Biome format check
- shell syntax, YAML parse, and `git diff --check`
