### PR TITLE
Restart poisoned footprinter WASM workers

### DIFF
--- a/.github/workflows/populate-footprinter-strings.yml
+++ b/.github/workflows/populate-footprinter-strings.yml
@@ -70,7 +70,7 @@ jobs:
           if [[ "${RETRY_NULL_ENTRIES}" == "true" ]]; then
             args+=(--retry-null-entries)
           fi
-          bun run populate:footprinter-strings -- "${args[@]}"
+          bun run populate:footprinter-strings:supervised -- "${args[@]}"
 
       - name: Report production row counts
         if: always()

--- a/lib/footprinter-population-restarts.ts
+++ b/lib/footprinter-population-restarts.ts
@@ -1,0 +1,15 @@
+export const POPULATION_BATCH_COMPONENT_LIMIT = 1_000
+export const POPULATION_BATCH_RESTART_EXIT_CODE = 75
+export const POPULATION_WASM_RESTART_EXIT_CODE = 76
+export const RAPID_WASM_RESTART_LIMIT = 3
+export const RAPID_WASM_RESTART_THRESHOLD_MS = 30_000
+export const SUPERVISOR_DEADLINE_BUFFER_MS = 45_000
+export const WASM_RESTART_DELAY_MS = 1_000
+
+export const isManifoldWasmAbort = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error)
+  return (
+    message.startsWith("Aborted(") &&
+    message.includes("Build with -sASSERTIONS")
+  )
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "setup:derived-tables": "bun run scripts/setup-derived-tables.ts",
     "setup:derived-sync-db": "bun run scripts/build-derived-sync-db.ts",
     "populate:footprinter-strings": "bun run scripts/populate-footprinter-strings.ts",
+    "populate:footprinter-strings:supervised": "bun run scripts/supervise-footprinter-strings.ts",
     "format": "biome format --write .",
     "format:check": "biome format ."
   },

--- a/scripts/populate-footprinter-strings.ts
+++ b/scripts/populate-footprinter-strings.ts
@@ -13,6 +13,11 @@ import {
   isPermanentEasyEdaMiss,
 } from "../lib/footprinter-strings"
 import {
+  POPULATION_BATCH_RESTART_EXIT_CODE,
+  POPULATION_WASM_RESTART_EXIT_CODE,
+  isManifoldWasmAbort,
+} from "../lib/footprinter-population-restarts"
+import {
   PoliteRateLimitedFetch,
   RequestDeadlineReachedError,
   type PoliteRateLimitedFetchMetrics,
@@ -48,6 +53,7 @@ interface Cursor {
 interface Options {
   maxComponents: number | null
   maxRuntimeMinutes: number
+  restartOnLimit: boolean
   retryNullEntries: boolean
 }
 
@@ -77,12 +83,26 @@ type ComponentResult =
   | { status: "stopped" }
 
 let stopRequested = false
+let wasmRestartRequested = false
 const stopController = new AbortController()
 
 const requestGracefulStop = (signal: string) => {
   console.log(`Received ${signal}; stopping and flushing completed components.`)
   stopRequested = true
-  stopController.abort(signal)
+  if (!stopController.signal.aborted) stopController.abort(signal)
+}
+
+const requestWasmRestart = (lcsc: number) => {
+  if (!wasmRestartRequested) {
+    console.warn(
+      `C${lcsc}: Manifold WASM entered an aborted state; stopping this batch and requesting a fresh process.`,
+    )
+  }
+  wasmRestartRequested = true
+  stopRequested = true
+  if (!stopController.signal.aborted) {
+    stopController.abort(`Manifold WASM aborted while processing C${lcsc}`)
+  }
 }
 
 process.on("SIGINT", () => requestGracefulStop("SIGINT"))
@@ -100,6 +120,7 @@ const parseOptions = (args: readonly string[]): Options => {
   const options: Options = {
     maxComponents: null,
     maxRuntimeMinutes: DEFAULT_RUNTIME_MINUTES,
+    restartOnLimit: false,
     retryNullEntries: false,
   }
 
@@ -107,6 +128,10 @@ const parseOptions = (args: readonly string[]): Options => {
     const argument = args[index]
     if (argument === "--retry-null-entries") {
       options.retryNullEntries = true
+      continue
+    }
+    if (argument === "--restart-on-limit") {
+      options.restartOnLimit = true
       continue
     }
 
@@ -315,11 +340,19 @@ const processComponent = async (
       status: row.footprinterString === null ? "no-match" : "matched",
     }
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (isManifoldWasmAbort(error)) {
+      console.warn(
+        `C${component.lcsc}: ${message}; leaving it eligible to retry in a fresh process.`,
+      )
+      requestWasmRestart(component.lcsc)
+      return { status: "retryable-failure" }
+    }
+
     if (error instanceof RequestDeadlineReachedError || stopRequested) {
       return { status: "stopped" }
     }
 
-    const message = error instanceof Error ? error.message : String(error)
     if (message.includes("rate limit exceeded")) {
       console.warn(
         `C${component.lcsc}: ${message}; leaving it eligible to retry after the global cooldown.`,
@@ -496,12 +529,25 @@ const main = async () => {
   const cpuUsage = process.cpuUsage(cpuStartedAt)
   const cpuDurationMs = (cpuUsage.user + cpuUsage.system) / 1_000
   const cpuUtilization = (cpuDurationMs / elapsedMs) * 100
+  const reachedComponentLimit =
+    options.maxComponents !== null && attempted >= options.maxComponents
+  const finishReason = wasmRestartRequested
+    ? "for a Manifold WASM restart"
+    : reachedComponentLimit
+      ? "at the component limit"
+      : "cleanly"
   console.log(
-    `Finished cleanly after ${elapsedSeconds}s: ${attempted} attempted, ${recorded} recorded, ${matched} matched, ${permanentMisses} permanent misses, ${failed} retryable failures.`,
+    `Finished ${finishReason} after ${elapsedSeconds}s: ${attempted} attempted, ${recorded} recorded, ${matched} matched, ${permanentMisses} permanent misses, ${failed} retryable failures.`,
   )
   console.log(
     `Timing: EasyEDA R2 cache ${metrics.cacheHits} hit(s), ${metrics.negativeCacheHits} negative hit(s), ${metrics.cacheMisses} miss(es); ${metrics.requestCount} rate-limited fill(s) / ${metrics.requestDurationMs}ms (${formatAverage(metrics.requestDurationMs, metrics.requestCount)}ms avg), ${metrics.throttleWaitMs}ms aggregate throttle wait, ${metrics.cooldownCount} cooldown(s); conversion ${metrics.conversionCount} / ${metrics.conversionDurationMs}ms (${formatAverage(metrics.conversionDurationMs, metrics.conversionCount)}ms avg); D1 reads ${metrics.d1ReadCount} / ${metrics.d1ReadDurationMs}ms, writes ${metrics.d1WriteCount} / ${metrics.d1WriteDurationMs}ms; CPU ${cpuDurationMs.toFixed(0)}ms (${cpuUtilization.toFixed(1)}% of one core).`,
   )
+
+  if (wasmRestartRequested) {
+    process.exitCode = POPULATION_WASM_RESTART_EXIT_CODE
+  } else if (reachedComponentLimit && options.restartOnLimit) {
+    process.exitCode = POPULATION_BATCH_RESTART_EXIT_CODE
+  }
 }
 
 if (import.meta.main) {

--- a/scripts/supervise-footprinter-strings.ts
+++ b/scripts/supervise-footprinter-strings.ts
@@ -1,0 +1,172 @@
+import { join } from "node:path"
+import {
+  POPULATION_BATCH_COMPONENT_LIMIT,
+  POPULATION_BATCH_RESTART_EXIT_CODE,
+  POPULATION_WASM_RESTART_EXIT_CODE,
+  RAPID_WASM_RESTART_LIMIT,
+  RAPID_WASM_RESTART_THRESHOLD_MS,
+  SUPERVISOR_DEADLINE_BUFFER_MS,
+  WASM_RESTART_DELAY_MS,
+} from "../lib/footprinter-population-restarts"
+
+const DEFAULT_RUNTIME_MINUTES = 240
+const WORKER_SCRIPT = join(import.meta.dir, "populate-footprinter-strings.ts")
+
+export interface PopulationSupervisorOptions {
+  maxRuntimeMinutes: number
+  retryNullEntries: boolean
+}
+
+export interface PopulationBatchOptions extends PopulationSupervisorOptions {
+  maxComponents: number
+  restartOnLimit: boolean
+}
+
+interface PopulationSupervisorDependencies {
+  now: () => number
+  runBatch: (options: PopulationBatchOptions) => Promise<number>
+  sleep: (durationMs: number) => Promise<void>
+}
+
+const parsePositiveInteger = (value: string, name: string): number => {
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`)
+  }
+  return parsed
+}
+
+export const parseSupervisorOptions = (
+  args: readonly string[],
+): PopulationSupervisorOptions => {
+  const options: PopulationSupervisorOptions = {
+    maxRuntimeMinutes: DEFAULT_RUNTIME_MINUTES,
+    retryNullEntries: false,
+  }
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (argument === "--retry-null-entries") {
+      options.retryNullEntries = true
+      continue
+    }
+
+    const value = args[index + 1]
+    if (!value) throw new Error(`Missing value for ${argument}`)
+
+    if (argument !== "--max-runtime-minutes") {
+      throw new Error(`Unknown argument: ${argument}`)
+    }
+    options.maxRuntimeMinutes = parsePositiveInteger(value, argument)
+    if (options.maxRuntimeMinutes > DEFAULT_RUNTIME_MINUTES) {
+      throw new Error(
+        `--max-runtime-minutes cannot exceed ${DEFAULT_RUNTIME_MINUTES}`,
+      )
+    }
+    index += 1
+  }
+
+  return options
+}
+
+const sleep = (durationMs: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, durationMs))
+
+const runBatch = async (options: PopulationBatchOptions): Promise<number> => {
+  const args = [
+    "bun",
+    "run",
+    WORKER_SCRIPT,
+    "--max-runtime-minutes",
+    String(options.maxRuntimeMinutes),
+    "--max-components",
+    String(options.maxComponents),
+  ]
+  if (options.restartOnLimit) args.push("--restart-on-limit")
+  if (options.retryNullEntries) args.push("--retry-null-entries")
+
+  const child = Bun.spawn(args, {
+    env: process.env,
+    stderr: "inherit",
+    stdin: "inherit",
+    stdout: "inherit",
+  })
+  return child.exited
+}
+
+const defaultDependencies: PopulationSupervisorDependencies = {
+  now: Date.now,
+  runBatch,
+  sleep,
+}
+
+export const superviseFootprinterPopulation = async (
+  options: PopulationSupervisorOptions,
+  dependencies: PopulationSupervisorDependencies = defaultDependencies,
+): Promise<void> => {
+  const deadline = dependencies.now() + options.maxRuntimeMinutes * 60_000
+  let rapidWasmRestarts = 0
+  let batchNumber = 0
+
+  while (true) {
+    const remainingRuntimeMs = deadline - dependencies.now()
+    if (remainingRuntimeMs <= SUPERVISOR_DEADLINE_BUFFER_MS) {
+      console.log("Supervisor runtime reached; exiting cleanly.")
+      return
+    }
+    const remainingRuntimeMinutes = Math.ceil(
+      (remainingRuntimeMs - SUPERVISOR_DEADLINE_BUFFER_MS) / 60_000,
+    )
+
+    batchNumber += 1
+    console.log(
+      `Starting footprinter population batch ${batchNumber} with up to ${POPULATION_BATCH_COMPONENT_LIMIT} components and ${remainingRuntimeMinutes} minute(s) remaining.`,
+    )
+    const batchStartedAt = dependencies.now()
+    const exitCode = await dependencies.runBatch({
+      maxComponents: POPULATION_BATCH_COMPONENT_LIMIT,
+      maxRuntimeMinutes: remainingRuntimeMinutes,
+      restartOnLimit: true,
+      retryNullEntries: options.retryNullEntries,
+    })
+    const batchDurationMs = dependencies.now() - batchStartedAt
+
+    if (exitCode === 0) {
+      console.log("Population worker finished without requesting a restart.")
+      return
+    }
+
+    if (exitCode === POPULATION_BATCH_RESTART_EXIT_CODE) {
+      rapidWasmRestarts = 0
+      console.log(
+        `Population batch reached its component limit; starting with a fresh WASM runtime.`,
+      )
+      continue
+    }
+
+    if (exitCode === POPULATION_WASM_RESTART_EXIT_CODE) {
+      rapidWasmRestarts =
+        batchDurationMs < RAPID_WASM_RESTART_THRESHOLD_MS
+          ? rapidWasmRestarts + 1
+          : 1
+      if (rapidWasmRestarts >= RAPID_WASM_RESTART_LIMIT) {
+        throw new Error(
+          `Manifold WASM aborted ${rapidWasmRestarts} times in rapid succession; stopping instead of retrying indefinitely.`,
+        )
+      }
+      console.warn(
+        `Population worker detected a poisoned Manifold WASM runtime; restarting in ${WASM_RESTART_DELAY_MS}ms.`,
+      )
+      await dependencies.sleep(WASM_RESTART_DELAY_MS)
+      continue
+    }
+
+    throw new Error(`Population worker exited with code ${exitCode}`)
+  }
+}
+
+if (import.meta.main) {
+  await superviseFootprinterPopulation(
+    parseSupervisorOptions(Bun.argv.slice(2)),
+  )
+}

--- a/tests/footprinter-population-restarts.test.ts
+++ b/tests/footprinter-population-restarts.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test"
+import {
+  POPULATION_BATCH_COMPONENT_LIMIT,
+  POPULATION_BATCH_RESTART_EXIT_CODE,
+  POPULATION_WASM_RESTART_EXIT_CODE,
+  RAPID_WASM_RESTART_LIMIT,
+  WASM_RESTART_DELAY_MS,
+  isManifoldWasmAbort,
+} from "../lib/footprinter-population-restarts"
+import {
+  parseSupervisorOptions,
+  superviseFootprinterPopulation,
+  type PopulationBatchOptions,
+} from "../scripts/supervise-footprinter-strings"
+
+describe("footprinter population restarts", () => {
+  test("recognizes an Emscripten Manifold abort", () => {
+    expect(
+      isManifoldWasmAbort(
+        new WebAssembly.RuntimeError(
+          "Aborted(). Build with -sASSERTIONS for more info.",
+        ),
+      ),
+    ).toBe(true)
+    expect(isManifoldWasmAbort(new Error("The operation was aborted"))).toBe(
+      false,
+    )
+  })
+
+  test("parses workflow options", () => {
+    expect(
+      parseSupervisorOptions([
+        "--max-runtime-minutes",
+        "120",
+        "--retry-null-entries",
+      ]),
+    ).toEqual({ maxRuntimeMinutes: 120, retryNullEntries: true })
+  })
+
+  test("starts fresh workers after each planned batch", async () => {
+    let currentTime = 0
+    const batchOptions: PopulationBatchOptions[] = []
+    const exitCodes = [
+      POPULATION_BATCH_RESTART_EXIT_CODE,
+      POPULATION_BATCH_RESTART_EXIT_CODE,
+      0,
+    ]
+
+    await superviseFootprinterPopulation(
+      { maxRuntimeMinutes: 10, retryNullEntries: false },
+      {
+        now: () => currentTime,
+        runBatch: async (options) => {
+          batchOptions.push(options)
+          currentTime += 60_000
+          return exitCodes.shift() ?? 0
+        },
+        sleep: async () => {},
+      },
+    )
+
+    expect(batchOptions).toHaveLength(3)
+    expect(batchOptions[0]).toMatchObject({
+      maxComponents: POPULATION_BATCH_COMPONENT_LIMIT,
+      maxRuntimeMinutes: 10,
+      restartOnLimit: true,
+    })
+    expect(batchOptions[1]?.maxRuntimeMinutes).toBe(9)
+  })
+
+  test("restarts after a WASM abort with a short delay", async () => {
+    let currentTime = 0
+    const sleeps: number[] = []
+    const exitCodes = [POPULATION_WASM_RESTART_EXIT_CODE, 0]
+
+    await superviseFootprinterPopulation(
+      { maxRuntimeMinutes: 10, retryNullEntries: false },
+      {
+        now: () => currentTime,
+        runBatch: async () => exitCodes.shift() ?? 0,
+        sleep: async (durationMs) => {
+          sleeps.push(durationMs)
+          currentTime += durationMs
+        },
+      },
+    )
+
+    expect(sleeps).toEqual([WASM_RESTART_DELAY_MS])
+  })
+
+  test("stops a rapid WASM restart storm", async () => {
+    let attempts = 0
+
+    await expect(
+      superviseFootprinterPopulation(
+        { maxRuntimeMinutes: 10, retryNullEntries: false },
+        {
+          now: () => 0,
+          runBatch: async () => {
+            attempts += 1
+            return POPULATION_WASM_RESTART_EXIT_CODE
+          },
+          sleep: async () => {},
+        },
+      ),
+    ).rejects.toThrow("stopping instead of retrying indefinitely")
+    expect(attempts).toBe(RAPID_WASM_RESTART_LIMIT)
+  })
+})


### PR DESCRIPTION
## Summary

- run footprinter population in supervised 1,000-component child batches so Manifold WASM is periodically recycled
- detect the observed Emscripten `Aborted(). Build with -sASSERTIONS...` failure, flush completed rows, and restart in a fresh process
- stop after three rapid WASM aborts instead of creating an infinite retry loop
- keep the workflow's 240-minute global deadline and existing null-retry behavior

## Root cause

The four-hour production run processed components normally for about 76 minutes, then the long-lived Manifold WASM module entered an aborted state. Every later conversion failed even though affected components, including C696190, converted successfully in a fresh process. Network requests and permanent-null writes continued, so the poisoned process wasted the remainder of the run.

## Validation

- `bun test` — 223 passed
- `bun test tests/footprinter-population-restarts.test.ts` — 5 passed
- `bunx tsc --noEmit`
- `bun run format:check`
- `git diff --cached --check`

The affected production run was canceled; rows already committed to D1 and objects already cached in R2 were preserved.