### PR TITLE
Record permanent footprinter source misses

### DIFF
--- a/lib/footprinter-strings.ts
+++ b/lib/footprinter-strings.ts
@@ -11,6 +11,20 @@ export interface FootprinterStringRow {
   lcsc: number
 }
 
+const PERMANENT_EASYEDA_MISS_MESSAGES = [
+  "Component not found",
+  "Failed to fetch the component details (HTTP 404)",
+]
+
+export const isPermanentEasyEdaMiss = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return (
+    PERMANENT_EASYEDA_MISS_MESSAGES.includes(message) ||
+    message.startsWith('No exact EasyEDA component match for "')
+  )
+}
+
 export const createFootprinterStringRow = (
   lcsc: number,
   candidate: FootprinterCandidate | null | undefined,

--- a/scripts/populate-footprinter-strings.ts
+++ b/scripts/populate-footprinter-strings.ts
@@ -7,6 +7,7 @@ import {
   type FootprinterStringRow,
   buildFootprinterStringUpsert,
   createFootprinterStringRow,
+  isPermanentEasyEdaMiss,
 } from "../lib/footprinter-strings"
 
 const DATABASE_NAME = "jlcsearch"
@@ -267,6 +268,7 @@ const main = async () => {
   let attempted = 0
   let failed = 0
   let matched = 0
+  let permanentMisses = 0
   let recorded = 0
 
   console.log(
@@ -309,10 +311,20 @@ const main = async () => {
           }
           continue
         }
-        failed += 1
-        console.warn(
-          `C${component.lcsc}: ${message}; leaving it eligible to retry.`,
-        )
+
+        if (isPermanentEasyEdaMiss(error)) {
+          pendingRows.push(createFootprinterStringRow(component.lcsc, null))
+          recorded += 1
+          permanentMisses += 1
+          console.warn(
+            `C${component.lcsc}: ${message}; recording a permanent null result.`,
+          )
+        } else {
+          failed += 1
+          console.warn(
+            `C${component.lcsc}: ${message}; leaving it eligible to retry.`,
+          )
+        }
       }
 
       if (pendingRows.length >= WRITE_BATCH_SIZE) {
@@ -329,7 +341,7 @@ const main = async () => {
   await flushRows(pendingRows)
   const elapsedSeconds = ((Date.now() - startedAt) / 1000).toFixed(1)
   console.log(
-    `Finished cleanly after ${elapsedSeconds}s: ${attempted} attempted, ${recorded} recorded, ${matched} matched, ${failed} failed.`,
+    `Finished cleanly after ${elapsedSeconds}s: ${attempted} attempted, ${recorded} recorded, ${matched} matched, ${permanentMisses} permanent misses, ${failed} retryable failures.`,
   )
 }
 

--- a/tests/footprinter-strings.test.ts
+++ b/tests/footprinter-strings.test.ts
@@ -4,7 +4,27 @@ import {
   COPPER_IOU_THRESHOLD,
   buildFootprinterStringUpsert,
   createFootprinterStringRow,
+  isPermanentEasyEdaMiss,
 } from "../lib/footprinter-strings"
+
+describe("isPermanentEasyEdaMiss", () => {
+  test.each([
+    "Component not found",
+    'No exact EasyEDA component match for "C123"',
+    "Failed to fetch the component details (HTTP 404)",
+  ])("recognizes a definitive source miss: %s", (message) => {
+    expect(isPermanentEasyEdaMiss(new Error(message))).toBe(true)
+  })
+
+  test.each([
+    'EasyEDA API rate limit exceeded while searching for "C123" (HTTP 403)',
+    "Failed to search for the component (HTTP 500)",
+    "The operation timed out",
+    "Wrangler exited with code 1",
+  ])("keeps a transient failure retryable: %s", (message) => {
+    expect(isPermanentEasyEdaMiss(new Error(message))).toBe(false)
+  })
+})
 
 describe("createFootprinterStringRow", () => {
   test("keeps strings strictly above the copper IoU threshold", () => {


### PR DESCRIPTION
## What changed

- classify definitive EasyEDA source misses separately from transient failures
- record definitive misses as nullable `footprinter_strings` rows
- retain retries for rate limits, timeouts, HTTP 5xx responses, parsing failures, and Wrangler failures
- report permanent misses and retryable failures separately in workflow logs

## Why

The backfill previously left every thrown lookup error unrecorded. As a result, components that EasyEDA definitively does not contain were selected and attempted again on every default workflow run.

The default query already skips existing nullable rows, so recording permanent misses makes the backfill idempotent for those components. The manual `retry_null_entries` workflow input remains available when an intentional refresh is needed.

## Validation

- `bun test` (206 passed)
- `bun run format:check`
- `bunx tsc --noEmit`
