### PR TITLE
Add PCBA type to component results

### DIFF
--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -10,6 +10,11 @@ export interface ComponentCatalogQueryParams {
   is_preferred?: string
 }
 
+export type PcbaType = "Economic and Standard" | "Standard"
+
+export const getPcbaType = (isBasic: boolean): PcbaType =>
+  isBasic ? "Economic and Standard" : "Standard"
+
 export async function queryComponentCatalog(
   db: Kysely<DB>,
   params: ComponentCatalogQueryParams,

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -1,5 +1,5 @@
 import { CacheService, addCorsHeaders, addVaryHeader } from "./cache-service"
-import { queryComponentCatalog } from "./components"
+import { getPcbaType, queryComponentCatalog } from "./components"
 import { getD1Handler } from "./d1-routes"
 import { getD1Client } from "./db/get-d1-client"
 import { renderD1TablePage, renderHomePage } from "./render"
@@ -368,6 +368,7 @@ async function handleD1Search(
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
       is_preferred: Boolean(row.preferred),
+      pcba_type: getPcbaType(Boolean(row.basic)),
       description: row.description ?? "",
       stock: row.stock ?? 0,
       price: row.price1 ?? extractSmallQuantityPrice(row.price),
@@ -493,6 +494,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        pcba_type: getPcbaType(Boolean(row.basic)),
       })),
     }
 

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -158,6 +158,7 @@ const COLUMN_LABELS: Record<string, string> = {
   in_stock: "In Stock",
   is_basic: "Basic",
   is_preferred: "Preferred",
+  pcba_type: "PCBA Type",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
   voltage_rating: "Voltage",

--- a/cf-proxy/test/components.test.ts
+++ b/cf-proxy/test/components.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest"
+import { getPcbaType } from "../src/components"
+
+describe("getPcbaType", () => {
+  it("marks basic parts as available for Economic and Standard assembly", () => {
+    expect(getPcbaType(true)).toBe("Economic and Standard")
+  })
+
+  it("marks non-basic parts as Standard assembly only", () => {
+    expect(getPcbaType(false)).toBe("Standard")
+  })
+})

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -309,6 +309,7 @@ describe("render helpers", () => {
             max_resolution: "32x4",
             is_basic: false,
             is_preferred: true,
+            pcba_type: "Standard",
             stock: 18416,
           },
         ],
@@ -330,6 +331,8 @@ describe("render helpers", () => {
     expect(html).toContain('name="max_resolution"')
     expect(html).toContain('value="32x4" selected')
     expect(html).toContain(">Max Resolution</th>")
+    expect(html).toContain(">PCBA Type</th>")
+    expect(html).toContain(">Standard</td>")
     expect(html).toContain('name="is_basic"')
     expect(html).toContain('name="is_preferred" value="true" checked')
     expect(html).toContain("HT1621B")


### PR DESCRIPTION
## What changed

- Add a `pcba_type` field to component catalog and search API results.
- Map JLCPCB Basic parts to `Economic and Standard` and non-Basic parts to `Standard`.
- Display the field as `PCBA Type` in rendered component tables.
- Add unit and rendering coverage for both the mapping and table output.

## Why

Standard-only JLCPCB parts incur an additional setup fee. Exposing the PCBA type directly lets component-search consumers show that distinction without needing to interpret the internal `is_basic` flag.

## Impact

API consumers receive one additional backward-compatible field, and component pages clearly show whether a part supports Economic assembly or requires Standard assembly.

## Validation

- `npm test --prefix cf-proxy -- --run` (143 tests passed)
- `npx --prefix cf-proxy tsc --noEmit --project cf-proxy/tsconfig.json`
