### PR TITLE
Update easyeda to 0.0.301

### DIFF
--- a/cf-proxy/bun.lock
+++ b/cf-proxy/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "cf-proxy",
       "dependencies": {
-        "easyeda": "^0.0.299",
+        "easyeda": "^0.0.301",
         "kysely": "^0.28.3",
         "kysely-d1": "^0.4.0",
       },
@@ -281,7 +281,7 @@
 
     "devalue": ["devalue@4.3.3", "", {}, "sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg=="],
 
-    "easyeda": ["easyeda@0.0.299", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-T3uwCuryNIGKpDWcdee5L6CVXPjqng7VYsNT+l3lqHOclBT0mVwGp5SqEiFKO0STma/P7ky43gZ3Bv+uEU9D9Q=="],
+    "easyeda": ["easyeda@0.0.301", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-O0dPOFJgmcYvYeBA6+6Fey9gaRe4VOVfeVh06F1whzCPQOZu+SQtEVW5X5QN014bL78b4VDtPyjXu6ldmfq6HA=="],
 
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 

--- a/cf-proxy/package.json
+++ b/cf-proxy/package.json
@@ -10,7 +10,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "easyeda": "^0.0.299",
+    "easyeda": "^0.0.301",
     "kysely": "^0.28.3",
     "kysely-d1": "^0.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@tscircuit/footprinter": "^0.0.143",
     "circuit-json-to-footprinter": "^0.0.40",
-    "easyeda": "^0.0.299",
+    "easyeda": "^0.0.301",
     "format-si-unit": "^0.0.10",
     "kysely-bun-sqlite": "^0.3.2"
   }


### PR DESCRIPTION
## Summary

- update the root population dependency from `easyeda@^0.0.299` to the current npm release, `^0.0.301`
- update the Cloudflare proxy dependency and Bun lockfile to the same version

## Why

Keep the footprinter population worker and shared EasyEDA cache worker on the latest converter fixes. Since `easyeda` is still below `0.1.0`, the existing caret range does not float from `0.0.299` to `0.0.301`.

## Impact

Population workflows dispatched after this PR is merged will install `easyeda@0.0.301`. Any workflow that has already checked out its commit remains unchanged.

## Validation

- `bun test` — 223 passed
- `bunx tsc --noEmit`
- `bunx biome format . --vcs-enabled=true --vcs-use-ignore-file=true --vcs-client-kind=git`
- parsed live cached payloads for `C53562`, `C110074`, and `C2879807` with `EasyEdaJsonSchema`
