### PR TITLE
Add footprinter string backfill and lookup API

### DIFF
--- a/.github/workflows/populate-footprinter-strings.yml
+++ b/.github/workflows/populate-footprinter-strings.yml
@@ -1,0 +1,80 @@
+name: Populate footprinter strings
+
+on:
+  workflow_dispatch:
+    inputs:
+      max_runtime_minutes:
+        description: Sequential processing time (1-60 minutes)
+        required: true
+        default: "60"
+        type: string
+      retry_null_entries:
+        description: Reprocess rows whose footprinter string is null
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-d1-sync
+  cancel-in-progress: false
+
+jobs:
+  populate:
+    name: Populate production D1
+    runs-on: ubuntu-latest
+    timeout-minutes: 65
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Validate inputs and credentials
+        env:
+          MAX_RUNTIME_MINUTES: ${{ inputs.max_runtime_minutes }}
+        run: |
+          if [[ -z "${CLOUDFLARE_ACCOUNT_ID}" || -z "${CLOUDFLARE_API_TOKEN}" ]]; then
+            echo "::error::Cloudflare credentials are not configured."
+            exit 1
+          fi
+          if [[ ! "${MAX_RUNTIME_MINUTES}" =~ ^[0-9]+$ ]] || (( MAX_RUNTIME_MINUTES < 1 || MAX_RUNTIME_MINUTES > 60 )); then
+            echo "::error::max_runtime_minutes must be an integer from 1 through 60."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: |
+          bun install --ignore-scripts
+          bun install --cwd cf-proxy --frozen-lockfile
+
+      - name: Apply production D1 migrations
+        working-directory: cf-proxy
+        run: bash scripts/retry-command.sh bunx wrangler d1 migrations apply jlcsearch --remote
+
+      - name: Populate footprinter strings
+        env:
+          MAX_RUNTIME_MINUTES: ${{ inputs.max_runtime_minutes }}
+          RETRY_NULL_ENTRIES: ${{ inputs.retry_null_entries }}
+        run: |
+          args=(--max-runtime-minutes "${MAX_RUNTIME_MINUTES}")
+          if [[ "${RETRY_NULL_ENTRIES}" == "true" ]]; then
+            args+=(--retry-null-entries)
+          fi
+          bun run populate:footprinter-strings -- "${args[@]}"
+
+      - name: Report production row counts
+        if: always()
+        working-directory: cf-proxy
+        run: |
+          bunx wrangler d1 execute jlcsearch --remote \
+            --command "SELECT COUNT(*) AS attempted, COUNT(footprinter_string) AS matched FROM footprinter_strings;"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,26 @@ curl https://jlcsearch.tscircuit.com/resistors/list.json?package=&resistance=1k
 #      ...
 ```
 
+Look up a generated tscircuit footprinter string by numeric or `C`-prefixed
+LCSC number:
+
+```bash
+curl https://jlcsearch.tscircuit.com/api/footprinter_strings/C2906861
+
+# {
+#   "component_footprinter_details": {
+#     "lcsc": 2906861,
+#     "footprinter_string": "sod723_p0.865mm_pw0.54mm_pl0.57mm",
+#     "copper_iou": 0.9923751612092405,
+#     "updated_at": "2026-08-12 04:34:12"
+#   }
+# }
+```
+
+A `200` response with a null `footprinter_string` means the component was
+processed without a match above 95% copper IoU. A `404` means the component has
+not been processed yet.
+
 ## Development
 
 [Bun](https://bun.com/) is required. Install dependencies for both the data

--- a/cf-proxy/migrations/0004_footprinter_strings.sql
+++ b/cf-proxy/migrations/0004_footprinter_strings.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS footprinter_strings (
+  lcsc INTEGER PRIMARY KEY,
+  footprinter_string TEXT,
+  copper_iou REAL,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CHECK (copper_iou IS NULL OR (copper_iou >= 0 AND copper_iou <= 1)),
+  CHECK (
+    footprinter_string IS NULL
+    OR (copper_iou IS NOT NULL AND copper_iou > 0.95)
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_footprinter_strings_copper_iou
+  ON footprinter_strings (copper_iou);

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -987,6 +987,13 @@ export interface WireToBoardConnector {
   stock: number | null
 }
 
+export interface FootprinterStrings {
+  copper_iou: number | null
+  footprinter_string: string | null
+  lcsc: number
+  updated_at: Generated<string>
+}
+
 export interface DB {
   accelerometer: Accelerometer
   adc: Adc
@@ -1004,6 +1011,7 @@ export interface DB {
   dimm_connector: DimmConnector
   fpc_connector: FpcConnector
   fpga: Fpga
+  footprinter_strings: FootprinterStrings
   fuse: Fuse
   gas_sensor: GasSensor
   gyroscope: Gyroscope

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -19,6 +19,7 @@ const HOME_PAGE_CACHE_CONTROL = [
   `s-maxage=${HOME_PAGE_CACHE_MAX_AGE_SECONDS}`,
   "must-revalidate",
 ].join(", ")
+const FOOTPRINTER_STRINGS_API_PREFIX = "/api/footprinter_strings/"
 
 const extractSmallQuantityPrice = (price: string | null): string | number => {
   if (!price) return ""
@@ -83,6 +84,26 @@ const buildD1NotFoundResponse = (
     status: 404,
     headers,
   })
+}
+
+const buildD1InvalidLcscResponse = (origin: string | null): Response => {
+  const headers = new Headers({
+    "cache-control": "no-store",
+    "content-type": "application/json",
+    "x-data-source": "d1",
+    "x-cache": "D1",
+  })
+  addCorsHeaders(headers, origin)
+
+  return new Response(
+    JSON.stringify({
+      error: {
+        error_code: "invalid_lcsc",
+        message: "LCSC must be a positive integer with an optional C prefix",
+      },
+    }),
+    { status: 400, headers },
+  )
 }
 
 const getPreferredContentType = (
@@ -310,6 +331,10 @@ async function tryD1Route(
 
   const pathname = url.pathname.replace(/\.json$/, "")
 
+  if (pathname.startsWith(FOOTPRINTER_STRINGS_API_PREFIX)) {
+    return handleD1FootprinterString(pathname, env, origin)
+  }
+
   if (pathname === "/api/search") {
     return handleCachedD1Response(
       url,
@@ -351,6 +376,60 @@ async function tryD1Route(
     async () => handleD1TableRoute(pathname, url, isJsonRequest, env, origin),
     { cacheBust },
   )
+}
+
+const parseLcscPathParameter = (pathname: string): number | null => {
+  const rawLcsc = pathname.slice(FOOTPRINTER_STRINGS_API_PREFIX.length)
+  const normalizedLcsc = rawLcsc.replace(/^c/i, "")
+  if (!/^\d+$/.test(normalizedLcsc)) return null
+
+  const lcsc = Number(normalizedLcsc)
+  return Number.isSafeInteger(lcsc) && lcsc > 0 ? lcsc : null
+}
+
+async function handleD1FootprinterString(
+  pathname: string,
+  env: Env,
+  origin: string | null,
+): Promise<Response> {
+  const lcsc = parseLcscPathParameter(pathname)
+  if (lcsc === null) return buildD1InvalidLcscResponse(origin)
+
+  try {
+    const db = getD1Client(env.DB)
+    const row = await db
+      .selectFrom("footprinter_strings")
+      .select(["lcsc", "footprinter_string", "copper_iou", "updated_at"])
+      .where("lcsc", "=", lcsc)
+      .executeTakeFirst()
+
+    if (!row) {
+      const response = buildD1NotFoundResponse(origin)
+      response.headers.set("cache-control", "no-store")
+      return response
+    }
+
+    const headers = new Headers({
+      "cache-control": "no-store",
+      "content-type": "application/json",
+      "x-data-source": "d1",
+      "x-cache": "D1",
+    })
+    addCorsHeaders(headers, origin)
+
+    return new Response(
+      JSON.stringify({ component_footprinter_details: row }),
+      { status: 200, headers },
+    )
+  } catch (error) {
+    console.error(`D1 footprinter string lookup failed for C${lcsc}:`, error)
+    return buildD1ErrorResponse(
+      origin,
+      error instanceof Error
+        ? error.message
+        : "Unknown D1 footprinter string lookup error",
+    )
+  }
 }
 
 async function handleD1Search(

--- a/cf-proxy/test/test-env.ts
+++ b/cf-proxy/test/test-env.ts
@@ -77,6 +77,25 @@ export const createTestEnv = () => ({
   DB: {} as D1Database,
 })
 
+export const createFootprinterStringsD1 = (
+  rows: Array<{
+    copper_iou: number | null
+    footprinter_string: string | null
+    lcsc: number
+    updated_at: string
+  }>,
+): D1Database =>
+  ({
+    prepare: () => ({
+      bind: (lcsc: number) => ({
+        all: async () => ({
+          results: rows.filter((row) => row.lcsc === lcsc),
+          meta: { changes: 0 },
+        }),
+      }),
+    }),
+  }) as unknown as D1Database
+
 export const createSelf = (env: ReturnType<typeof createTestEnv>) => ({
   pending: [] as Promise<unknown>[],
   fetch(input: RequestInfo | URL, init?: RequestInit) {

--- a/cf-proxy/test/worker.test.ts
+++ b/cf-proxy/test/worker.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest"
 import { generateCacheKey } from "../src/cache-key"
-import { createSelf, createTestEnv } from "./test-env"
+import {
+  createFootprinterStringsD1,
+  createSelf,
+  createTestEnv,
+} from "./test-env"
 
 describe("Worker integration", () => {
   const env = createTestEnv()
@@ -8,6 +12,7 @@ describe("Worker integration", () => {
 
   beforeEach(async () => {
     env.USE_D1 = "false"
+    env.DB = createFootprinterStringsD1([])
 
     const keys = await env.CACHE_KV.list()
     for (const key of keys.keys) {
@@ -70,6 +75,96 @@ describe("Worker integration", () => {
       error: {
         error_code: "not_found",
         message: "Not Found",
+      },
+    })
+  })
+
+  it("returns component footprinter details for a C-prefixed LCSC", async () => {
+    env.USE_D1 = "true"
+    env.DB = createFootprinterStringsD1([
+      {
+        lcsc: 2906861,
+        footprinter_string: "sod723_p0.865mm_pw0.54mm_pl0.57mm",
+        copper_iou: 0.9923751612092405,
+        updated_at: "2026-08-12 04:34:12",
+      },
+    ])
+
+    const response = await SELF.fetch(
+      "https://example.com/api/footprinter_strings/C2906861",
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("content-type")).toContain("application/json")
+    expect(response.headers.get("cache-control")).toBe("no-store")
+    expect(response.headers.get("x-cache")).toBe("D1")
+    expect(await response.json()).toEqual({
+      component_footprinter_details: {
+        lcsc: 2906861,
+        footprinter_string: "sod723_p0.865mm_pw0.54mm_pl0.57mm",
+        copper_iou: 0.9923751612092405,
+        updated_at: "2026-08-12 04:34:12",
+      },
+    })
+  })
+
+  it("returns a processed nullable footprinter row for a numeric LCSC", async () => {
+    env.USE_D1 = "true"
+    env.DB = createFootprinterStringsD1([
+      {
+        lcsc: 123,
+        footprinter_string: null,
+        copper_iou: 0.94,
+        updated_at: "2026-08-12 05:00:00",
+      },
+    ])
+
+    const response = await SELF.fetch(
+      "https://example.com/api/footprinter_strings/123",
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      component_footprinter_details: {
+        lcsc: 123,
+        footprinter_string: null,
+        copper_iou: 0.94,
+        updated_at: "2026-08-12 05:00:00",
+      },
+    })
+  })
+
+  it("returns 404 when an LCSC has not been processed", async () => {
+    env.USE_D1 = "true"
+
+    const response = await SELF.fetch(
+      "https://example.com/api/footprinter_strings/C404",
+    )
+
+    expect(response.status).toBe(404)
+    expect(response.headers.get("cache-control")).toBe("no-store")
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: {
+        error_code: "not_found",
+        message: "Not Found",
+      },
+    })
+  })
+
+  it("returns 400 for an invalid footprinter LCSC", async () => {
+    env.USE_D1 = "true"
+
+    const response = await SELF.fetch(
+      "https://example.com/api/footprinter_strings/not-an-lcsc",
+    )
+
+    expect(response.status).toBe(400)
+    expect(response.headers.get("cache-control")).toBe("no-store")
+    expect(await response.json()).toEqual({
+      error: {
+        error_code: "invalid_lcsc",
+        message: "LCSC must be a positive integer with an optional C prefix",
       },
     })
   })

--- a/lib/footprinter-strings.ts
+++ b/lib/footprinter-strings.ts
@@ -1,0 +1,57 @@
+export const COPPER_IOU_THRESHOLD = 0.95
+
+export interface FootprinterCandidate {
+  copperIntersectionOverUnion: number
+  footprinterString: string
+}
+
+export interface FootprinterStringRow {
+  copperIou: number | null
+  footprinterString: string | null
+  lcsc: number
+}
+
+export const createFootprinterStringRow = (
+  lcsc: number,
+  candidate: FootprinterCandidate | null | undefined,
+): FootprinterStringRow => {
+  const copperIou = candidate?.copperIntersectionOverUnion ?? null
+
+  return {
+    lcsc,
+    footprinterString:
+      copperIou !== null && copperIou > COPPER_IOU_THRESHOLD
+        ? candidate!.footprinterString
+        : null,
+    copperIou,
+  }
+}
+
+const sqlString = (value: string): string => `'${value.replaceAll("'", "''")}'`
+
+export const buildFootprinterStringUpsert = (
+  rows: readonly FootprinterStringRow[],
+): string => {
+  if (rows.length === 0) {
+    throw new Error("Cannot build a footprinter_strings upsert without rows")
+  }
+
+  const values = rows
+    .map(
+      (row) =>
+        `(${row.lcsc}, ${row.footprinterString === null ? "NULL" : sqlString(row.footprinterString)}, ${row.copperIou ?? "NULL"}, CURRENT_TIMESTAMP)`,
+    )
+    .join(",\n  ")
+
+  return `INSERT INTO footprinter_strings (
+  lcsc,
+  footprinter_string,
+  copper_iou,
+  updated_at
+) VALUES
+  ${values}
+ON CONFLICT(lcsc) DO UPDATE SET
+  footprinter_string = excluded.footprinter_string,
+  copper_iou = excluded.copper_iou,
+  updated_at = CURRENT_TIMESTAMP;`
+}

--- a/package.json
+++ b/package.json
@@ -22,12 +22,15 @@
     "setup:optimize-db": "bun run scripts/setup-db-optimizations.ts",
     "setup:derived-tables": "bun run scripts/setup-derived-tables.ts",
     "setup:derived-sync-db": "bun run scripts/build-derived-sync-db.ts",
+    "populate:footprinter-strings": "bun run scripts/populate-footprinter-strings.ts",
     "format": "biome format --write .",
     "format:check": "biome format ."
   },
   "type": "module",
   "dependencies": {
     "@tscircuit/footprinter": "^0.0.143",
+    "circuit-json-to-footprinter": "^0.0.40",
+    "easyeda": "^0.0.286",
     "format-si-unit": "^0.0.10",
     "kysely-bun-sqlite": "^0.3.2"
   }

--- a/scripts/populate-footprinter-strings.ts
+++ b/scripts/populate-footprinter-strings.ts
@@ -1,0 +1,338 @@
+import { join } from "node:path"
+import { circuitJsonToFootprinter } from "circuit-json-to-footprinter"
+import { EasyEdaJsonSchema, convertEasyEdaJsonToCircuitJson } from "easyeda"
+import { fetchEasyEDAComponent } from "easyeda/browser"
+import {
+  COPPER_IOU_THRESHOLD,
+  type FootprinterStringRow,
+  buildFootprinterStringUpsert,
+  createFootprinterStringRow,
+} from "../lib/footprinter-strings"
+
+const DATABASE_NAME = "jlcsearch"
+const DEFAULT_RUNTIME_MINUTES = 60
+const QUERY_BATCH_SIZE = 25
+const WRITE_BATCH_SIZE = 10
+const FETCH_TIMEOUT_MS = 20_000
+const RATE_LIMIT_COOLDOWN_MS = 120_000
+const GRACE_PERIOD_MS = 45_000
+const CF_PROXY_DIRECTORY = join(import.meta.dir, "../cf-proxy")
+
+interface ComponentCatalogRow {
+  description: string | null
+  lcsc: number
+  mfr: string | null
+  package: string | null
+  stock: number
+}
+
+interface Cursor {
+  lcsc: number
+  stock: number
+}
+
+interface Options {
+  maxComponents: number | null
+  maxRuntimeMinutes: number
+  retryNullEntries: boolean
+}
+
+interface WranglerResult {
+  results?: unknown
+  success?: boolean
+}
+
+let stopRequested = false
+const stopController = new AbortController()
+
+const requestGracefulStop = (signal: string) => {
+  console.log(`Received ${signal}; stopping and flushing completed components.`)
+  stopRequested = true
+  stopController.abort(signal)
+}
+
+process.on("SIGINT", () => requestGracefulStop("SIGINT"))
+process.on("SIGTERM", () => requestGracefulStop("SIGTERM"))
+
+const parsePositiveInteger = (value: string, name: string): number => {
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`)
+  }
+  return parsed
+}
+
+const parseOptions = (args: readonly string[]): Options => {
+  const options: Options = {
+    maxComponents: null,
+    maxRuntimeMinutes: DEFAULT_RUNTIME_MINUTES,
+    retryNullEntries: false,
+  }
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (argument === "--retry-null-entries") {
+      options.retryNullEntries = true
+      continue
+    }
+
+    const value = args[index + 1]
+    if (!value) throw new Error(`Missing value for ${argument}`)
+
+    if (argument === "--max-components") {
+      options.maxComponents = parsePositiveInteger(value, argument)
+    } else if (argument === "--max-runtime-minutes") {
+      options.maxRuntimeMinutes = parsePositiveInteger(value, argument)
+      if (options.maxRuntimeMinutes > DEFAULT_RUNTIME_MINUTES) {
+        throw new Error(
+          `--max-runtime-minutes cannot exceed ${DEFAULT_RUNTIME_MINUTES}`,
+        )
+      }
+    } else {
+      throw new Error(`Unknown argument: ${argument}`)
+    }
+    index += 1
+  }
+
+  return options
+}
+
+const runWrangler = async (args: readonly string[]): Promise<unknown> => {
+  const child = Bun.spawn(["bunx", "wrangler", ...args], {
+    cwd: CF_PROXY_DIRECTORY,
+    env: process.env,
+    stderr: "inherit",
+    stdout: "pipe",
+  })
+  const output = await new Response(child.stdout).text()
+  const exitCode = await child.exited
+  if (exitCode !== 0) {
+    throw new Error(`Wrangler exited with code ${exitCode}`)
+  }
+
+  try {
+    return JSON.parse(output)
+  } catch {
+    throw new Error(`Wrangler returned invalid JSON: ${output.slice(0, 500)}`)
+  }
+}
+
+const getWranglerRows = (payload: unknown): unknown[] => {
+  const entries = Array.isArray(payload) ? payload : [payload]
+  for (const entry of entries) {
+    const result = entry as WranglerResult
+    if (result.success === false) throw new Error("Wrangler D1 query failed")
+    if (Array.isArray(result.results)) return result.results
+  }
+  return []
+}
+
+const buildComponentQuery = (
+  cursor: Cursor | null,
+  retryNullEntries: boolean,
+): string => {
+  const unprocessedCondition = retryNullEntries
+    ? "(f.lcsc IS NULL OR f.footprinter_string IS NULL)"
+    : "f.lcsc IS NULL"
+  const cursorCondition = cursor
+    ? `AND (
+      c.stock < ${cursor.stock}
+      OR (c.stock = ${cursor.stock} AND c.lcsc > ${cursor.lcsc})
+    )`
+    : ""
+
+  return `SELECT
+  c.lcsc,
+  c.mfr,
+  c.package,
+  c.description,
+  c.stock
+FROM component_catalog AS c
+LEFT JOIN footprinter_strings AS f ON f.lcsc = c.lcsc
+WHERE c.lcsc IS NOT NULL
+  AND ${unprocessedCondition}
+  ${cursorCondition}
+ORDER BY c.stock DESC, c.lcsc ASC
+LIMIT ${QUERY_BATCH_SIZE};`
+}
+
+const fetchComponents = async (
+  cursor: Cursor | null,
+  retryNullEntries: boolean,
+): Promise<ComponentCatalogRow[]> => {
+  const payload = await runWrangler([
+    "d1",
+    "execute",
+    DATABASE_NAME,
+    "--remote",
+    "--json",
+    "--command",
+    buildComponentQuery(cursor, retryNullEntries),
+  ])
+
+  return getWranglerRows(payload).map((row) => {
+    const component = row as ComponentCatalogRow
+    return {
+      ...component,
+      lcsc: Number(component.lcsc),
+      stock: Number(component.stock),
+    }
+  })
+}
+
+const fetchWithTimeout: typeof fetch = Object.assign(
+  (input: Parameters<typeof fetch>[0], init: RequestInit = {}) => {
+    const signals = [
+      stopController.signal,
+      AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    ]
+    if (init.signal) signals.push(init.signal)
+
+    return fetch(input, {
+      ...init,
+      signal: AbortSignal.any(signals),
+    })
+  },
+  { preconnect: fetch.preconnect },
+)
+
+const deriveFootprinterRow = async (
+  component: ComponentCatalogRow,
+): Promise<FootprinterStringRow> => {
+  const lcsc = `C${component.lcsc}`
+  const rawEasyEdaJson = await fetchEasyEDAComponent(lcsc, {
+    fetch: fetchWithTimeout,
+    includeModelMetadata: false,
+  })
+  const circuitJson = convertEasyEdaJsonToCircuitJson(
+    EasyEdaJsonSchema.parse(rawEasyEdaJson),
+    { useModelCdn: false },
+  )
+  const sourceHint = [
+    lcsc,
+    component.mfr,
+    component.package,
+    component.description,
+  ]
+    .filter(Boolean)
+    .join(" ")
+  const discovery = circuitJsonToFootprinter(circuitJson, {
+    maxCandidates: 3,
+    sourceHints: [sourceHint],
+  })
+
+  return createFootprinterStringRow(component.lcsc, discovery.best)
+}
+
+const flushRows = async (rows: FootprinterStringRow[]): Promise<void> => {
+  if (rows.length === 0) return
+
+  await runWrangler([
+    "d1",
+    "execute",
+    DATABASE_NAME,
+    "--remote",
+    "--json",
+    "--command",
+    buildFootprinterStringUpsert(rows),
+  ])
+  console.log(`Saved ${rows.length} footprinter_strings rows.`)
+  rows.length = 0
+}
+
+const waitForRateLimit = async (deadline: number): Promise<boolean> => {
+  if (Date.now() + RATE_LIMIT_COOLDOWN_MS + GRACE_PERIOD_MS >= deadline) {
+    console.log(
+      "EasyEDA rate limit reached too near the deadline; exiting cleanly.",
+    )
+    return false
+  }
+
+  console.log(
+    "EasyEDA rate limit reached; waiting 120 seconds before continuing.",
+  )
+  const cooldownEndsAt = Date.now() + RATE_LIMIT_COOLDOWN_MS
+  while (!stopRequested && Date.now() < cooldownEndsAt) {
+    await Bun.sleep(Math.min(1_000, cooldownEndsAt - Date.now()))
+  }
+  return !stopRequested
+}
+
+const main = async () => {
+  const options = parseOptions(Bun.argv.slice(2))
+  const startedAt = Date.now()
+  const deadline = startedAt + options.maxRuntimeMinutes * 60_000
+  const pendingRows: FootprinterStringRow[] = []
+  let cursor: Cursor | null = null
+  let attempted = 0
+  let failed = 0
+  let matched = 0
+  let recorded = 0
+
+  console.log(
+    `Populating footprinter_strings sequentially for up to ${options.maxRuntimeMinutes} minute(s); strings require copper_iou > ${COPPER_IOU_THRESHOLD}.`,
+  )
+
+  while (!stopRequested && Date.now() + GRACE_PERIOD_MS < deadline) {
+    const components = await fetchComponents(cursor, options.retryNullEntries)
+    if (components.length === 0) {
+      console.log("No more eligible component_catalog rows were found.")
+      break
+    }
+
+    for (const component of components) {
+      cursor = { lcsc: component.lcsc, stock: component.stock }
+      if (
+        stopRequested ||
+        Date.now() + GRACE_PERIOD_MS >= deadline ||
+        (options.maxComponents !== null && attempted >= options.maxComponents)
+      ) {
+        break
+      }
+
+      attempted += 1
+      try {
+        const row = await deriveFootprinterRow(component)
+        pendingRows.push(row)
+        recorded += 1
+        if (row.footprinterString !== null) matched += 1
+        console.log(
+          `C${component.lcsc}: ${row.footprinterString ?? "no >95% match"} (${row.copperIou?.toFixed(4) ?? "no candidate"})`,
+        )
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        if (message.includes("rate limit exceeded")) {
+          attempted -= 1
+          if (!(await waitForRateLimit(deadline))) {
+            stopRequested = true
+            break
+          }
+          continue
+        }
+        failed += 1
+        console.warn(
+          `C${component.lcsc}: ${message}; leaving it eligible to retry.`,
+        )
+      }
+
+      if (pendingRows.length >= WRITE_BATCH_SIZE) {
+        await flushRows(pendingRows)
+      }
+    }
+
+    if (options.maxComponents !== null && attempted >= options.maxComponents) {
+      console.log(`Reached the ${options.maxComponents}-component limit.`)
+      break
+    }
+  }
+
+  await flushRows(pendingRows)
+  const elapsedSeconds = ((Date.now() - startedAt) / 1000).toFixed(1)
+  console.log(
+    `Finished cleanly after ${elapsedSeconds}s: ${attempted} attempted, ${recorded} recorded, ${matched} matched, ${failed} failed.`,
+  )
+}
+
+if (import.meta.main) {
+  await main()
+}

--- a/tests/footprinter-strings.test.ts
+++ b/tests/footprinter-strings.test.ts
@@ -1,0 +1,85 @@
+import { Database } from "bun:sqlite"
+import { describe, expect, test } from "bun:test"
+import {
+  COPPER_IOU_THRESHOLD,
+  buildFootprinterStringUpsert,
+  createFootprinterStringRow,
+} from "../lib/footprinter-strings"
+
+describe("createFootprinterStringRow", () => {
+  test("keeps strings strictly above the copper IoU threshold", () => {
+    expect(
+      createFootprinterStringRow(123, {
+        footprinterString: "soic8",
+        copperIntersectionOverUnion: COPPER_IOU_THRESHOLD + 0.0001,
+      }),
+    ).toEqual({
+      lcsc: 123,
+      footprinterString: "soic8",
+      copperIou: COPPER_IOU_THRESHOLD + 0.0001,
+    })
+  })
+
+  test("stores a nullable string at or below the threshold", () => {
+    expect(
+      createFootprinterStringRow(456, {
+        footprinterString: "qfn16",
+        copperIntersectionOverUnion: COPPER_IOU_THRESHOLD,
+      }),
+    ).toEqual({
+      lcsc: 456,
+      footprinterString: null,
+      copperIou: COPPER_IOU_THRESHOLD,
+    })
+  })
+
+  test("allows a fully null discovery result", () => {
+    expect(createFootprinterStringRow(789, null)).toEqual({
+      lcsc: 789,
+      footprinterString: null,
+      copperIou: null,
+    })
+  })
+})
+
+test("buildFootprinterStringUpsert escapes strings and preserves nulls", () => {
+  const sql = buildFootprinterStringUpsert([
+    { lcsc: 123, footprinterString: "pinrow4_note('x')", copperIou: 0.99 },
+    { lcsc: 456, footprinterString: null, copperIou: null },
+  ])
+
+  expect(sql).toContain("pinrow4_note(''x'')")
+  expect(sql).toContain("(456, NULL, NULL, CURRENT_TIMESTAMP)")
+  expect(sql).toContain("ON CONFLICT(lcsc) DO UPDATE")
+})
+
+test("D1 migration allows null matches and enforces the IoU threshold", async () => {
+  const database = new Database(":memory:")
+  const migrationPath = new URL(
+    "../cf-proxy/migrations/0004_footprinter_strings.sql",
+    import.meta.url,
+  )
+  const migration = await Bun.file(migrationPath).text()
+
+  try {
+    database.exec(migration)
+    database.exec(migration)
+    database.exec(
+      "INSERT INTO footprinter_strings (lcsc, footprinter_string, copper_iou) VALUES (1, NULL, NULL)",
+    )
+    database.exec(
+      "INSERT INTO footprinter_strings (lcsc, footprinter_string, copper_iou) VALUES (2, 'soic8', 0.951)",
+    )
+
+    expect(() =>
+      database.exec(
+        "INSERT INTO footprinter_strings (lcsc, footprinter_string, copper_iou) VALUES (3, 'qfn16', 0.95)",
+      ),
+    ).toThrow()
+    expect(
+      database.query("SELECT COUNT(*) AS count FROM footprinter_strings").get(),
+    ).toEqual({ count: 2 })
+  } finally {
+    database.close()
+  }
+})


### PR DESCRIPTION
## Summary

- add the production D1 `footprinter_strings` table keyed by numeric LCSC ID
- store `footprinter_string` only when `copper_iou > 0.95`, while allowing nullable results for attempted components without a qualifying match
- derive mappings sequentially with `circuit-json-to-footprinter` from EasyEDA Circuit JSON
- add a manually dispatched, production-serialized workflow that runs for at most 60 minutes, batches writes, handles rate limits, and flushes completed work on timeout or termination
- expose `GET /api/footprinter_strings/:lcsc` for numeric or `C`-prefixed identifiers
- return API results under the `component_footprinter_details` top-level key, with nullable matches preserved
- return `404` for unprocessed components and `400` for invalid identifiers without long-lived caching

## Impact

This creates a queryable LCSC-to-tscircuit-footprinter mapping, an incremental production backfill, and a direct lookup API. Existing component/search response contracts are unchanged.

## API

```http
GET /api/footprinter_strings/C2906861
```

```json
{
  "component_footprinter_details": {
    "lcsc": 2906861,
    "footprinter_string": "sod723_p0.865mm_pw0.54mm_pl0.57mm",
    "copper_iou": 0.9923751612092405,
    "updated_at": "2026-08-12 04:34:12"
  }
}
```

## Validation

- `bun test`: 199 passed
- `bunx tsc --noEmit`
- `bun run format:check`
- `git diff --check`
- local Wrangler Worker smoke test covered `200`, `400`, and `404` responses
- applied all migrations to local Wrangler D1 and verified nullable rows plus the strict greater-than-95% constraint
- applied `0004_footprinter_strings.sql` to production D1 with Wrangler
- ran a three-component production backfill: 3 recorded, 3 matched, 0 failed
- queried the persisted production rows: minimum IoU `0.9923751612`; 0 invalid rows at or below the threshold
