### PR TITLE
Update easyeda to 0.0.299

### DIFF
--- a/cf-proxy/bun.lock
+++ b/cf-proxy/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "cf-proxy",
       "dependencies": {
-        "easyeda": "^0.0.286",
+        "easyeda": "^0.0.299",
         "kysely": "^0.28.3",
         "kysely-d1": "^0.4.0",
       },
@@ -281,7 +281,7 @@
 
     "devalue": ["devalue@4.3.3", "", {}, "sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg=="],
 
-    "easyeda": ["easyeda@0.0.286", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda": "dist/main.cjs", "easyeda-converter": "dist/main.cjs" } }, "sha512-FZcQf3TqJmyF69WO1fJvL5G7jtCUWtCBhTC19P+mZfuBGKteGCt9pMCfzLEarIfstIDLJB+xfE72SZpV785qLg=="],
+    "easyeda": ["easyeda@0.0.299", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-T3uwCuryNIGKpDWcdee5L6CVXPjqng7VYsNT+l3lqHOclBT0mVwGp5SqEiFKO0STma/P7ky43gZ3Bv+uEU9D9Q=="],
 
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 

--- a/cf-proxy/package.json
+++ b/cf-proxy/package.json
@@ -10,7 +10,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "easyeda": "^0.0.286",
+    "easyeda": "^0.0.299",
     "kysely": "^0.28.3",
     "kysely-d1": "^0.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@tscircuit/footprinter": "^0.0.143",
     "circuit-json-to-footprinter": "^0.0.40",
-    "easyeda": "^0.0.286",
+    "easyeda": "^0.0.299",
     "format-si-unit": "^0.0.10",
     "kysely-bun-sqlite": "^0.3.2"
   }


### PR DESCRIPTION
## Summary

- update the root population dependency from `easyeda@^0.0.286` to `^0.0.299`
- update the Cloudflare proxy dependency and Bun lockfile to the same version

## Why

[easyeda-converter PR #457](https://github.com/tscircuit/easyeda-converter/pull/457) safely normalizes the three malformed payload families seen by the population workflow:

- digit-only string values for `szlcsc.id`
- missing, null, or empty `dataStr.head.utime`
- text alignment `"P"`

Because the package is still below `0.1.0`, the existing `^0.0.286` range cannot resolve to `0.0.299`; the manifest must be updated explicitly.

## Impact

The next footprinter population workflow dispatched after this PR is merged will use the parsing fixes. The already-running workflow remains on its original checkout.

## Validation

- `bun test` — 223 passed
- `bunx tsc --noEmit`
- `bunx biome format . --vcs-enabled=true --vcs-use-ignore-file=true --vcs-client-kind=git`
- parsed live cached payloads for `C53562`, `C110074`, and `C2879807` with `EasyEdaJsonSchema`
