### PR TITLE
Update easyeda to 0.0.303

### DIFF
--- a/cf-proxy/bun.lock
+++ b/cf-proxy/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "cf-proxy",
       "dependencies": {
-        "easyeda": "^0.0.301",
+        "easyeda": "^0.0.303",
         "kysely": "^0.28.3",
         "kysely-d1": "^0.4.0",
       },
@@ -281,7 +281,7 @@
 
     "devalue": ["devalue@4.3.3", "", {}, "sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg=="],
 
-    "easyeda": ["easyeda@0.0.301", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-O0dPOFJgmcYvYeBA6+6Fey9gaRe4VOVfeVh06F1whzCPQOZu+SQtEVW5X5QN014bL78b4VDtPyjXu6ldmfq6HA=="],
+    "easyeda": ["easyeda@0.0.303", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-cyc0VGvnfNiH7zA9VA/6oAGiFgS9rT3QFaQZFC0V1RSSqT4hTtQCGTpZ1tVYcgPbaHj7wU02AqVUAwsfjuv6DA=="],
 
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 

--- a/cf-proxy/package.json
+++ b/cf-proxy/package.json
@@ -10,7 +10,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "easyeda": "^0.0.301",
+    "easyeda": "^0.0.303",
     "kysely": "^0.28.3",
     "kysely-d1": "^0.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@tscircuit/footprinter": "^0.0.143",
     "circuit-json-to-footprinter": "^0.0.40",
-    "easyeda": "^0.0.301",
+    "easyeda": "^0.0.303",
     "format-si-unit": "^0.0.10",
     "kysely-bun-sqlite": "^0.3.2"
   }


### PR DESCRIPTION
## Summary

- Update `easyeda` from `0.0.301` to `0.0.303` in the root package and Cloudflare proxy package.
- Refresh `cf-proxy/bun.lock` to resolve the new release.

This picks up the latest EasyEDA converter release after the payload parsing issues reported in [easyeda-converter#464](https://github.com/tscircuit/easyeda-converter/issues/464).

## Validation

- Root test suite: 223 passed.
- Cloudflare proxy test suite: 150 passed.
- `git diff --check`: passed.
- The repository-wide formatter check still reports the pre-existing generated `.wrangler/cache/wrangler-account.json` formatting issue; no generated files are included in this PR.