### PR TITLE
Allow four-hour footprinter population runs

### DIFF
--- a/.github/workflows/populate-footprinter-strings.yml
+++ b/.github/workflows/populate-footprinter-strings.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       max_runtime_minutes:
-        description: Processing time (1-60 minutes)
+        description: Processing time (1-240 minutes)
         required: true
-        default: "60"
+        default: "240"
         type: string
       retry_null_entries:
         description: Reprocess rows whose footprinter string is null
@@ -25,7 +25,7 @@ jobs:
   populate:
     name: Populate production D1
     runs-on: ubuntu-latest
-    timeout-minutes: 65
+    timeout-minutes: 250
     env:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -47,8 +47,8 @@ jobs:
             echo "::error::Cloudflare credentials are not configured."
             exit 1
           fi
-          if [[ ! "${MAX_RUNTIME_MINUTES}" =~ ^[0-9]+$ ]] || (( MAX_RUNTIME_MINUTES < 1 || MAX_RUNTIME_MINUTES > 60 )); then
-            echo "::error::max_runtime_minutes must be an integer from 1 through 60."
+          if [[ ! "${MAX_RUNTIME_MINUTES}" =~ ^[0-9]+$ ]] || (( MAX_RUNTIME_MINUTES < 1 || MAX_RUNTIME_MINUTES > 240 )); then
+            echo "::error::max_runtime_minutes must be an integer from 1 through 240."
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ optional `cache_bust_url`. The workflow requires the
 `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` repository secrets.
 
 The manually dispatched **Populate footprinter strings** workflow processes
-the highest-stock unindexed components first. It runs eight component
+the highest-stock unindexed components first for up to four hours by default.
+It runs eight component
 conversions concurrently behind one shared EasyEDA limiter capped at four
 request starts per second. An EasyEDA 403 pauses all requests for two minutes
 and lowers the rest of that run to one request per second. Production D1 reads

--- a/scripts/populate-footprinter-strings.ts
+++ b/scripts/populate-footprinter-strings.ts
@@ -16,7 +16,7 @@ import {
 } from "../lib/polite-rate-limited-fetch"
 
 const DATABASE_NAME = "jlcsearch"
-const DEFAULT_RUNTIME_MINUTES = 60
+const DEFAULT_RUNTIME_MINUTES = 240
 const QUERY_BATCH_SIZE = 250
 const WRITE_BATCH_SIZE = 50
 const COMPONENT_CONCURRENCY = 8


### PR DESCRIPTION
## Summary

- make 240 minutes the population workflow default and maximum
- raise the GitHub Actions job timeout to 250 minutes for setup, graceful flushing, and final reporting
- update the script safety ceiling and workflow documentation

## Why

Longer runs reduce manual dispatch overhead while preserving the existing eight-worker concurrency, shared four request/second EasyEDA limiter, and 403 cooldown behavior.

## Validation

- `bunx tsc --noEmit`
- `bun test tests/polite-rate-limited-fetch.test.ts tests/footprinter-strings.test.ts`
- `bun run format:check`
- `git diff --check`