### PR TITLE
Add extended promotional component filter

### DIFF
--- a/cf-proxy/scripts/rebuild-search-index-batched.sh
+++ b/cf-proxy/scripts/rebuild-search-index-batched.sh
@@ -70,6 +70,7 @@ INSERT INTO search_index_next (
   price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   manufacturer_name,
@@ -102,6 +103,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -144,7 +146,8 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
    CREATE INDEX IF NOT EXISTS idx_search_index_next_lcsc ON search_index_next(lcsc);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_package ON search_index_next(package);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_basic ON search_index_next(basic);
-   CREATE INDEX IF NOT EXISTS idx_search_index_next_preferred ON search_index_next(preferred);"
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_preferred ON search_index_next(preferred);
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_extended_promotional ON search_index_next(is_extended_promotional);"
 
 echo "Validating row count..."
 run_wrangler d1 execute "$DB_NAME" --remote --command \

--- a/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
+++ b/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
@@ -25,6 +25,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -66,3 +67,5 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);

--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -332,6 +332,7 @@ SELECT
   package,
   basic,
   preferred,
+  coalesce(extended, 0) AS is_extended_promotional,
   description,
   stock,
   price,
@@ -342,6 +343,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(is_extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA
 }
@@ -357,6 +359,7 @@ CREATE TABLE component_catalog (
   package TEXT,
   basic INTEGER,
   preferred INTEGER,
+  is_extended_promotional INTEGER,
   description TEXT,
   stock INTEGER,
   price TEXT,
@@ -366,6 +369,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(is_extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA_EXPORT
 }
@@ -399,6 +403,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -440,6 +445,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);
 SEARCH_INDEX_SCHEMA
 }
 
@@ -456,6 +463,7 @@ CREATE TABLE search_index (
   price1 REAL,
   basic INTEGER,
   preferred INTEGER,
+  is_extended_promotional INTEGER,
   category TEXT,
   subcategory TEXT,
   manufacturer_name TEXT,
@@ -473,6 +481,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);
 SEARCH_INDEX_SCHEMA_EXPORT
 }
 

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -22,6 +23,7 @@ export async function queryComponentCatalog(
     package: string | null
     basic: number | null
     preferred: number | null
+    is_extended_promotional: number | null
     description: string | null
     stock: number | null
     price: string | null
@@ -34,6 +36,7 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -208,6 +208,7 @@ export interface ComponentCatalog {
   category: string | null
   description: string | null
   extra: string | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   package: string | null
@@ -770,6 +771,7 @@ export interface SearchIndex {
   basic: number | null
   category: string | null
   description: string | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   manufacturer_name: string | null

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -493,6 +493,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        is_extended_promotional: Boolean(row.is_extended_promotional),
       })),
     }
 

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -158,6 +158,7 @@ const COLUMN_LABELS: Record<string, string> = {
   in_stock: "In Stock",
   is_basic: "Basic",
   is_preferred: "Preferred",
+  is_extended_promotional: "Extended Promotional",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
   voltage_rating: "Voltage",
@@ -684,6 +685,9 @@ const renderComponentsFilters = (
   </div>
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
+  </div>
+  <div>
+    <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <button type="submit">Filter</button>
 </form>`

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -21,6 +22,7 @@ interface SearchRow {
   price1: number | null
   basic: number | null
   preferred: number | null
+  is_extended_promotional: number | null
   category: string | null
   subcategory: string | null
 }
@@ -110,6 +112,13 @@ export async function searchIndex(
     conditions.push(sql`search_index.preferred = 1`)
   }
 
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`search_index.is_extended_promotional = 1`)
+  }
+
   const raw = params.q?.trim()
 
   if (raw) {
@@ -151,6 +160,7 @@ export async function searchIndex(
       search_index.price1,
       search_index.basic,
       search_index.preferred,
+      search_index.is_extended_promotional,
       search_index.category,
       search_index.subcategory
     FROM search_index

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -139,6 +139,37 @@ describe("render helpers", () => {
     expect(html).toContain("/hdmi_ports/list.json")
   })
 
+  it("renders the component catalog page with extended promotional filter", () => {
+    const html = renderD1TablePage(
+      "/components/list",
+      {
+        components: [
+          {
+            lcsc: 23456,
+            mfr: "HDMI-EXT",
+            package: "SMD",
+            description: "Extended promotional HDMI part",
+            is_extended_promotional: true,
+          },
+        ],
+      },
+      {
+        search: "HDMI",
+        is_extended_promotional: "true",
+      },
+      "https://jlcsearch.tscircuit.com/components/list?search=HDMI&is_extended_promotional=true",
+    )
+
+    expect(html).toContain("<h2>Components</h2>")
+    expect(html).toContain('name="is_basic"')
+    expect(html).toContain('name="is_preferred"')
+    expect(html).toContain(
+      'name="is_extended_promotional" value="true" checked',
+    )
+    expect(html).toContain(">Extended Promotional</th>")
+    expect(html).toContain("HDMI-EXT")
+  })
+
   it("renders ARM processor memory sizes with byte units", () => {
     const html = renderD1TablePage(
       "/arm_processors/list",

--- a/scripts/build-derived-sync-db.ts
+++ b/scripts/build-derived-sync-db.ts
@@ -93,6 +93,8 @@ export const buildDerivedSyncDatabase = async ({
       j.fetched_at AS last_update,
       j.sync_seen AS flag,
       CASE WHEN j.stock > 0 THEN 1 ELSE 0 END AS in_stock,
+      CASE WHEN j.library_type = 'extended' THEN 1 ELSE 0 END AS extended,
+      CASE WHEN j.library_type = 'extended' THEN 1 ELSE 0 END AS is_extended_promotional,
       json_object(
         'attributes',
         json(
@@ -136,6 +138,7 @@ export const buildDerivedSyncDatabase = async ({
         j.package,
         CASE WHEN j.library_type = 'base' THEN 1 ELSE 0 END AS basic,
         j.preferred,
+        CASE WHEN j.library_type = 'extended' THEN 1 ELSE 0 END AS is_extended_promotional,
         j.description,
         j.stock,
         j.price,

--- a/tests/build-derived-sync-db.test.ts
+++ b/tests/build-derived-sync-db.test.ts
@@ -65,12 +65,39 @@ const createSourceDatabase = async () => {
 
   source
     .query(
+      `INSERT INTO jlc_components (
+        lcsc, fetched_at, present, sync_seen, category, subcategory, mfr,
+        package, joints, manufacturer, library_type, preferred, last_on_stock,
+        description, datasheet, stock, price, attributes
+      ) VALUES (
+        23456, unixepoch(), 1, 1, 'Connectors',
+        'HDMI Connectors', 'HDMI-EXT', 'SMD', 19, 'Example', 'extended', 0,
+        unixepoch(), 'Extended promotional HDMI part', '', 125,
+        '1-:1.50',
+        '{"Connector Type":"HDMI","Number of Pins":"19"}'
+      )`,
+    )
+    .run()
+
+  source
+    .query(
       `INSERT INTO lcsc_components (
         lcsc, fetched_at, manufacturer, attributes, image, url_slug
       ) VALUES (
         12345, unixepoch(), 'Example Inc.',
         '{"Gender":"Female","Mounting Style":"Surface Mount"}',
         'example.jpg', 'hdmi-19p'
+      )`,
+    )
+    .run()
+  source
+    .query(
+      `INSERT INTO lcsc_components (
+        lcsc, fetched_at, manufacturer, attributes, image, url_slug
+      ) VALUES (
+        23456, unixepoch(), 'Example Inc.',
+        '{"Gender":"Female","Mounting Style":"Surface Mount"}',
+        'example-extended.jpg', 'hdmi-ext'
       )`,
     )
     .run()
@@ -104,7 +131,8 @@ describe("buildDerivedSyncDatabase", () => {
         `SELECT
           lcsc, price1, number_of_pins, gender, mounting_style,
           is_basic, is_preferred
-        FROM hdmi_port`,
+        FROM hdmi_port
+        WHERE lcsc = 12345`,
       )
       .get() as Record<string, unknown>
 
@@ -148,24 +176,27 @@ describe("buildDerivedSyncDatabase", () => {
     const row = output
       .query(
         `SELECT
-          lcsc, mfr, category, subcategory, basic, preferred, stock,
+          lcsc, mfr, category, subcategory, basic, preferred,
+          is_extended_promotional, stock,
           json_extract(extra, '$.manufacturer.name') AS manufacturer,
           json_extract(extra, '$.mpn') AS mpn,
           json_extract(extra, '$.attributes.Gender') AS gender
-        FROM component_catalog`,
+        FROM component_catalog
+        WHERE lcsc = 23456`,
       )
       .get() as Record<string, unknown>
 
     expect(row).toEqual({
-      lcsc: 12345,
-      mfr: "HDMI-19P",
+      lcsc: 23456,
+      mfr: "HDMI-EXT",
       category: "Connectors",
       subcategory: "HDMI Connectors",
-      basic: 1,
-      preferred: 1,
-      stock: 250,
+      basic: 0,
+      preferred: 0,
+      is_extended_promotional: 1,
+      stock: 125,
       manufacturer: "Example Inc.",
-      mpn: "HDMI-19P",
+      mpn: "HDMI-EXT",
       gender: "Female",
     })
     output.close()
@@ -204,6 +235,7 @@ describe("buildDerivedSyncDatabase", () => {
         .all(),
     ).toEqual([
       { lcsc: 12345, stock: 250 },
+      { lcsc: 23456, stock: 125 },
       { lcsc: 54321, stock: 0 },
     ])
     output.close()


### PR DESCRIPTION
## Summary
- add an is_extended_promotional flag to derived component catalog/search-index data
- expose the flag in /components/list JSON and table rendering
- add a filter checkbox for extended promotional parts and wire it into search queries

/claim #92
Fixes #92

## Tests
- bun test tests/build-derived-sync-db.test.ts cf-proxy/test/render.test.ts
- bun run format:check
- bash -n cf-proxy/scripts/sync-db.sh cf-proxy/scripts/rebuild-search-index-batched.sh
- bun test cf-proxy/test/contracts.test.ts