### PR TITLE
Fix component price rendering

### DIFF
--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -113,8 +113,23 @@ const getPageTitle = (pathname: string): string => {
 const getPageHeading = (pathname: string): string =>
   routeHeadings[pathname] ?? getPageTitle(pathname)
 
+const extractSmallQuantityPrice = (value: string): number => {
+  try {
+    const priceTiers = JSON.parse(value)
+    return Number(priceTiers[0]?.price) || 0
+  } catch {
+    const firstTier = value.split(",", 1)[0]
+    return Number(firstTier?.split(":").at(-1)) || 0
+  }
+}
+
 const formatPrice = (value: unknown): string => {
-  const price = typeof value === "number" ? value : Number(value)
+  const price =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.includes(":")
+        ? extractSmallQuantityPrice(value)
+        : Number(value)
   if (!price) return ""
   return price.toLocaleString("en-US", {
     style: "currency",

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -20,6 +20,28 @@ describe("render helpers", () => {
     expect(html).toContain("/photo_diodes/list")
   })
 
+  it("renders the first price tier on component search results", () => {
+    const html = renderD1TablePage(
+      "/components/list",
+      {
+        components: [
+          {
+            lcsc: 1848077,
+            mfr: "MSP430G2332IRSA16R",
+            package: "QFN-16-EP(4x4)",
+            stock: 33000,
+            price: "1-9:1.5228,10-29:1.2592,30-99:1.1145,100-499:0.9501",
+          },
+        ],
+      },
+      { search: "MSP430" },
+      "https://jlcsearch.tscircuit.com/components/list?search=MSP430",
+    )
+
+    expect(html).toContain("MSP430G2332IRSA16R")
+    expect(html).toContain("$1.52")
+  })
+
   it("renders the Photo Diodes page and JSON API link", () => {
     const pathname = "/photo_diodes/list"
 


### PR DESCRIPTION
## Summary

- parse tiered component prices before formatting the HTML Price cell
- support both the compact `1-9:1.5228,...` format used by current catalog data and JSON price tiers
- add a regression test using an MSP430 result from the affected search

## Why

`/components/list` preserves the raw tier string in its JSON response, but the HTML renderer tried to convert that whole string directly to a number. The conversion produced `NaN`, leaving the Price column blank.

## Verification

- `bunx vitest run test/render.test.ts`
- `bun run test` (151 tests)
- `bunx tsc --noEmit --project tsconfig.json`
- `bunx @biomejs/biome@1.9.4 format cf-proxy/src/render.ts cf-proxy/test/render.test.ts`
