### PR TITLE
Add is_extended_promotional column to components

### DIFF
--- a/cf-proxy/scripts/rebuild-search-index-batched.sh
+++ b/cf-proxy/scripts/rebuild-search-index-batched.sh
@@ -43,6 +43,7 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
      price1 REAL,
      basic INTEGER,
      preferred INTEGER,
+     extended_promotional INTEGER,
      category TEXT,
      subcategory TEXT,
      manufacturer_name TEXT,
@@ -70,6 +71,7 @@ INSERT INTO search_index_next (
   price1,
   basic,
   preferred,
+  extended_promotional,
   category,
   subcategory,
   manufacturer_name,
@@ -102,6 +104,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  extended_promotional,
   category,
   subcategory,
   CASE
@@ -144,7 +147,8 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
    CREATE INDEX IF NOT EXISTS idx_search_index_next_lcsc ON search_index_next(lcsc);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_package ON search_index_next(package);
    CREATE INDEX IF NOT EXISTS idx_search_index_next_basic ON search_index_next(basic);
-   CREATE INDEX IF NOT EXISTS idx_search_index_next_preferred ON search_index_next(preferred);"
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_preferred ON search_index_next(preferred);
+   CREATE INDEX IF NOT EXISTS idx_search_index_next_extended_promotional ON search_index_next(extended_promotional);"
 
 echo "Validating row count..."
 run_wrangler d1 execute "$DB_NAME" --remote --command \
@@ -168,11 +172,13 @@ run_wrangler d1 execute "$DB_NAME" --remote --command \
    DROP INDEX IF EXISTS idx_search_index_package;
    DROP INDEX IF EXISTS idx_search_index_basic;
    DROP INDEX IF EXISTS idx_search_index_preferred;
+   DROP INDEX IF EXISTS idx_search_index_extended_promotional;
    ALTER TABLE search_index_next RENAME TO search_index;
    CREATE INDEX IF NOT EXISTS idx_search_index_stock ON search_index(stock DESC);
    CREATE INDEX IF NOT EXISTS idx_search_index_lcsc ON search_index(lcsc);
    CREATE INDEX IF NOT EXISTS idx_search_index_package ON search_index(package);
    CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
-   CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);"
+   CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
+   CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(extended_promotional);"
 
 echo "Done. Old table kept as search_index_old for rollback."

--- a/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
+++ b/cf-proxy/scripts/rebuild-search-index-from-component-catalog.sql
@@ -25,6 +25,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  extended_promotional,
   category,
   subcategory,
   CASE
@@ -66,3 +67,5 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(extended_promotional, stock DESC);

--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -152,6 +152,16 @@ require_table() {
   fi
 }
 
+require_column() {
+  local table="$1"
+  local column="$2"
+  require_table "${table}"
+  if [[ "$(sqlite3 db.sqlite3 "SELECT EXISTS(SELECT 1 FROM pragma_table_info('${table}') WHERE name='${column}');")" != "1" ]]; then
+    echo "Expected ${table}.${column} to exist in the source database; refusing to upload a silent default."
+    exit 1
+  fi
+}
+
 require_unique_lcsc() {
   local table="$1"
   local row_count unique_lcsc_count null_lcsc_count
@@ -332,6 +342,7 @@ SELECT
   package,
   basic,
   preferred,
+  CASE WHEN preferred = 1 AND basic = 0 THEN 1 ELSE 0 END AS extended_promotional,
   description,
   stock,
   price,
@@ -342,6 +353,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA
 }
@@ -357,6 +369,7 @@ CREATE TABLE component_catalog (
   package TEXT,
   basic INTEGER,
   preferred INTEGER,
+  extended_promotional INTEGER,
   description TEXT,
   stock INTEGER,
   price TEXT,
@@ -366,6 +379,7 @@ CREATE INDEX IF NOT EXISTS idx_component_catalog_subcategory ON component_catalo
 CREATE INDEX IF NOT EXISTS idx_component_catalog_package ON component_catalog(package);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_basic ON component_catalog(basic);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_preferred ON component_catalog(preferred);
+CREATE INDEX IF NOT EXISTS idx_component_catalog_extended_promotional ON component_catalog(extended_promotional);
 CREATE INDEX IF NOT EXISTS idx_component_catalog_stock ON component_catalog(stock DESC);
 COMPONENT_CATALOG_SCHEMA_EXPORT
 }
@@ -399,6 +413,7 @@ SELECT
   END AS price1,
   basic,
   preferred,
+  extended_promotional,
   category,
   subcategory,
   CASE
@@ -440,6 +455,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(extended_promotional, stock DESC);
 SEARCH_INDEX_SCHEMA
 }
 
@@ -456,6 +473,7 @@ CREATE TABLE search_index (
   price1 REAL,
   basic INTEGER,
   preferred INTEGER,
+  extended_promotional INTEGER,
   category TEXT,
   subcategory TEXT,
   manufacturer_name TEXT,
@@ -473,6 +491,8 @@ CREATE INDEX IF NOT EXISTS idx_search_index_basic ON search_index(basic);
 CREATE INDEX IF NOT EXISTS idx_search_index_basic_stock ON search_index(basic, stock DESC);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred ON search_index(preferred);
 CREATE INDEX IF NOT EXISTS idx_search_index_preferred_stock ON search_index(preferred, stock DESC);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional ON search_index(extended_promotional);
+CREATE INDEX IF NOT EXISTS idx_search_index_extended_promotional_stock ON search_index(extended_promotional, stock DESC);
 SEARCH_INDEX_SCHEMA_EXPORT
 }
 
@@ -518,6 +538,7 @@ main() {
   fi
 
   if [[ "${SYNC_COMPONENT_CATALOG}" == "1" ]]; then
+    require_column component_catalog extended_promotional
     require_unique_lcsc component_catalog
     write_component_catalog_schema
     echo "Importing component catalog schema to D1..."
@@ -532,6 +553,7 @@ main() {
       echo "Using search_index already prepared in the source database."
       require_table search_index
     fi
+    require_column search_index extended_promotional
     require_unique_lcsc search_index
     write_search_index_schema
     echo "Importing search index schema to D1..."

--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -22,6 +23,7 @@ export async function queryComponentCatalog(
     package: string | null
     basic: number | null
     preferred: number | null
+    extended_promotional: number | null
     description: string | null
     stock: number | null
     price: string | null
@@ -34,6 +36,7 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -206,6 +206,7 @@ export interface BuckBoostConverter {
 export interface ComponentCatalog {
   basic: number | null
   category: string | null
+  extended_promotional: number | null
   description: string | null
   extra: string | null
   lcsc: Generated<number | null>
@@ -769,6 +770,7 @@ export interface SearchIndex {
   attributes: string | null
   basic: number | null
   category: string | null
+  extended_promotional: number | null
   description: string | null
   lcsc: Generated<number | null>
   mfr: string | null

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -456,6 +456,7 @@ async function handleD1Search(
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
       is_preferred: Boolean(row.preferred),
+      is_extended_promotional: Boolean(row.extended_promotional),
       description: row.description ?? "",
       stock: row.stock ?? 0,
       price: row.price1 ?? extractSmallQuantityPrice(row.price),
@@ -581,6 +582,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        is_extended_promotional: Boolean(row.extended_promotional),
       })),
     }
 

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -158,6 +158,7 @@ const COLUMN_LABELS: Record<string, string> = {
   in_stock: "In Stock",
   is_basic: "Basic",
   is_preferred: "Preferred",
+  is_extended_promotional: "Extended Promotional",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
   voltage_rating: "Voltage",
@@ -684,6 +685,9 @@ const renderComponentsFilters = (
   </div>
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
+  </div>
+  <div>
+    <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <button type="submit">Filter</button>
 </form>`

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -21,6 +22,7 @@ interface SearchRow {
   price1: number | null
   basic: number | null
   preferred: number | null
+  extended_promotional: number | null
   category: string | null
   subcategory: string | null
 }
@@ -110,6 +112,13 @@ export async function searchIndex(
     conditions.push(sql`search_index.preferred = 1`)
   }
 
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`search_index.extended_promotional = 1`)
+  }
+
   const raw = params.q?.trim()
 
   if (raw) {
@@ -151,6 +160,7 @@ export async function searchIndex(
       search_index.price1,
       search_index.basic,
       search_index.preferred,
+      search_index.extended_promotional,
       search_index.category,
       search_index.subcategory
     FROM search_index

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -20,6 +20,34 @@ describe("render helpers", () => {
     expect(html).toContain("/photo_diodes/list")
   })
 
+  it("renders the extended promotional components filter", () => {
+    const html = renderD1TablePage(
+      "/components/list",
+      {
+        components: [
+          {
+            lcsc: 12345,
+            mfr: "PROMO-PART",
+            package: "SMD",
+            description: "Promotional extended part",
+            stock: 100,
+            is_basic: false,
+            is_preferred: true,
+            is_extended_promotional: true,
+          },
+        ],
+      },
+      { is_extended_promotional: "true" },
+      "https://jlcsearch.tscircuit.com/components/list?is_extended_promotional=true",
+    )
+
+    expect(html).toContain('name="is_extended_promotional"')
+    expect(html).toContain(
+      'name="is_extended_promotional" value="true" checked',
+    )
+    expect(html).toContain("Extended Promotional")
+  })
+
   it("renders the Photo Diodes page and JSON API link", () => {
     const pathname = "/photo_diodes/list"
 

--- a/cf-proxy/test/search.test.ts
+++ b/cf-proxy/test/search.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest"
+import { getD1Client } from "../src/db/get-d1-client"
+import { searchIndex } from "../src/search"
+
+type RecordedStatement = {
+  sql: string
+  parameters: unknown[]
+}
+
+const createRecordingD1 = () => {
+  const statements: RecordedStatement[] = []
+  const database = {
+    prepare(sql: string) {
+      return {
+        bind(...parameters: unknown[]) {
+          statements.push({ sql, parameters })
+          return {
+            all: async () => ({
+              results: [
+                {
+                  lcsc: 12345,
+                  mfr: "PROMO-PART",
+                  package: "SMD",
+                  description: "Promotional extended part",
+                  stock: 100,
+                  price: "1-:1.00",
+                  price1: 1,
+                  basic: 0,
+                  preferred: 1,
+                  extended_promotional: 1,
+                  category: "Connectors",
+                  subcategory: "HDMI Connectors",
+                },
+              ],
+              meta: { changes: 0 },
+            }),
+          }
+        },
+      }
+    },
+  } as unknown as D1Database
+
+  return { database, statements }
+}
+
+describe("searchIndex extended promotional filter", () => {
+  it("adds the filter to the compiled D1 query when requested", async () => {
+    const { database, statements } = createRecordingD1()
+    const db = getD1Client(database)
+
+    const rows = await searchIndex(db, { is_extended_promotional: "true" })
+
+    expect(rows[0]?.extended_promotional).toBe(1)
+    expect(statements).toHaveLength(1)
+    expect(statements[0]?.sql).toContain(
+      "search_index.extended_promotional = 1",
+    )
+    expect(statements[0]?.parameters).toEqual([100])
+    await db.destroy()
+  })
+
+  it("does not constrain extended promotional status by default", async () => {
+    const { database, statements } = createRecordingD1()
+    const db = getD1Client(database)
+
+    await searchIndex(db, {})
+
+    expect(statements).toHaveLength(1)
+    expect(statements[0]?.sql).not.toContain(
+      "search_index.extended_promotional = 1",
+    )
+    await db.destroy()
+  })
+})

--- a/scripts/build-derived-sync-db.ts
+++ b/scripts/build-derived-sync-db.ts
@@ -136,6 +136,10 @@ export const buildDerivedSyncDatabase = async ({
         j.package,
         CASE WHEN j.library_type = 'base' THEN 1 ELSE 0 END AS basic,
         j.preferred,
+        CASE
+          WHEN j.preferred = 1 AND j.library_type != 'base' THEN 1
+          ELSE 0
+        END AS extended_promotional,
         j.description,
         j.stock,
         j.price,
@@ -181,6 +185,7 @@ export const buildDerivedSyncDatabase = async ({
         AND j.last_on_stock >= unixepoch('now', '-1 year');
 
       CREATE INDEX idx_component_catalog_lcsc ON component_catalog(lcsc);
+      CREATE INDEX idx_component_catalog_extended_promotional ON component_catalog(extended_promotional);
       CREATE INDEX idx_component_catalog_stock ON component_catalog(stock DESC);
     `)
   }

--- a/tests/build-derived-sync-db.test.ts
+++ b/tests/build-derived-sync-db.test.ts
@@ -171,6 +171,49 @@ describe("buildDerivedSyncDatabase", () => {
     output.close()
   })
 
+  test("materializes extended promotional status from source library type and preferred flag", async () => {
+    const { sourcePath, outputPath } = await createSourceDatabase()
+    const source = new Database(sourcePath)
+    source.exec(`
+      INSERT INTO jlc_components (
+        lcsc, fetched_at, present, sync_seen, category, subcategory, mfr,
+        package, joints, manufacturer, library_type, preferred, last_on_stock,
+        description, datasheet, stock, price, attributes
+      ) VALUES
+        (23456, unixepoch(), 1, 1, 'Connectors', 'HDMI Connectors',
+         'PROMO-EXPAND', 'SMD', 19, 'Example', 'expand', 1, unixepoch(),
+         'Promotional extended part', '', 100, '1-:1.00', '{}'),
+        (34567, unixepoch(), 1, 1, 'Connectors', 'HDMI Connectors',
+         'STANDARD-EXPAND', 'SMD', 19, 'Example', 'expand', 0, unixepoch(),
+         'Standard extended part', '', 100, '1-:1.00', '{}');
+    `)
+    source.close()
+
+    await buildDerivedSyncDatabase({
+      sourcePath,
+      outputPath,
+      tableNames: ["hdmi_port"],
+      includeComponentCatalog: true,
+      logger: () => {},
+    })
+
+    const output = new Database(outputPath, { readonly: true })
+    const rows = output
+      .query(
+        `SELECT lcsc, basic, preferred, extended_promotional
+         FROM component_catalog
+         ORDER BY lcsc`,
+      )
+      .all()
+
+    expect(rows).toEqual([
+      { lcsc: 12345, basic: 1, preferred: 1, extended_promotional: 0 },
+      { lcsc: 23456, basic: 0, preferred: 1, extended_promotional: 1 },
+      { lcsc: 34567, basic: 0, preferred: 0, extended_promotional: 0 },
+    ])
+    output.close()
+  })
+
   test("materializes a stock snapshot with zeroes for absent parts", async () => {
     const { sourcePath, outputPath } = await createSourceDatabase()
     const source = new Database(sourcePath)


### PR DESCRIPTION
## Summary

- materialize `extended_promotional` from the source-backed component catalog, using `preferred = 1` with a non-base library type
- carry the flag through `component_catalog`, `search_index`, D1 sync/rebuild schemas, `/api/search`, and `/components/list`
- add the filter/response field, supporting indexes, and fail-closed sync checks so a missing source column cannot silently become `0`
- cover Basic+preferred, Extended+preferred, and Extended+not-preferred source rows plus the compiled D1 filter and rendered UI control

## Verification

- `cd cf-proxy && bun test` — 153 passed, 0 failed
- TypeScript checks passed
- Biome/format checks passed
- bash syntax checks passed for the touched sync scripts
- `git diff --check` passed
- SQLite source proof: Basic+preferred → false, Extended+preferred → true, Extended+not-preferred → false

AI-assisted with GPT-5.6 Sol via ChatGPT. ChatJimmy.ai was used for secondary semantic review.

Fixes #92

/claim #92