### PR TITLE
Add shared EasyEDA R2 component cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,28 @@ A `200` response with a null `footprinter_string` means the component was
 processed without a match above 95% copper IoU. A `404` means the component has
 not been processed yet.
 
+Fetch raw EasyEDA component JSON through the shared R2-backed cache:
+
+```bash
+curl https://jlcsearch.tscircuit.com/api/easyeda_components/C2906861
+
+# {
+#   "easyeda_component_details": {
+#     "lcsc": 2906861,
+#     "easyeda_uuid": "...",
+#     "fetched_at": "2026-08-13T16:00:00.000Z",
+#     "easyeda_json": { "...": "..." }
+#   }
+# }
+```
+
+The endpoint normalizes numeric and `C`-prefixed LCSC numbers. It serves fresh
+objects from the shared R2 bucket and fills missing objects from EasyEDA.
+Successful payloads are refreshed after 90 days; definitive not-found results
+are negative-cached for six hours. Callers that only want an existing object
+can add `?cache_only=true`; a `cache_miss` response never contacts EasyEDA.
+The `x-cache` response header reports `R2-HIT`, `R2-MISS`, or `R2-STALE`.
+
 ## Development
 
 [Bun](https://bun.com/) is required. Install dependencies for both the data
@@ -113,12 +135,12 @@ optional `cache_bust_url`. The workflow requires the
 
 The manually dispatched **Populate footprinter strings** workflow processes
 the highest-stock unindexed components first for up to four hours by default.
-It runs eight component
-conversions concurrently behind one shared EasyEDA limiter capped at four
-request starts per second. An EasyEDA 403 pauses all requests for two minutes
-and lowers the rest of that run to one request per second. Production D1 reads
-and writes are batched, and the final log reports request, conversion, D1, and
-CPU timing metrics.
+It runs eight component conversions concurrently and probes the shared EasyEDA
+R2 cache before any upstream request. Cache misses are limited to two component
+fills per second, or about four EasyEDA requests per second. An EasyEDA 403
+pauses all fills for two minutes and lowers the rest of that run to one fill per
+second. Production D1 reads and writes are batched, and the final log reports R2
+hits and misses, fill, conversion, D1, and CPU timing metrics.
 
 ## How Does It work?
 As a developer new to this codebase, or a curious user, you may have some questions about the flow of data through the scripts and automations inside this repo.  It all starts with the [jlcparts](https://github.com/yaqwsx/jlcparts) project, which compiles a massive **11GB** sqlite3 database of *everything* [JLCPCB](https://jlcpcb.com) has to offer.  As you can imagine, this would be very resource-intensive and slow to search, so the next steps are scripts that optimize it heavily, although it's more accurate to say that they rebuild it entirely. 

--- a/cf-proxy/bun.lock
+++ b/cf-proxy/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "cf-proxy",
       "dependencies": {
+        "easyeda": "^0.0.286",
         "kysely": "^0.28.3",
         "kysely-d1": "^0.4.0",
       },
@@ -279,6 +280,8 @@
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "devalue": ["devalue@4.3.3", "", {}, "sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg=="],
+
+    "easyeda": ["easyeda@0.0.286", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda": "dist/main.cjs", "easyeda-converter": "dist/main.cjs" } }, "sha512-FZcQf3TqJmyF69WO1fJvL5G7jtCUWtCBhTC19P+mZfuBGKteGCt9pMCfzLEarIfstIDLJB+xfE72SZpV785qLg=="],
 
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 

--- a/cf-proxy/package.json
+++ b/cf-proxy/package.json
@@ -10,6 +10,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "easyeda": "^0.0.286",
     "kysely": "^0.28.3",
     "kysely-d1": "^0.4.0"
   },

--- a/cf-proxy/src/easyeda-component-cache.ts
+++ b/cf-proxy/src/easyeda-component-cache.ts
@@ -1,0 +1,310 @@
+import { fetchEasyEDAComponent } from "easyeda/browser"
+import { addCorsHeaders } from "./cache-service"
+
+export const EASYEDA_COMPONENTS_API_PREFIX = "/api/easyeda_components/"
+
+const CACHE_SCHEMA_VERSION = 1
+const FOUND_TTL_MS = 90 * 24 * 60 * 60 * 1_000
+const NOT_FOUND_TTL_MS = 6 * 60 * 60 * 1_000
+
+interface FoundCacheEntry {
+  schemaVersion: typeof CACHE_SCHEMA_VERSION
+  status: "found"
+  lcsc: number
+  fetchedAt: string
+  easyedaJson: unknown
+}
+
+interface NotFoundCacheEntry {
+  schemaVersion: typeof CACHE_SCHEMA_VERSION
+  status: "not_found"
+  lcsc: number
+  fetchedAt: string
+  reason: string
+}
+
+type EasyEdaCacheEntry = FoundCacheEntry | NotFoundCacheEntry
+
+type EasyEdaCacheStatus = "R2-HIT" | "R2-MISS" | "R2-STALE"
+
+const inFlightFills = new Map<number, Promise<EasyEdaCacheEntry>>()
+
+const getCacheKey = (lcsc: number): string => `components/C${lcsc}.json`
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+const isPermanentNotFound = (message: string): boolean =>
+  message === "Component not found" ||
+  message.startsWith('No exact EasyEDA component match for "') ||
+  message.includes("Failed to fetch the component details (HTTP 404)")
+
+const getUpstreamStatus = (message: string): number => {
+  const match = message.match(/HTTP (\d{3})/)
+  const status = match ? Number(match[1]) : 502
+  return status >= 400 && status <= 599 ? status : 502
+}
+
+const parseCacheEntry = (
+  value: unknown,
+  lcsc: number,
+): EasyEdaCacheEntry | null => {
+  if (typeof value !== "object" || value === null) return null
+  const entry = value as Partial<EasyEdaCacheEntry>
+  if (
+    entry.schemaVersion !== CACHE_SCHEMA_VERSION ||
+    entry.lcsc !== lcsc ||
+    typeof entry.fetchedAt !== "string" ||
+    !Number.isFinite(Date.parse(entry.fetchedAt))
+  ) {
+    return null
+  }
+  if (entry.status === "found" && "easyedaJson" in entry) {
+    return entry as FoundCacheEntry
+  }
+  if (entry.status === "not_found" && typeof entry.reason === "string") {
+    return entry as NotFoundCacheEntry
+  }
+  return null
+}
+
+const readCacheEntry = async (
+  bucket: R2Bucket,
+  lcsc: number,
+): Promise<EasyEdaCacheEntry | null> => {
+  const object = await bucket.get(getCacheKey(lcsc))
+  if (!object) return null
+  try {
+    return parseCacheEntry(JSON.parse(await object.text()), lcsc)
+  } catch {
+    return null
+  }
+}
+
+const isFresh = (entry: EasyEdaCacheEntry, now = Date.now()): boolean => {
+  const ttl = entry.status === "found" ? FOUND_TTL_MS : NOT_FOUND_TTL_MS
+  return now - Date.parse(entry.fetchedAt) < ttl
+}
+
+const writeCacheEntry = async (
+  bucket: R2Bucket,
+  entry: EasyEdaCacheEntry,
+): Promise<void> => {
+  await bucket.put(getCacheKey(entry.lcsc), JSON.stringify(entry), {
+    httpMetadata: { contentType: "application/json" },
+    customMetadata: {
+      fetchedAt: entry.fetchedAt,
+      lcsc: `C${entry.lcsc}`,
+      schemaVersion: String(entry.schemaVersion),
+      status: entry.status,
+    },
+  })
+}
+
+const fetchAndCacheEntry = async (
+  bucket: R2Bucket,
+  lcsc: number,
+  upstreamFetch: typeof fetch,
+): Promise<EasyEdaCacheEntry> => {
+  try {
+    const easyedaJson = await fetchEasyEDAComponent(`C${lcsc}`, {
+      fetch: upstreamFetch,
+      includeModelMetadata: false,
+    })
+    const entry: FoundCacheEntry = {
+      schemaVersion: CACHE_SCHEMA_VERSION,
+      status: "found",
+      lcsc,
+      fetchedAt: new Date().toISOString(),
+      easyedaJson,
+    }
+    await writeCacheEntry(bucket, entry)
+    return entry
+  } catch (error) {
+    const reason = getErrorMessage(error)
+    if (!isPermanentNotFound(reason)) throw error
+    const entry: NotFoundCacheEntry = {
+      schemaVersion: CACHE_SCHEMA_VERSION,
+      status: "not_found",
+      lcsc,
+      fetchedAt: new Date().toISOString(),
+      reason,
+    }
+    await writeCacheEntry(bucket, entry)
+    return entry
+  }
+}
+
+const fillCacheEntry = (
+  bucket: R2Bucket,
+  lcsc: number,
+  upstreamFetch: typeof fetch,
+): Promise<EasyEdaCacheEntry> => {
+  const existing = inFlightFills.get(lcsc)
+  if (existing) return existing
+
+  const fill = fetchAndCacheEntry(bucket, lcsc, upstreamFetch).finally(() => {
+    inFlightFills.delete(lcsc)
+  })
+  inFlightFills.set(lcsc, fill)
+  return fill
+}
+
+const buildFoundResponse = (
+  entry: FoundCacheEntry,
+  cacheStatus: EasyEdaCacheStatus,
+  origin: string | null,
+): Response => {
+  const raw = entry.easyedaJson as Record<string, unknown> | null
+  const headers = new Headers({
+    "cache-control": "public, max-age=300",
+    "content-type": "application/json",
+    "x-cache": cacheStatus,
+    "x-data-source": cacheStatus === "R2-MISS" ? "easyeda" : "r2",
+  })
+  addCorsHeaders(headers, origin)
+  return new Response(
+    JSON.stringify({
+      easyeda_component_details: {
+        lcsc: entry.lcsc,
+        easyeda_uuid: raw && typeof raw.uuid === "string" ? raw.uuid : null,
+        fetched_at: entry.fetchedAt,
+        easyeda_json: entry.easyedaJson,
+      },
+    }),
+    { status: 200, headers },
+  )
+}
+
+const buildNotFoundResponse = (
+  entry: NotFoundCacheEntry,
+  cacheStatus: EasyEdaCacheStatus,
+  origin: string | null,
+): Response => {
+  const headers = new Headers({
+    "cache-control": "public, max-age=60",
+    "content-type": "application/json",
+    "x-cache": cacheStatus,
+    "x-data-source": cacheStatus === "R2-MISS" ? "easyeda" : "r2",
+  })
+  addCorsHeaders(headers, origin)
+  return new Response(
+    JSON.stringify({
+      easyeda_component_details: {
+        lcsc: entry.lcsc,
+        easyeda_uuid: null,
+        fetched_at: entry.fetchedAt,
+        easyeda_json: null,
+      },
+      error: {
+        error_code: "component_not_found",
+        message: entry.reason,
+      },
+    }),
+    { status: 404, headers },
+  )
+}
+
+const buildCacheMissResponse = (
+  lcsc: number,
+  origin: string | null,
+): Response => {
+  const headers = new Headers({
+    "cache-control": "no-store",
+    "content-type": "application/json",
+    "x-cache": "R2-MISS",
+    "x-data-source": "r2",
+  })
+  addCorsHeaders(headers, origin)
+  return new Response(
+    JSON.stringify({
+      error: {
+        error_code: "cache_miss",
+        message: `No fresh EasyEDA cache entry exists for C${lcsc}`,
+      },
+    }),
+    { status: 404, headers },
+  )
+}
+
+const buildUpstreamErrorResponse = (
+  lcsc: number,
+  error: unknown,
+  origin: string | null,
+): Response => {
+  const message = getErrorMessage(error)
+  const headers = new Headers({
+    "cache-control": "no-store",
+    "content-type": "application/json",
+    "x-cache": "R2-MISS",
+    "x-data-source": "easyeda",
+  })
+  addCorsHeaders(headers, origin)
+  return new Response(
+    JSON.stringify({
+      error: {
+        error_code: "easyeda_fetch_failed",
+        message: `Failed to fill the EasyEDA cache for C${lcsc}: ${message}`,
+      },
+    }),
+    { status: getUpstreamStatus(message), headers },
+  )
+}
+
+const parseLcsc = (pathname: string): number | null => {
+  const rawLcsc = pathname.slice(EASYEDA_COMPONENTS_API_PREFIX.length)
+  const normalizedLcsc = rawLcsc.replace(/^c/i, "")
+  if (!/^\d+$/.test(normalizedLcsc)) return null
+  const lcsc = Number(normalizedLcsc)
+  return Number.isSafeInteger(lcsc) && lcsc > 0 ? lcsc : null
+}
+
+export async function handleEasyEdaComponentCache(
+  url: URL,
+  bucket: R2Bucket,
+  origin: string | null,
+  upstreamFetch: typeof fetch = fetch,
+): Promise<Response | null> {
+  if (!url.pathname.startsWith(EASYEDA_COMPONENTS_API_PREFIX)) return null
+
+  const lcsc = parseLcsc(url.pathname)
+  if (lcsc === null) {
+    const headers = new Headers({
+      "cache-control": "no-store",
+      "content-type": "application/json",
+    })
+    addCorsHeaders(headers, origin)
+    return new Response(
+      JSON.stringify({
+        error: {
+          error_code: "invalid_lcsc",
+          message: "LCSC must be a positive integer with an optional C prefix",
+        },
+      }),
+      { status: 400, headers },
+    )
+  }
+
+  const cachedEntry = await readCacheEntry(bucket, lcsc)
+  if (cachedEntry && isFresh(cachedEntry)) {
+    return cachedEntry.status === "found"
+      ? buildFoundResponse(cachedEntry, "R2-HIT", origin)
+      : buildNotFoundResponse(cachedEntry, "R2-HIT", origin)
+  }
+
+  if (url.searchParams.get("cache_only") === "true") {
+    return buildCacheMissResponse(lcsc, origin)
+  }
+
+  try {
+    const entry = await fillCacheEntry(bucket, lcsc, upstreamFetch)
+    return entry.status === "found"
+      ? buildFoundResponse(entry, "R2-MISS", origin)
+      : buildNotFoundResponse(entry, "R2-MISS", origin)
+  } catch (error) {
+    if (cachedEntry?.status === "found") {
+      return buildFoundResponse(cachedEntry, "R2-STALE", origin)
+    }
+    return buildUpstreamErrorResponse(lcsc, error, origin)
+  }
+}

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -2,12 +2,14 @@ import { CacheService, addCorsHeaders, addVaryHeader } from "./cache-service"
 import { queryComponentCatalog } from "./components"
 import { getD1Handler } from "./d1-routes"
 import { getD1Client } from "./db/get-d1-client"
+import { handleEasyEdaComponentCache } from "./easyeda-component-cache"
 import { renderD1TablePage, renderHomePage } from "./render"
 import { searchIndex } from "./search"
 
 export interface Env {
   CACHE_KV: KVNamespace
   DB: D1Database
+  EASYEDA_COMPONENT_CACHE: R2Bucket
   USE_D1: string
 }
 
@@ -216,6 +218,13 @@ export default {
         getPreferredContentType(request, url),
       )
     }
+
+    const easyEdaCacheResponse = await handleEasyEdaComponentCache(
+      url,
+      env.EASYEDA_COMPONENT_CACHE,
+      origin,
+    )
+    if (easyEdaCacheResponse) return easyEdaCacheResponse
 
     const cache = new CacheService(env.CACHE_KV)
 

--- a/cf-proxy/test/easyeda-component-cache.test.ts
+++ b/cf-proxy/test/easyeda-component-cache.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { handleEasyEdaComponentCache } from "../src/easyeda-component-cache"
+import { MemoryR2 } from "./test-env"
+
+const searchPayload = (lcsc: string, uuid = "easyeda-uuid") => ({
+  success: true,
+  result: {
+    lists: {
+      lcsc: [{ uuid, lcsc: { number: lcsc } }],
+    },
+  },
+})
+
+describe("EasyEDA R2 component cache", () => {
+  let bucket: MemoryR2
+
+  beforeEach(() => {
+    bucket = new MemoryR2()
+  })
+
+  it("fills R2 on a miss and serves the next request without EasyEDA", async () => {
+    const upstreamFetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString()
+      if (url.endsWith("/api/components/search")) {
+        return Response.json(searchPayload("C123"))
+      }
+      return Response.json({
+        result: { uuid: "easyeda-uuid", lcsc: { number: "C123" } },
+      })
+    })
+
+    const first = await handleEasyEdaComponentCache(
+      new URL("https://example.com/api/easyeda_components/C123"),
+      bucket as unknown as R2Bucket,
+      null,
+      upstreamFetch as unknown as typeof fetch,
+    )
+    expect(first?.status).toBe(200)
+    expect(first?.headers.get("x-cache")).toBe("R2-MISS")
+    expect(upstreamFetch).toHaveBeenCalledTimes(2)
+    expect(await first?.json()).toEqual({
+      easyeda_component_details: {
+        lcsc: 123,
+        easyeda_uuid: "easyeda-uuid",
+        fetched_at: expect.any(String),
+        easyeda_json: {
+          uuid: "easyeda-uuid",
+          lcsc: { number: "C123" },
+        },
+      },
+    })
+
+    upstreamFetch.mockClear()
+    const second = await handleEasyEdaComponentCache(
+      new URL("https://example.com/api/easyeda_components/123?cache_only=true"),
+      bucket as unknown as R2Bucket,
+      null,
+      upstreamFetch as unknown as typeof fetch,
+    )
+    expect(second?.status).toBe(200)
+    expect(second?.headers.get("x-cache")).toBe("R2-HIT")
+    expect(upstreamFetch).not.toHaveBeenCalled()
+  })
+
+  it("returns an R2-only miss without calling EasyEDA", async () => {
+    const upstreamFetch = vi.fn()
+    const response = await handleEasyEdaComponentCache(
+      new URL(
+        "https://example.com/api/easyeda_components/C456?cache_only=true",
+      ),
+      bucket as unknown as R2Bucket,
+      null,
+      upstreamFetch as unknown as typeof fetch,
+    )
+
+    expect(response?.status).toBe(404)
+    expect(response?.headers.get("x-cache")).toBe("R2-MISS")
+    expect(await response?.json()).toEqual({
+      error: {
+        error_code: "cache_miss",
+        message: "No fresh EasyEDA cache entry exists for C456",
+      },
+    })
+    expect(upstreamFetch).not.toHaveBeenCalled()
+  })
+
+  it("negative-caches permanent component misses", async () => {
+    const upstreamFetch = vi.fn(async () =>
+      Response.json({ success: true, result: { lists: { lcsc: [] } } }),
+    )
+
+    const first = await handleEasyEdaComponentCache(
+      new URL("https://example.com/api/easyeda_components/C789"),
+      bucket as unknown as R2Bucket,
+      null,
+      upstreamFetch as unknown as typeof fetch,
+    )
+    expect(first?.status).toBe(404)
+    expect(first?.headers.get("x-cache")).toBe("R2-MISS")
+    expect(upstreamFetch).toHaveBeenCalledTimes(1)
+    const firstBody = (await first?.json()) as {
+      error: { error_code: string; message: string }
+    }
+    expect(firstBody.error).toEqual({
+      error_code: "component_not_found",
+      message: "Component not found",
+    })
+
+    upstreamFetch.mockClear()
+    const second = await handleEasyEdaComponentCache(
+      new URL("https://example.com/api/easyeda_components/C789"),
+      bucket as unknown as R2Bucket,
+      null,
+      upstreamFetch as unknown as typeof fetch,
+    )
+    expect(second?.status).toBe(404)
+    expect(second?.headers.get("x-cache")).toBe("R2-HIT")
+    expect(upstreamFetch).not.toHaveBeenCalled()
+  })
+
+  it("preserves EasyEDA 403 responses for caller-side cooldowns", async () => {
+    const upstreamFetch = vi.fn(
+      async () => new Response("rate limited", { status: 403 }),
+    )
+
+    const response = await handleEasyEdaComponentCache(
+      new URL("https://example.com/api/easyeda_components/C999"),
+      bucket as unknown as R2Bucket,
+      null,
+      upstreamFetch as unknown as typeof fetch,
+    )
+    expect(response?.status).toBe(403)
+    const responseBody = (await response?.json()) as {
+      error: { error_code: string }
+    }
+    expect(responseBody.error.error_code).toBe("easyeda_fetch_failed")
+
+    upstreamFetch.mockClear()
+    const probe = await handleEasyEdaComponentCache(
+      new URL(
+        "https://example.com/api/easyeda_components/C999?cache_only=true",
+      ),
+      bucket as unknown as R2Bucket,
+      null,
+      upstreamFetch as unknown as typeof fetch,
+    )
+    const probeBody = (await probe?.json()) as {
+      error: { error_code: string }
+    }
+    expect(probeBody.error.error_code).toBe("cache_miss")
+  })
+})

--- a/cf-proxy/test/test-env.ts
+++ b/cf-proxy/test/test-env.ts
@@ -1,6 +1,11 @@
 import worker from "../src/index"
 
 type KVValue = { value: string | null; metadata: unknown }
+type R2Value = {
+  body: string
+  customMetadata?: Record<string, string>
+  uploaded: Date
+}
 
 export class MemoryKV {
   private store = new Map<string, KVValue>()
@@ -71,8 +76,87 @@ export class MemoryKV {
   }
 }
 
+export class MemoryR2 {
+  private store = new Map<string, R2Value>()
+
+  async get(key: string): Promise<R2ObjectBody | null> {
+    const entry = this.store.get(key)
+    if (!entry) return null
+    const body = entry.body
+    return {
+      key,
+      version: "1",
+      size: new TextEncoder().encode(body).byteLength,
+      etag: "test-etag",
+      httpEtag: '"test-etag"',
+      checksums: {} as R2Checksums,
+      uploaded: entry.uploaded,
+      customMetadata: entry.customMetadata,
+      storageClass: "Standard",
+      body: new Response(body).body!,
+      bodyUsed: false,
+      arrayBuffer: () => new Response(body).arrayBuffer(),
+      bytes: async () => new TextEncoder().encode(body),
+      text: async () => body,
+      json: async <T>() => JSON.parse(body) as T,
+      blob: () => new Response(body).blob(),
+      writeHttpMetadata: () => {},
+    } as unknown as R2ObjectBody
+  }
+
+  async put(
+    key: string,
+    value: string | ArrayBuffer | ArrayBufferView | Blob | null,
+    options?: R2PutOptions,
+  ): Promise<R2Object> {
+    const body =
+      typeof value === "string"
+        ? value
+        : value === null
+          ? ""
+          : value instanceof Blob
+            ? await value.text()
+            : new TextDecoder().decode(
+                value instanceof ArrayBuffer
+                  ? new Uint8Array(value)
+                  : new Uint8Array(
+                      value.buffer,
+                      value.byteOffset,
+                      value.byteLength,
+                    ),
+              )
+    const uploaded = new Date()
+    this.store.set(key, {
+      body,
+      customMetadata: options?.customMetadata,
+      uploaded,
+    })
+    return {
+      key,
+      version: "1",
+      size: new TextEncoder().encode(body).byteLength,
+      etag: "test-etag",
+      httpEtag: '"test-etag"',
+      checksums: {} as R2Checksums,
+      uploaded,
+      customMetadata: options?.customMetadata,
+      storageClass: "Standard",
+      writeHttpMetadata: () => {},
+    } as R2Object
+  }
+
+  async delete(key: string | string[]): Promise<void> {
+    for (const item of Array.isArray(key) ? key : [key]) this.store.delete(item)
+  }
+
+  async clear(): Promise<void> {
+    this.store.clear()
+  }
+}
+
 export const createTestEnv = () => ({
   CACHE_KV: new MemoryKV(),
+  EASYEDA_COMPONENT_CACHE: new MemoryR2() as MemoryR2 & R2Bucket,
   USE_D1: "false",
   DB: {} as D1Database,
 })

--- a/cf-proxy/test/worker.test.ts
+++ b/cf-proxy/test/worker.test.ts
@@ -18,6 +18,7 @@ describe("Worker integration", () => {
     for (const key of keys.keys) {
       await env.CACHE_KV.delete(key.name)
     }
+    await env.EASYEDA_COMPONENT_CACHE.clear()
   })
 
   it("serves /health directly from the worker", async () => {
@@ -104,6 +105,41 @@ describe("Worker integration", () => {
         footprinter_string: "sod723_p0.865mm_pw0.54mm_pl0.57mm",
         copper_iou: 0.9923751612092405,
         updated_at: "2026-08-12 04:34:12",
+      },
+    })
+  })
+
+  it("serves EasyEDA component JSON from the shared R2 cache", async () => {
+    await env.EASYEDA_COMPONENT_CACHE.put(
+      "components/C123.json",
+      JSON.stringify({
+        schemaVersion: 1,
+        status: "found",
+        lcsc: 123,
+        fetchedAt: new Date().toISOString(),
+        easyedaJson: {
+          uuid: "easyeda-uuid",
+          lcsc: { number: "C123" },
+        },
+      }),
+    )
+
+    const response = await SELF.fetch(
+      "https://example.com/api/easyeda_components/C123?cache_only=true",
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("x-cache")).toBe("R2-HIT")
+    expect(response.headers.get("x-data-source")).toBe("r2")
+    expect(await response.json()).toEqual({
+      easyeda_component_details: {
+        lcsc: 123,
+        easyeda_uuid: "easyeda-uuid",
+        fetched_at: expect.any(String),
+        easyeda_json: {
+          uuid: "easyeda-uuid",
+          lcsc: { number: "C123" },
+        },
       },
     })
   })

--- a/cf-proxy/vitest.config.ts
+++ b/cf-proxy/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineWorkersConfig({
         wrangler: { configPath: "./wrangler.toml" },
         miniflare: {
           kvNamespaces: ["CACHE_KV"],
+          r2Buckets: ["EASYEDA_COMPONENT_CACHE"],
         },
       },
     },

--- a/cf-proxy/wrangler.toml
+++ b/cf-proxy/wrangler.toml
@@ -23,6 +23,11 @@ binding = "DB"
 database_name = "jlcsearch"
 database_id = "dbd51802-2175-4e82-b1a9-8f129e46ec26"
 
+[[r2_buckets]]
+binding = "EASYEDA_COMPONENT_CACHE"
+bucket_name = "tscircuit-easyeda-component-cache"
+preview_bucket_name = "tscircuit-easyeda-component-cache-staging"
+
 [env.staging]
 name = "jlcsearch-proxy-staging"
 workers_dev = true
@@ -39,3 +44,7 @@ id = "4fe1b99f0b90468bb4684a5b6822b10a"
 binding = "DB"
 database_name = "jlcsearch"
 database_id = "dbd51802-2175-4e82-b1a9-8f129e46ec26"
+
+[[env.staging.r2_buckets]]
+binding = "EASYEDA_COMPONENT_CACHE"
+bucket_name = "tscircuit-easyeda-component-cache-staging"

--- a/lib/easyeda-component-cache-client.ts
+++ b/lib/easyeda-component-cache-client.ts
@@ -1,0 +1,85 @@
+export interface EasyEdaComponentCacheMetrics {
+  cacheHits: number
+  cacheMisses: number
+  negativeCacheHits: number
+}
+
+type FetchFunction = (
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1],
+) => Promise<Response>
+
+interface CacheResponseBody {
+  easyeda_component_details?: {
+    easyeda_json?: unknown
+  }
+  error?: {
+    error_code?: string
+    message?: string
+  }
+}
+
+interface FetchEasyEdaComponentFromCacheOptions {
+  cacheFillFetch: FetchFunction
+  cacheOrigin: string
+  cacheProbeFetch: FetchFunction
+  metrics: EasyEdaComponentCacheMetrics
+}
+
+const readResponseBody = async (
+  response: Response,
+): Promise<CacheResponseBody> =>
+  response.json().catch(() => ({})) as Promise<CacheResponseBody>
+
+const getResponseError = (response: Response, body: CacheResponseBody): Error =>
+  new Error(
+    body.error?.message ??
+      `EasyEDA component cache returned HTTP ${response.status}`,
+  )
+
+const getEasyEdaJson = (
+  response: Response,
+  body: CacheResponseBody,
+): unknown => {
+  if (
+    response.ok &&
+    body.easyeda_component_details &&
+    "easyeda_json" in body.easyeda_component_details &&
+    body.easyeda_component_details.easyeda_json !== null
+  ) {
+    return body.easyeda_component_details.easyeda_json
+  }
+  throw getResponseError(response, body)
+}
+
+export async function fetchEasyEdaComponentFromCache(
+  lcsc: string,
+  options: FetchEasyEdaComponentFromCacheOptions,
+): Promise<unknown> {
+  const origin = options.cacheOrigin.replace(/\/$/, "")
+  const componentUrl = `${origin}/api/easyeda_components/${lcsc}`
+  const probeResponse = await options.cacheProbeFetch(
+    `${componentUrl}?cache_only=true`,
+    { headers: { accept: "application/json" } },
+  )
+  const probeBody = await readResponseBody(probeResponse)
+
+  if (probeResponse.ok) {
+    options.metrics.cacheHits += 1
+    return getEasyEdaJson(probeResponse, probeBody)
+  }
+  if (probeBody.error?.error_code === "component_not_found") {
+    options.metrics.negativeCacheHits += 1
+    throw getResponseError(probeResponse, probeBody)
+  }
+  if (probeBody.error?.error_code !== "cache_miss") {
+    throw getResponseError(probeResponse, probeBody)
+  }
+
+  options.metrics.cacheMisses += 1
+  const fillResponse = await options.cacheFillFetch(componentUrl, {
+    headers: { accept: "application/json" },
+  })
+  const fillBody = await readResponseBody(fillResponse)
+  return getEasyEdaJson(fillResponse, fillBody)
+}

--- a/scripts/populate-footprinter-strings.ts
+++ b/scripts/populate-footprinter-strings.ts
@@ -1,7 +1,10 @@
 import { join } from "node:path"
 import { circuitJsonToFootprinter } from "circuit-json-to-footprinter"
 import { EasyEdaJsonSchema, convertEasyEdaJsonToCircuitJson } from "easyeda"
-import { fetchEasyEDAComponent } from "easyeda/browser"
+import {
+  type EasyEdaComponentCacheMetrics,
+  fetchEasyEdaComponentFromCache,
+} from "../lib/easyeda-component-cache-client"
 import {
   COPPER_IOU_THRESHOLD,
   type FootprinterStringRow,
@@ -20,8 +23,10 @@ const DEFAULT_RUNTIME_MINUTES = 240
 const QUERY_BATCH_SIZE = 250
 const WRITE_BATCH_SIZE = 50
 const COMPONENT_CONCURRENCY = 8
-const EASYEDA_REQUESTS_PER_SECOND = 4
-const EASYEDA_REQUESTS_PER_SECOND_AFTER_403 = 1
+const EASYEDA_CACHE_FILLS_PER_SECOND = 2
+const EASYEDA_CACHE_FILLS_PER_SECOND_AFTER_403 = 1
+const EASYEDA_CACHE_ORIGIN =
+  process.env.EASYEDA_CACHE_ORIGIN?.trim() || "https://jlcsearch.tscircuit.com"
 const FETCH_TIMEOUT_MS = 20_000
 const RATE_LIMIT_COOLDOWN_MS = 120_000
 const GRACE_PERIOD_MS = 45_000
@@ -51,7 +56,9 @@ interface WranglerResult {
   success?: boolean
 }
 
-interface TimingMetrics extends PoliteRateLimitedFetchMetrics {
+interface TimingMetrics
+  extends PoliteRateLimitedFetchMetrics,
+    EasyEdaComponentCacheMetrics {
   conversionCount: number
   conversionDurationMs: number
   d1ReadCount: number
@@ -227,13 +234,16 @@ const fetchComponents = async (
 
 const deriveFootprinterRow = async (
   component: ComponentCatalogRow,
-  easyEdaFetch: typeof fetch,
+  cacheProbeFetch: typeof fetch,
+  cacheFillFetch: typeof fetch,
   metrics: TimingMetrics,
 ): Promise<FootprinterStringRow> => {
   const lcsc = `C${component.lcsc}`
-  const rawEasyEdaJson = await fetchEasyEDAComponent(lcsc, {
-    fetch: easyEdaFetch,
-    includeModelMetadata: false,
+  const rawEasyEdaJson = await fetchEasyEdaComponentFromCache(lcsc, {
+    cacheFillFetch,
+    cacheOrigin: EASYEDA_CACHE_ORIGIN,
+    cacheProbeFetch,
+    metrics,
   })
   const conversionStartedAt = Date.now()
   metrics.conversionCount += 1
@@ -286,11 +296,17 @@ const flushRows = async (
 
 const processComponent = async (
   component: ComponentCatalogRow,
-  easyEdaFetch: typeof fetch,
+  cacheProbeFetch: typeof fetch,
+  cacheFillFetch: typeof fetch,
   metrics: TimingMetrics,
 ): Promise<ComponentResult> => {
   try {
-    const row = await deriveFootprinterRow(component, easyEdaFetch, metrics)
+    const row = await deriveFootprinterRow(
+      component,
+      cacheProbeFetch,
+      cacheFillFetch,
+      metrics,
+    )
     console.log(
       `C${component.lcsc}: ${row.footprinterString ?? "no >95% match"} (${row.copperIou?.toFixed(4) ?? "no candidate"})`,
     )
@@ -329,6 +345,8 @@ const processComponent = async (
 }
 
 const createTimingMetrics = (): TimingMetrics => ({
+  cacheHits: 0,
+  cacheMisses: 0,
   conversionCount: 0,
   conversionDurationMs: 0,
   cooldownCount: 0,
@@ -336,6 +354,7 @@ const createTimingMetrics = (): TimingMetrics => ({
   d1ReadDurationMs: 0,
   d1WriteCount: 0,
   d1WriteDurationMs: 0,
+  negativeCacheHits: 0,
   requestCount: 0,
   requestDurationMs: 0,
   throttleWaitMs: 0,
@@ -358,41 +377,43 @@ const main = async () => {
   let permanentMisses = 0
   let recorded = 0
 
+  const abortableFetch: typeof fetch = Object.assign(
+    (input: Parameters<typeof fetch>[0], init: RequestInit = {}) => {
+      const signals = [
+        stopController.signal,
+        AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      ]
+      if (init.signal) signals.push(init.signal)
+      return fetch(input, {
+        ...init,
+        signal: AbortSignal.any(signals),
+      })
+    },
+    { preconnect: fetch.preconnect },
+  )
+
   const limiter = new PoliteRateLimitedFetch({
     cooldownMs: RATE_LIMIT_COOLDOWN_MS,
-    cooldownRequestsPerSecond: EASYEDA_REQUESTS_PER_SECOND_AFTER_403,
+    cooldownRequestsPerSecond: EASYEDA_CACHE_FILLS_PER_SECOND_AFTER_403,
     deadline: requestDeadline,
-    fetch: Object.assign(
-      (input: Parameters<typeof fetch>[0], init: RequestInit = {}) => {
-        const signals = [
-          stopController.signal,
-          AbortSignal.timeout(FETCH_TIMEOUT_MS),
-        ]
-        if (init.signal) signals.push(init.signal)
-        return fetch(input, {
-          ...init,
-          signal: AbortSignal.any(signals),
-        })
-      },
-      { preconnect: fetch.preconnect },
-    ),
+    fetch: abortableFetch,
     metrics,
     onCooldown: (cooldownMs, requestsPerSecond) => {
       console.warn(
-        `EasyEDA returned HTTP 403; pausing all requests for ${cooldownMs / 1_000}s, then limiting to ${requestsPerSecond} request/s.`,
+        `EasyEDA cache fill returned HTTP 403; pausing all fills for ${cooldownMs / 1_000}s, then limiting to ${requestsPerSecond} component fill/s.`,
       )
     },
-    requestsPerSecond: EASYEDA_REQUESTS_PER_SECOND,
+    requestsPerSecond: EASYEDA_CACHE_FILLS_PER_SECOND,
     signal: stopController.signal,
   })
-  const easyEdaFetch: typeof fetch = Object.assign(
+  const cacheFillFetch: typeof fetch = Object.assign(
     (input: Parameters<typeof fetch>[0], init: RequestInit = {}) =>
       limiter.fetch(input, init),
     { preconnect: fetch.preconnect },
   )
 
   console.log(
-    `Populating footprinter_strings with ${COMPONENT_CONCURRENCY} concurrent component(s) and a shared ${EASYEDA_REQUESTS_PER_SECOND} request/s EasyEDA limit for up to ${options.maxRuntimeMinutes} minute(s); strings require copper_iou > ${COPPER_IOU_THRESHOLD}.`,
+    `Populating footprinter_strings with ${COMPONENT_CONCURRENCY} concurrent component(s), the shared EasyEDA R2 cache, and at most ${EASYEDA_CACHE_FILLS_PER_SECOND} cache fill(s)/s (about ${EASYEDA_CACHE_FILLS_PER_SECOND * 2} EasyEDA requests/s) for up to ${options.maxRuntimeMinutes} minute(s); strings require copper_iou > ${COPPER_IOU_THRESHOLD}.`,
   )
 
   while (!stopRequested && Date.now() + GRACE_PERIOD_MS < deadline) {
@@ -433,7 +454,8 @@ const main = async () => {
 
           const result = await processComponent(
             component,
-            easyEdaFetch,
+            abortableFetch,
+            cacheFillFetch,
             metrics,
           )
           if (result.status === "stopped" || result.status === "rate-limited") {
@@ -478,7 +500,7 @@ const main = async () => {
     `Finished cleanly after ${elapsedSeconds}s: ${attempted} attempted, ${recorded} recorded, ${matched} matched, ${permanentMisses} permanent misses, ${failed} retryable failures.`,
   )
   console.log(
-    `Timing: EasyEDA ${metrics.requestCount} requests / ${metrics.requestDurationMs}ms (${formatAverage(metrics.requestDurationMs, metrics.requestCount)}ms avg), ${metrics.throttleWaitMs}ms aggregate throttle wait, ${metrics.cooldownCount} cooldown(s); conversion ${metrics.conversionCount} / ${metrics.conversionDurationMs}ms (${formatAverage(metrics.conversionDurationMs, metrics.conversionCount)}ms avg); D1 reads ${metrics.d1ReadCount} / ${metrics.d1ReadDurationMs}ms, writes ${metrics.d1WriteCount} / ${metrics.d1WriteDurationMs}ms; CPU ${cpuDurationMs.toFixed(0)}ms (${cpuUtilization.toFixed(1)}% of one core).`,
+    `Timing: EasyEDA R2 cache ${metrics.cacheHits} hit(s), ${metrics.negativeCacheHits} negative hit(s), ${metrics.cacheMisses} miss(es); ${metrics.requestCount} rate-limited fill(s) / ${metrics.requestDurationMs}ms (${formatAverage(metrics.requestDurationMs, metrics.requestCount)}ms avg), ${metrics.throttleWaitMs}ms aggregate throttle wait, ${metrics.cooldownCount} cooldown(s); conversion ${metrics.conversionCount} / ${metrics.conversionDurationMs}ms (${formatAverage(metrics.conversionDurationMs, metrics.conversionCount)}ms avg); D1 reads ${metrics.d1ReadCount} / ${metrics.d1ReadDurationMs}ms, writes ${metrics.d1WriteCount} / ${metrics.d1WriteDurationMs}ms; CPU ${cpuDurationMs.toFixed(0)}ms (${cpuUtilization.toFixed(1)}% of one core).`,
   )
 }
 

--- a/tests/easyeda-component-cache-client.test.ts
+++ b/tests/easyeda-component-cache-client.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test"
+import {
+  type EasyEdaComponentCacheMetrics,
+  fetchEasyEdaComponentFromCache,
+} from "../lib/easyeda-component-cache-client"
+
+const createMetrics = (): EasyEdaComponentCacheMetrics => ({
+  cacheHits: 0,
+  cacheMisses: 0,
+  negativeCacheHits: 0,
+})
+
+const foundResponse = () =>
+  Response.json({
+    easyeda_component_details: {
+      lcsc: 123,
+      easyeda_json: { uuid: "easyeda-uuid" },
+    },
+  })
+
+describe("fetchEasyEdaComponentFromCache", () => {
+  test("returns an R2 hit without using the rate-limited fill fetch", async () => {
+    const metrics = createMetrics()
+    let fillCalls = 0
+    const result = await fetchEasyEdaComponentFromCache("C123", {
+      cacheOrigin: "https://jlcsearch.tscircuit.com/",
+      cacheProbeFetch: async () => foundResponse(),
+      cacheFillFetch: async () => {
+        fillCalls += 1
+        return foundResponse()
+      },
+      metrics,
+    })
+
+    expect(result).toEqual({ uuid: "easyeda-uuid" })
+    expect(fillCalls).toBe(0)
+    expect(metrics).toEqual({
+      cacheHits: 1,
+      cacheMisses: 0,
+      negativeCacheHits: 0,
+    })
+  })
+
+  test("fills the cache after an R2-only miss", async () => {
+    const metrics = createMetrics()
+    const requestedUrls: string[] = []
+    const result = await fetchEasyEdaComponentFromCache("C123", {
+      cacheOrigin: "https://jlcsearch.tscircuit.com",
+      cacheProbeFetch: async (input) => {
+        requestedUrls.push(input.toString())
+        return Response.json(
+          {
+            error: { error_code: "cache_miss", message: "not cached" },
+          },
+          { status: 404 },
+        )
+      },
+      cacheFillFetch: async (input) => {
+        requestedUrls.push(input.toString())
+        return foundResponse()
+      },
+      metrics,
+    })
+
+    expect(result).toEqual({ uuid: "easyeda-uuid" })
+    expect(requestedUrls).toEqual([
+      "https://jlcsearch.tscircuit.com/api/easyeda_components/C123?cache_only=true",
+      "https://jlcsearch.tscircuit.com/api/easyeda_components/C123",
+    ])
+    expect(metrics.cacheMisses).toBe(1)
+  })
+
+  test("surfaces negative R2 hits without attempting another fill", async () => {
+    const metrics = createMetrics()
+    let fillCalls = 0
+    const request = fetchEasyEdaComponentFromCache("C404", {
+      cacheOrigin: "https://jlcsearch.tscircuit.com",
+      cacheProbeFetch: async () =>
+        Response.json(
+          {
+            error: {
+              error_code: "component_not_found",
+              message: "Component not found",
+            },
+          },
+          { status: 404 },
+        ),
+      cacheFillFetch: async () => {
+        fillCalls += 1
+        return foundResponse()
+      },
+      metrics,
+    })
+
+    await expect(request).rejects.toThrow("Component not found")
+    expect(fillCalls).toBe(0)
+    expect(metrics.negativeCacheHits).toBe(1)
+  })
+
+  test("preserves a rate-limit error from the fill endpoint", async () => {
+    const metrics = createMetrics()
+    const request = fetchEasyEdaComponentFromCache("C123", {
+      cacheOrigin: "https://jlcsearch.tscircuit.com",
+      cacheProbeFetch: async () =>
+        Response.json(
+          { error: { error_code: "cache_miss", message: "not cached" } },
+          { status: 404 },
+        ),
+      cacheFillFetch: async () =>
+        Response.json(
+          {
+            error: {
+              error_code: "easyeda_fetch_failed",
+              message: "EasyEDA API rate limit exceeded (HTTP 403)",
+            },
+          },
+          { status: 403 },
+        ),
+      metrics,
+    })
+
+    await expect(request).rejects.toThrow("rate limit exceeded")
+  })
+})


### PR DESCRIPTION
## Summary

- add a fetch-through R2 cache for raw EasyEDA component JSON, keyed by normalized LCSC number
- expose `GET /api/easyeda_components/:lcsc` with the `easyeda_component_details` top-level response convention
- support R2-only probes with `?cache_only=true` and `R2-HIT`, `R2-MISS`, and `R2-STALE` response metadata
- cache successful payloads for 90 days and definitive not-found responses for 6 hours
- route footprinter population through the shared cache and report positive hits, negative hits, and fills
- limit cache fills to 2 components/second (approximately the existing 4 EasyEDA requests/second) and preserve the 403 cooldown

## Why

Raw EasyEDA footprint payloads were fetched independently by each caller and discarded after conversion. Persisting them in a shared cache prevents duplicate upstream traffic, lets other tscircuit services reuse the same payload, and makes future footprinter re-indexing possible without refetching every component.

## Infrastructure

Provisioned these R2 buckets in the existing Cloudflare account:

- `tscircuit-easyeda-component-cache` (production)
- `tscircuit-easyeda-component-cache-staging` (staging/preview)

The staging Worker was deployed from this branch and verified with a real C2906861 miss-to-hit cycle. The stored payload was then read directly from the staging R2 object, and the population cache client parsed the R2 hit through `EasyEdaJsonSchema` without invoking a fill.

## Validation

- `bun test` — 218 passing
- `bun run test --cwd cf-proxy` — 150 passing
- `bunx tsc --noEmit`
- `bunx tsc --noEmit --project cf-proxy/tsconfig.json`
- `bun run format:check`
- `git diff --check`
- staging Worker deployment and live R2 hit verification

## Deployment

After merge, deploy the production Worker before starting another population run so `/api/easyeda_components/:lcsc` is available on `jlcsearch.tscircuit.com`.