### PR TITLE
Add extended promotional component filter

### DIFF
--- a/.github/workflows/d1-migrations.yml
+++ b/.github/workflows/d1-migrations.yml
@@ -155,12 +155,24 @@ jobs:
               exit 1
             fi
 
+            extended_promotional_count="$(sqlite3 db.sqlite3 "SELECT COUNT(*) FROM component_catalog WHERE is_extended_promotional=1;")"
+            if [[ "${extended_promotional_count}" == "0" ]]; then
+              echo "::error::Prepared catalog contains no extended promotional components."
+              exit 1
+            fi
+
+            classification_mismatches="$(sqlite3 db.sqlite3 "SELECT COUNT(*) FROM component_catalog WHERE coalesce(is_extended_promotional, -1) <> CASE WHEN basic=0 AND preferred=1 THEN 1 ELSE 0 END;")"
+            if [[ "${classification_mismatches}" != "0" ]]; then
+              echo "::error::Prepared catalog contains ${classification_mismatches} inconsistent extended promotional classifications."
+              exit 1
+            fi
+
             smoke_test_count="$(sqlite3 db.sqlite3 "SELECT COUNT(*) FROM component_catalog WHERE lcsc=${SMOKE_TEST_LCSC};")"
             if [[ "${smoke_test_count}" != "1" ]]; then
               echo "::error::Prepared catalog does not contain C${SMOKE_TEST_LCSC}."
               exit 1
             fi
-            echo "component_catalog: ${catalog_count} prepared rows"
+            echo "component_catalog: ${catalog_count} prepared rows (${extended_promotional_count} extended promotional)"
           elif [[ "${SYNC_SCOPE}" == "stock_only" ]]; then
             stock_snapshot_exists="$(sqlite3 db.sqlite3 "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='component_stock');")"
             if [[ "${stock_snapshot_exists}" != "1" ]]; then

--- a/cf-proxy/scripts/rebuild-search-index-batched.sh
+++ b/cf-proxy/scripts/rebuild-search-index-batched.sh
@@ -43,6 +43,7 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
      price1 REAL,
      basic INTEGER,
      preferred INTEGER,
+     is_extended_promotional INTEGER,
      category TEXT,
      subcategory TEXT,
      manufacturer_name TEXT,
@@ -70,6 +71,7 @@ INSERT INTO search_index_next (
   price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   manufacturer_name,
@@ -102,6 +104,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -144,7 +147,9 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
    CREATE INDEX IF NOT EXISTS idx_search_index_next_lcsc ON search_index_next(lcsc);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_package ON search_index_next(package);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_basic ON search_index_next(basic);
-   CREATE INDEX IF NOT EXISTS idx_search_index_next_preferred ON search_index_next(preferred);"
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_preferred ON search_index_next(preferred);
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_extended_promotional ON search_index_next(is_extended_promotional);
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_extended_promotional_stock ON search_index_next(is_extended_promotional, stock DESC);"
 
 echo "Validating row count..."
 run_wrangler d1 execute "$DB_NAME" --remote --command \
@@ -168,11 +173,15 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
    DROP INDEX IF EXISTS idx_search_index_package;
    DROP INDEX IF EXISTS idx_search_index_basic;
    DROP INDEX IF EXISTS idx_search_index_preferred;
+   DROP INDEX IF EXISTS idx_search_index_extended_promotional;
+   DROP INDEX IF EXISTS idx_search_index_extended_promotional_stock;
    ALTER TABLE search_index_next RENAME TO search_index;
    CREATE INDEX IF NOT EXISTS idx_search_index_stock ON search_index(stock DESC);
    CREATE INDEX IF NOT EXISTS idx_search_index_lcsc ON search_index(lcsc);
    CREATE INDEX IF NOT EXISTS idx_search_index_package ON search_index(package);
    CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
-   CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);"
+   CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
+   CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+   CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);"
 
 echo "Done. Old table kept as search_index_old for rollback."

--- a/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
+++ b/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
@@ -25,6 +25,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -66,3 +67,5 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);

--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -334,6 +334,11 @@ SELECT
   package,
   basic,
   preferred,
+  -- The legacy view exposes the same classification as basic + preferred.
+  CASE
+    WHEN basic = 0 AND preferred = 1 THEN 1
+    ELSE 0
+  END AS is_extended_promotional,
   description,
   stock,
   price,
@@ -344,6 +349,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(is_extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA
 }
@@ -359,6 +365,7 @@ CREATE TABLE component_catalog (
   package TEXT,
   basic INTEGER,
   preferred INTEGER,
+  is_extended_promotional INTEGER,
   description TEXT,
   stock INTEGER,
   price TEXT,
@@ -368,6 +375,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(is_extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA_EXPORT
 }
@@ -401,6 +409,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  is_extended_promotional,
   category,
   subcategory,
   CASE
@@ -442,6 +451,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);
 SEARCH_INDEX_SCHEMA
 }
 
@@ -458,6 +469,7 @@ CREATE TABLE search_index (
   price1 REAL,
   basic INTEGER,
   preferred INTEGER,
+  is_extended_promotional INTEGER,
   category TEXT,
   subcategory TEXT,
   manufacturer_name TEXT,
@@ -475,6 +487,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(is_extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(is_extended_promotional, stock DESC);
 SEARCH_INDEX_SCHEMA_EXPORT
 }
 

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -22,6 +23,7 @@ export async function queryComponentCatalog(
     package: string | null
     basic: number | null
     preferred: number | null
+    is_extended_promotional: number | null
     description: string | null
     stock: number | null
     price: string | null
@@ -34,6 +36,7 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -231,6 +231,7 @@ export interface ComponentCatalog {
   category: string | null
   description: string | null
   extra: string | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   package: string | null
@@ -815,6 +816,7 @@ export interface SearchIndex {
   basic: number | null
   category: string | null
   description: string | null
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   manufacturer_name: string | null

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -456,6 +456,7 @@ async function handleD1Search(
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
       is_preferred: Boolean(row.preferred),
+      is_extended_promotional: Boolean(row.is_extended_promotional),
       description: row.description ?? "",
       stock: row.stock ?? 0,
       price: row.price1 ?? extractSmallQuantityPrice(row.price),
@@ -581,6 +582,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        is_extended_promotional: Boolean(row.is_extended_promotional),
       })),
     }
 

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -175,6 +175,7 @@ const COLUMN_LABELS: Record<string, string> = {
   in_stock: "In Stock",
   is_basic: "Basic",
   is_preferred: "Preferred",
+  is_extended_promotional: "Extended Promotional",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
   voltage_rating: "Voltage",
@@ -709,6 +710,9 @@ const renderComponentsFilters = (
   </div>
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
+  </div>
+  <div>
+    <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <button type="submit">Filter</button>
 </form>`

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -21,6 +22,7 @@ interface SearchRow {
   price1: number | null
   basic: number | null
   preferred: number | null
+  is_extended_promotional: number | null
   category: string | null
   subcategory: string | null
 }
@@ -110,6 +112,13 @@ export async function searchIndex(
     conditions.push(sql`search_index.preferred = 1`)
   }
 
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`search_index.is_extended_promotional = 1`)
+  }
+
   const raw = params.q?.trim()
 
   if (raw) {
@@ -151,6 +160,7 @@ export async function searchIndex(
       search_index.price1,
       search_index.basic,
       search_index.preferred,
+      search_index.is_extended_promotional,
       search_index.category,
       search_index.subcategory
     FROM search_index

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -261,6 +261,35 @@ describe("render helpers", () => {
     expect(html).toContain("/hdmi_ports/list.json")
   })
 
+  it("renders and preserves the extended promotional component filter", () => {
+    const html = renderD1TablePage(
+      "/components/list",
+      {
+        components: [
+          {
+            lcsc: 23456,
+            mfr: "HDMI-EXT",
+            package: "SMD",
+            description: "Extended promotional HDMI part",
+            is_extended_promotional: true,
+          },
+        ],
+      },
+      {
+        search: "HDMI",
+        is_extended_promotional: "true",
+      },
+      "https://jlcsearch.tscircuit.com/components/list?search=HDMI&is_extended_promotional=true",
+    )
+
+    expect(html).toContain("<h2>Components</h2>")
+    expect(html).toContain(
+      'name="is_extended_promotional" value="true" checked',
+    )
+    expect(html).toContain(">Extended Promotional</th>")
+    expect(html).toContain("HDMI-EXT")
+  })
+
   it("renders ARM processor memory sizes with byte units", () => {
     const html = renderD1TablePage(
       "/arm_processors/list",

--- a/scripts/build-derived-sync-db.ts
+++ b/scripts/build-derived-sync-db.ts
@@ -136,6 +136,12 @@ export const buildDerivedSyncDatabase = async ({
         j.package,
         CASE WHEN j.library_type = 'base' THEN 1 ELSE 0 END AS basic,
         j.preferred,
+        -- source-db-v2 normalizes JLC's Extended label to "expand";
+        -- preferred marks the temporary fee-waived component list.
+        CASE
+          WHEN j.library_type = 'expand' AND j.preferred = 1 THEN 1
+          ELSE 0
+        END AS is_extended_promotional,
         j.description,
         j.stock,
         j.price,

--- a/tests/build-derived-sync-db.test.ts
+++ b/tests/build-derived-sync-db.test.ts
@@ -104,7 +104,8 @@ describe("buildDerivedSyncDatabase", () => {
         `SELECT
           lcsc, price1, number_of_pins, gender, mounting_style,
           is_basic, is_preferred
-        FROM hdmi_port`,
+        FROM hdmi_port
+        WHERE lcsc = 12345`,
       )
       .get() as Record<string, unknown>
 
@@ -168,6 +169,79 @@ describe("buildDerivedSyncDatabase", () => {
       mpn: "HDMI-19P",
       gender: "Female",
     })
+    output.close()
+  })
+
+  test("distinguishes base, regular extended, and promotional extended rows", async () => {
+    const { sourcePath, outputPath } = await createSourceDatabase()
+    const source = new Database(sourcePath)
+    source
+      .query(
+        `INSERT INTO jlc_components (
+          lcsc, fetched_at, present, sync_seen, category, subcategory, mfr,
+          package, joints, manufacturer, library_type, preferred, last_on_stock,
+          description, datasheet, stock, price, attributes
+        ) VALUES (
+          23456, unixepoch(), 1, 1, 'Connectors',
+          'HDMI Connectors', 'HDMI-EXT', 'SMD', 19, 'Example', 'expand', 1,
+          unixepoch(), 'Extended promotional HDMI part', '', 125,
+          '1-:1.50', '{}'
+        )`,
+      )
+      .run()
+    source
+      .query(
+        `INSERT INTO jlc_components (
+          lcsc, fetched_at, present, sync_seen, category, subcategory, mfr,
+          package, joints, manufacturer, library_type, preferred, last_on_stock,
+          description, datasheet, stock, price, attributes
+        ) VALUES (
+          34567, unixepoch(), 1, 1, 'Connectors',
+          'HDMI Connectors', 'HDMI-REGULAR-EXT', 'SMD', 19, 'Example',
+          'expand', 0, unixepoch(), 'Regular extended HDMI part', '', 100,
+          '1-:1.75', '{}'
+        )`,
+      )
+      .run()
+    source.close()
+
+    await buildDerivedSyncDatabase({
+      sourcePath,
+      outputPath,
+      tableNames: ["hdmi_port"],
+      includeComponentCatalog: true,
+      logger: () => {},
+    })
+
+    const output = new Database(outputPath, { readonly: true })
+    expect(
+      output
+        .query(
+          `SELECT lcsc, basic, preferred, is_extended_promotional
+           FROM component_catalog
+           ORDER BY lcsc`,
+        )
+        .all(),
+    ).toEqual([
+      {
+        lcsc: 12345,
+        basic: 1,
+        preferred: 1,
+        is_extended_promotional: 0,
+      },
+      {
+        lcsc: 23456,
+        basic: 0,
+        preferred: 1,
+        is_extended_promotional: 1,
+      },
+      {
+        lcsc: 34567,
+        basic: 0,
+        preferred: 0,
+        is_extended_promotional: 0,
+      },
+    ])
     output.close()
   })
 

--- a/tests/extended-promotional-search-index.test.ts
+++ b/tests/extended-promotional-search-index.test.ts
@@ -1,0 +1,84 @@
+import { Database } from "bun:sqlite"
+import { expect, test } from "bun:test"
+import { Kysely } from "kysely"
+import { BunSqliteDialect } from "kysely-bun-sqlite"
+import { queryComponentCatalog } from "../cf-proxy/src/components"
+import { searchIndex } from "../cf-proxy/src/search"
+
+test("search index materializes and filters extended promotional parts", async () => {
+  const database = new Database(":memory:")
+  database.exec(`
+    CREATE TABLE component_catalog (
+      lcsc INTEGER NOT NULL UNIQUE,
+      category TEXT,
+      subcategory TEXT,
+      mfr TEXT,
+      package TEXT,
+      basic INTEGER,
+      preferred INTEGER,
+      is_extended_promotional INTEGER,
+      description TEXT,
+      stock INTEGER,
+      price TEXT,
+      extra TEXT
+    );
+
+    INSERT INTO component_catalog (
+      lcsc, category, subcategory, mfr, package, basic, preferred,
+      is_extended_promotional, description, stock, price, extra
+    ) VALUES
+      (1001, 'Connectors', 'HDMI', 'HDMI-BASE', 'SMD', 1, 1, 0,
+       'Base HDMI part', 100, '1-:1.25', '{}'),
+      (1002, 'Connectors', 'HDMI', 'HDMI-EXT', 'SMD', 0, 1, 1,
+       'Extended promotional HDMI part', 200, '1-:1.50', '{}'),
+      (1003, 'Connectors', 'HDMI', 'HDMI-REGULAR-EXT', 'SMD', 0, 0, 0,
+       'Regular extended HDMI part', 150, '1-:1.75', '{}');
+  `)
+
+  const rebuildScript = await Bun.file(
+    new URL(
+      "../cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql",
+      import.meta.url,
+    ),
+  ).text()
+  database.exec(rebuildScript)
+
+  const db = new Kysely<any>({
+    dialect: new BunSqliteDialect({ database }),
+  })
+  const searchDb = db as unknown as Parameters<typeof searchIndex>[0]
+
+  try {
+    const rows = await searchIndex(searchDb, {
+      is_extended_promotional: "true",
+    })
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      lcsc: 1002,
+      is_extended_promotional: 1,
+    })
+
+    const numericRows = await searchIndex(searchDb, {
+      is_extended_promotional: "1",
+    })
+    expect(numericRows.map((row) => row.lcsc)).toEqual([1002])
+
+    const catalogRows = await queryComponentCatalog(searchDb, {
+      is_extended_promotional: "true",
+    })
+    expect(catalogRows.map((row) => row.lcsc)).toEqual([1002])
+
+    expect(
+      database
+        .query(
+          `SELECT name
+           FROM sqlite_master
+           WHERE type = 'index'
+             AND name = 'idx_search_index_extended_promotional_stock'`,
+        )
+        .get(),
+    ).toEqual({ name: "idx_search_index_extended_promotional_stock" })
+  } finally {
+    await db.destroy()
+  }
+})

--- a/tests/extended-promotional-worker.test.ts
+++ b/tests/extended-promotional-worker.test.ts
@@ -1,0 +1,103 @@
+/// <reference path="../cf-proxy/node_modules/@cloudflare/workers-types/index.d.ts" />
+
+import { Database, type SQLQueryBindings } from "bun:sqlite"
+import { expect, test } from "bun:test"
+import { createSelf, createTestEnv } from "../cf-proxy/test/test-env"
+
+const createSqliteD1 = (database: Database): D1Database => {
+  const prepare = (query: string, parameters: SQLQueryBindings[] = []) => ({
+    bind: (...values: SQLQueryBindings[]) => prepare(query, values),
+    all: async () => ({
+      results: database
+        .query<Record<string, unknown>, SQLQueryBindings[]>(query)
+        .all(...parameters),
+      success: true,
+      meta: { changes: 0 },
+    }),
+  })
+
+  return { prepare } as unknown as D1Database
+}
+
+test("worker filters and exposes extended promotional components", async () => {
+  const database = new Database(":memory:")
+  database.exec(`
+    CREATE TABLE search_index (
+      lcsc INTEGER PRIMARY KEY,
+      mfr TEXT,
+      package TEXT,
+      description TEXT,
+      stock INTEGER,
+      price TEXT,
+      price1 REAL,
+      basic INTEGER,
+      preferred INTEGER,
+      is_extended_promotional INTEGER,
+      category TEXT,
+      subcategory TEXT,
+      search_text TEXT
+    );
+    INSERT INTO search_index (
+      lcsc, mfr, package, description, stock, price, price1, basic, preferred,
+      is_extended_promotional, category, subcategory, search_text
+    ) VALUES
+      (1001, 'HDMI-BASE', 'SMD', 'Base HDMI part', 100, '1-:1.25', 1.25,
+       1, 1, 0, 'Connectors', 'HDMI', 'hdmi base'),
+      (1002, 'HDMI-EXT', 'SMD', 'Extended promotional HDMI part', 200,
+       '1-:1.50', 1.50, 0, 1, 1, 'Connectors', 'HDMI',
+       'hdmi extended promotional'),
+      (1003, 'HDMI-REGULAR-EXT', 'SMD', 'Regular extended HDMI part', 150,
+       '1-:1.75', 1.75, 0, 0, 0, 'Connectors', 'HDMI',
+       'hdmi regular extended');
+  `)
+
+  const env = createTestEnv()
+  env.USE_D1 = "true"
+  env.DB = createSqliteD1(database)
+  const self = createSelf(env)
+
+  try {
+    const searchResponse = await self.fetch(
+      "https://example.com/api/search?is_extended_promotional=true&cachebust=1",
+      { headers: { accept: "application/json" } },
+    )
+    expect(searchResponse.status).toBe(200)
+    expect((await searchResponse.json()) as any).toEqual({
+      components: [
+        expect.objectContaining({
+          lcsc: 1002,
+          is_extended_promotional: true,
+        }),
+      ],
+    })
+
+    const listResponse = await self.fetch(
+      "https://example.com/components/list?json=true&is_extended_promotional=1&cachebust=1",
+      { headers: { accept: "application/json" } },
+    )
+    expect(listResponse.status).toBe(200)
+    expect((await listResponse.json()) as any).toEqual({
+      components: [
+        expect.objectContaining({
+          lcsc: 1002,
+          is_extended_promotional: true,
+        }),
+      ],
+    })
+
+    const htmlResponse = await self.fetch(
+      "https://example.com/components/list?is_extended_promotional=true&cachebust=1",
+      { headers: { accept: "text/html" } },
+    )
+    const html = await htmlResponse.text()
+    expect(htmlResponse.status).toBe(200)
+    expect(html).toContain(
+      'name="is_extended_promotional" value="true" checked',
+    )
+    expect(html).toContain("HDMI-EXT")
+    expect(html).not.toContain("HDMI-REGULAR-EXT")
+  } finally {
+    await self.flushWaitUntil()
+    database.close()
+  }
+})


### PR DESCRIPTION
## Summary

- derive `is_extended_promotional` from the source-db-v2 catalog and materialize it through `component_catalog` and `search_index`
- expose the flag in `/api/search` and `/components/list`, add a parameterized `extended_promotional=true` filter, and render a checked UI filter plus result column
- verify the production full-catalog rebuild fails closed if promotional rows are absent or do not match the upstream `basic = 0 AND preferred = 1` semantics

## Why this classification

JLCPCB's Promotional Extended library is a subset of Extended parts, not every Extended part. The upstream data source normalizes the raw `libraryType="extended"` value to `library_type="expand"`, while the preferred-component import carries JLCPCB's promotional/preferred flag. The derived source-db-v2 classification is therefore:

```sql
library_type = 'expand' AND preferred = 1
```

The legacy catalog exposes only `basic` and `preferred`, so its equivalent is `basic = 0 AND preferred = 1`.

Primary references:

- upstream library-type normalization and preferred import: https://github.com/yaqwsx/jlcparts/blob/7ef2c97e359d6d192ab2c7ae1fa3f3c3e5de2bd7/jlcparts/sourceDb.py
- JLCPCB's Basic & Promotional Extended Parts page: https://jlcpcb.com/parts/basic_parts

## Coverage

- database regression covers Basic+preferred, Extended+preferred, and Extended+not-preferred rows
- actual SQLite materialization/query regression verifies the indexed filter
- Worker integration regression verifies both JSON endpoints and the rendered HTML filter/result
- existing API/render regressions remain green

## Checks

- `bun test` — 227 passed, 0 failed
- `cd cf-proxy && bun test` — 151 passed, 0 failed
- `bunx tsc --noEmit`
- `bunx tsc --noEmit --project cf-proxy/tsconfig.json`
- `bun run format:check`
- `bash -n cf-proxy/scripts/sync-db.sh cf-proxy/scripts/rebuild-search-index-batched.sh`
- `git diff --check`
- workflow YAML parse
- Gitleaks — 0 findings
- Semgrep changed-TypeScript scan — 0 findings across 89 rules

The real-browser UI demo is attached in the first PR comment.

/claim #92

Fixes #92
