### PR TITLE
Retry and split transient D1 writes

### DIFF
--- a/lib/footprinter-write-fallback.ts
+++ b/lib/footprinter-write-fallback.ts
@@ -1,0 +1,77 @@
+export const D1_WRANGLER_RETRY_ATTEMPTS = 3
+export const D1_WRANGLER_RETRY_BASE_DELAY_MS = 5_000
+export const D1_WRITE_FALLBACK_BATCH_SIZE = 10
+
+export interface WriteRowsWithFallbackOptions<T> {
+  maxAttempts?: number
+  baseDelayMs?: number
+  fallbackBatchSize?: number
+  sleep?: (durationMs: number) => Promise<void>
+  onRetry?: (
+    rows: readonly T[],
+    attempt: number,
+    delayMs: number,
+    error: unknown,
+  ) => void
+  onSplit?: (rows: readonly T[], error: unknown) => void
+  onFailure?: (rows: readonly T[], error: unknown) => void
+}
+
+export interface WriteRowsWithFallbackResult<T> {
+  failedRows: T[]
+  retryCount: number
+  splitCount: number
+}
+
+const sleep = (durationMs: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, durationMs))
+
+export const writeRowsWithFallback = async <T>(
+  rows: readonly T[],
+  writeRows: (rows: readonly T[]) => Promise<void>,
+  options: WriteRowsWithFallbackOptions<T> = {},
+): Promise<WriteRowsWithFallbackResult<T>> => {
+  const maxAttempts = options.maxAttempts ?? D1_WRANGLER_RETRY_ATTEMPTS
+  const baseDelayMs = options.baseDelayMs ?? D1_WRANGLER_RETRY_BASE_DELAY_MS
+  const fallbackBatchSize =
+    options.fallbackBatchSize ?? D1_WRITE_FALLBACK_BATCH_SIZE
+  const sleepFn = options.sleep ?? sleep
+  const failedRows: T[] = []
+  let retryCount = 0
+  let splitCount = 0
+
+  const writeBatch = async (batch: readonly T[]): Promise<void> => {
+    let lastError: unknown
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        await writeRows(batch)
+        return
+      } catch (error) {
+        lastError = error
+        if (attempt >= maxAttempts) break
+
+        const delayMs = baseDelayMs * 2 ** (attempt - 1)
+        retryCount += 1
+        options.onRetry?.(batch, attempt, delayMs, error)
+        await sleepFn(delayMs)
+      }
+    }
+
+    if (batch.length <= fallbackBatchSize) {
+      failedRows.push(...batch)
+      options.onFailure?.(batch, lastError)
+      return
+    }
+
+    splitCount += 1
+    options.onSplit?.(batch, lastError)
+    const midpoint = Math.ceil(batch.length / 2)
+    await writeBatch(batch.slice(0, midpoint))
+    await writeBatch(batch.slice(midpoint))
+  }
+
+  await writeBatch(rows)
+
+  return { failedRows, retryCount, splitCount }
+}

--- a/scripts/populate-footprinter-strings.ts
+++ b/scripts/populate-footprinter-strings.ts
@@ -13,6 +13,11 @@ import {
   isPermanentEasyEdaMiss,
 } from "../lib/footprinter-strings"
 import {
+  D1_WRANGLER_RETRY_ATTEMPTS,
+  D1_WRANGLER_RETRY_BASE_DELAY_MS,
+  writeRowsWithFallback,
+} from "../lib/footprinter-write-fallback"
+import {
   POPULATION_BATCH_RESTART_EXIT_CODE,
   POPULATION_WASM_RESTART_EXIT_CODE,
   isManifoldWasmAbort,
@@ -165,11 +170,14 @@ const runWrangler = async (
   const child = Bun.spawn(["bunx", "wrangler", ...args], {
     cwd: CF_PROXY_DIRECTORY,
     env: process.env,
-    stderr: "inherit",
+    stderr: "pipe",
     stdout: "pipe",
   })
-  const output = await new Response(child.stdout).text()
-  const exitCode = await child.exited
+  const [output, errorOutput, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ])
   const durationMs = Date.now() - startedAt
   if (operation === "read") {
     metrics.d1ReadCount += 1
@@ -179,7 +187,10 @@ const runWrangler = async (
     metrics.d1WriteDurationMs += durationMs
   }
   if (exitCode !== 0) {
-    throw new Error(`Wrangler exited with code ${exitCode}`)
+    const details = errorOutput.trim().slice(-1_000)
+    throw new Error(
+      `Wrangler exited with code ${exitCode}${details ? `: ${details}` : ""}`,
+    )
   }
 
   try {
@@ -187,6 +198,31 @@ const runWrangler = async (
   } catch {
     throw new Error(`Wrangler returned invalid JSON: ${output.slice(0, 500)}`)
   }
+}
+
+const runWranglerWithRetry = async (
+  args: readonly string[],
+  operation: WranglerOperation,
+  metrics: TimingMetrics,
+): Promise<unknown> => {
+  let lastError: unknown
+
+  for (let attempt = 1; attempt <= D1_WRANGLER_RETRY_ATTEMPTS; attempt += 1) {
+    try {
+      return await runWrangler(args, operation, metrics)
+    } catch (error) {
+      lastError = error
+      if (attempt >= D1_WRANGLER_RETRY_ATTEMPTS) break
+
+      const delayMs = D1_WRANGLER_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1)
+      console.warn(
+        `Wrangler ${operation} failed on attempt ${attempt}/${D1_WRANGLER_RETRY_ATTEMPTS}; retrying in ${delayMs}ms: ${error instanceof Error ? error.message : String(error)}`,
+      )
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
+    }
+  }
+
+  throw lastError
 }
 
 const getWranglerRows = (payload: unknown): unknown[] => {
@@ -233,7 +269,7 @@ const fetchComponents = async (
   retryNullEntries: boolean,
   metrics: TimingMetrics,
 ): Promise<ComponentCatalogRow[]> => {
-  const payload = await runWrangler(
+  const payload = await runWranglerWithRetry(
     [
       "d1",
       "execute",
@@ -302,20 +338,50 @@ const flushRows = async (
 ): Promise<void> => {
   if (rows.length === 0) return
 
-  await runWrangler(
-    [
-      "d1",
-      "execute",
-      DATABASE_NAME,
-      "--remote",
-      "--json",
-      "--command",
-      buildFootprinterStringUpsert(rows),
-    ],
-    "write",
-    metrics,
+  const result = await writeRowsWithFallback(
+    rows,
+    async (batch) => {
+      await runWrangler(
+        [
+          "d1",
+          "execute",
+          DATABASE_NAME,
+          "--remote",
+          "--json",
+          "--command",
+          buildFootprinterStringUpsert(batch),
+        ],
+        "write",
+        metrics,
+      )
+    },
+    {
+      onRetry: (batch, attempt, delayMs, error) => {
+        console.warn(
+          `Wrangler write failed for ${batch.length} rows on attempt ${attempt}/${D1_WRANGLER_RETRY_ATTEMPTS}; retrying in ${delayMs}ms: ${error instanceof Error ? error.message : String(error)}`,
+        )
+      },
+      onSplit: (batch, error) => {
+        console.warn(
+          `D1 write failed for ${batch.length} rows; retrying smaller batches: ${error instanceof Error ? error.message : String(error)}`,
+        )
+      },
+      onFailure: (batch, error) => {
+        console.warn(
+          `D1 write fallback exhausted for ${batch.length} rows; leaving them eligible for a future run: ${error instanceof Error ? error.message : String(error)}`,
+        )
+      },
+    },
   )
-  console.log(`Saved ${rows.length} footprinter_strings rows.`)
+  const savedRows = rows.length - result.failedRows.length
+  if (savedRows > 0) {
+    console.log(`Saved ${savedRows} footprinter_strings rows.`)
+  }
+  if (result.failedRows.length > 0) {
+    console.warn(
+      `Skipped ${result.failedRows.length} footprinter_strings rows after the D1 fallback; they remain eligible for retry.`,
+    )
+  }
   rows.length = 0
 }
 

--- a/tests/footprinter-write-fallback.test.ts
+++ b/tests/footprinter-write-fallback.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test"
+import { writeRowsWithFallback } from "../lib/footprinter-write-fallback"
+
+describe("writeRowsWithFallback", () => {
+  test("retries a transient write before succeeding", async () => {
+    let attempts = 0
+    const delays: number[] = []
+
+    const result = await writeRowsWithFallback(
+      [1, 2],
+      async () => {
+        attempts += 1
+        if (attempts === 1) throw new Error("temporary D1 failure")
+      },
+      {
+        baseDelayMs: 5,
+        sleep: async (delayMs) => {
+          delays.push(delayMs)
+        },
+      },
+    )
+
+    expect(attempts).toBe(2)
+    expect(delays).toEqual([5])
+    expect(result).toEqual({ failedRows: [], retryCount: 1, splitCount: 0 })
+  })
+
+  test("splits a failed batch and preserves successful sub-batches", async () => {
+    const writes: number[][] = []
+
+    const result = await writeRowsWithFallback(
+      [1, 2, 3, 4],
+      async (rows) => {
+        const values = [...rows]
+        writes.push(values)
+        if (values.length > 2) throw new Error("batch too large")
+      },
+      { maxAttempts: 1, fallbackBatchSize: 2, sleep: async () => {} },
+    )
+
+    expect(writes).toEqual([
+      [1, 2, 3, 4],
+      [1, 2],
+      [3, 4],
+    ])
+    expect(result).toEqual({ failedRows: [], retryCount: 0, splitCount: 1 })
+  })
+
+  test("leaves a persistently failing small batch eligible", async () => {
+    const result = await writeRowsWithFallback(
+      [1, 2],
+      async () => {
+        throw new Error("D1 unavailable")
+      },
+      { maxAttempts: 2, baseDelayMs: 5, sleep: async () => {} },
+    )
+
+    expect(result.failedRows).toEqual([1, 2])
+    expect(result.retryCount).toBe(1)
+    expect(result.splitCount).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

- Retry failed Wrangler D1 commands with exponential backoff.
- Capture Wrangler stderr so remote failures include actionable diagnostics.
- If a 50-row footprinter upsert still fails, retry it as smaller sub-batches and leave only exhausted rows eligible for a future run instead of aborting the population.
- Add unit coverage for retry, split, and exhausted-fallback behavior.

## Why

Run [#31931087288](https://github.com/tscircuit/jlcsearch/actions/runs/31931087288) stopped after about 24 minutes when a remote 50-row D1 write stalled and Wrangler exited with code 1. The population had already processed 1,200 components, and the final row-count report succeeded, so this was a transient write-path failure rather than an EasyEDA conversion failure.

## Validation

- Root suite: 226 tests passed.
- Cloudflare proxy suite: 150 tests passed.
- TypeScript check: passed.
- Diff check: passed.