### PR TITLE
Add barrel jack page

### DIFF
--- a/.github/workflows/d1-migrations.yml
+++ b/.github/workflows/d1-migrations.yml
@@ -60,7 +60,7 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       SYNC_SCOPE: ${{ github.event_name == 'schedule' && 'stock_only' || inputs.sync_scope || 'derived' }}
-      DERIVED_TABLES_LIST: ${{ inputs.derived_tables || 'photo_diode,micro_usb_connector' }}
+      DERIVED_TABLES_LIST: ${{ inputs.derived_tables || 'photo_diode,micro_usb_connector,barrel_jack' }}
       SMOKE_TEST_LCSC: ${{ inputs.smoke_test_lcsc || '7512' }}
 
     steps:
@@ -300,6 +300,8 @@ jobs:
           if [[ -z "${CACHE_BUST_URL}" ]]; then
             if [[ "${SYNC_SCOPE}" != "derived" ]]; then
               CACHE_BUST_URL="https://jlcsearch.tscircuit.com/components/list?search=C${SMOKE_TEST_LCSC}&json=true"
+            elif [[ ",${DERIVED_TABLES_LIST}," == *",barrel_jack,"* ]]; then
+              CACHE_BUST_URL="https://jlcsearch.tscircuit.com/barrel_jacks/list.json"
             elif [[ ",${DERIVED_TABLES_LIST}," == *",micro_usb_connector,"* ]]; then
               CACHE_BUST_URL="https://jlcsearch.tscircuit.com/micro_usb_connectors/list.json"
             else
@@ -337,6 +339,16 @@ jobs:
               exit 1
             fi
             echo "Production Micro USB API returned ${micro_usb_connector_count} connectors."
+          fi
+
+          if [[ "${CACHE_BUST_URL}" == *"/barrel_jacks/list.json"* ]]; then
+            barrel_jack_count="$(jq '.barrel_jacks | length' /tmp/d1-sync-response.json)"
+            if [[ "${barrel_jack_count}" == "0" || "${barrel_jack_count}" == "null" ]]; then
+              echo "::error::Production Barrel Jacks API still returned no connectors."
+              cat /tmp/d1-sync-response.json
+              exit 1
+            fi
+            echo "Production Barrel Jacks API returned ${barrel_jack_count} connectors."
           fi
 
           if [[ "${SYNC_SCOPE}" != "derived" ]]; then

--- a/cf-proxy/migrations/0006_barrel_jack.sql
+++ b/cf-proxy/migrations/0006_barrel_jack.sql
@@ -1,0 +1,45 @@
+CREATE TABLE IF NOT EXISTS barrel_jack (
+  lcsc INTEGER PRIMARY KEY,
+  mfr TEXT,
+  description TEXT,
+  stock INTEGER,
+  price1 REAL,
+  in_stock BOOLEAN,
+  package TEXT,
+  connector_type TEXT,
+  mounting_style TEXT,
+  orientation TEXT,
+  inside_diameter_mm REAL,
+  outside_diameter_mm REAL,
+  current_rating_a REAL,
+  voltage_rating_v REAL,
+  num_pins INTEGER,
+  operating_temp_min REAL,
+  operating_temp_max REAL,
+  is_basic BOOLEAN,
+  is_preferred BOOLEAN,
+  attributes TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_barrel_jack_stock
+  ON barrel_jack (stock);
+CREATE INDEX IF NOT EXISTS idx_barrel_jack_package_stock
+  ON barrel_jack (package, stock);
+CREATE INDEX IF NOT EXISTS idx_barrel_jack_mounting_style_stock
+  ON barrel_jack (mounting_style, stock);
+CREATE INDEX IF NOT EXISTS idx_barrel_jack_orientation_stock
+  ON barrel_jack (orientation, stock);
+CREATE INDEX IF NOT EXISTS idx_barrel_jack_inside_diameter_stock
+  ON barrel_jack (inside_diameter_mm, stock);
+CREATE INDEX IF NOT EXISTS idx_barrel_jack_outside_diameter_stock
+  ON barrel_jack (outside_diameter_mm, stock);
+CREATE INDEX IF NOT EXISTS idx_barrel_jack_current_rating_stock
+  ON barrel_jack (current_rating_a, stock);
+CREATE INDEX IF NOT EXISTS idx_barrel_jack_voltage_rating_stock
+  ON barrel_jack (voltage_rating_v, stock);
+CREATE INDEX IF NOT EXISTS idx_barrel_jack_num_pins_stock
+  ON barrel_jack (num_pins, stock);
+CREATE INDEX IF NOT EXISTS idx_barrel_jack_is_basic_stock
+  ON barrel_jack (is_basic, stock);
+CREATE INDEX IF NOT EXISTS idx_barrel_jack_is_preferred_stock
+  ON barrel_jack (is_preferred, stock);

--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -26,6 +26,7 @@ DERIVED_TABLES=(
   accelerometer
   adc
   analog_multiplexer
+  barrel_jack
   battery_holder
   bjt_transistor
   ble_chip

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -78,6 +78,29 @@ export interface AnalogMultiplexer {
   supply_voltage_min: number | null
 }
 
+export interface BarrelJack {
+  attributes: string | null
+  connector_type: string | null
+  current_rating_a: number | null
+  description: string | null
+  in_stock: number | null
+  inside_diameter_mm: number | null
+  is_basic: number | null
+  is_preferred: number | null
+  lcsc: Generated<number | null>
+  mfr: string | null
+  mounting_style: string | null
+  num_pins: number | null
+  operating_temp_max: number | null
+  operating_temp_min: number | null
+  orientation: string | null
+  outside_diameter_mm: number | null
+  package: string | null
+  price1: number | null
+  stock: number | null
+  voltage_rating_v: number | null
+}
+
 export interface BatteryHolder {
   attributes: string | null
   battery_type: string | null
@@ -1020,6 +1043,7 @@ export interface DB {
   accelerometer: Accelerometer
   adc: Adc
   analog_multiplexer: AnalogMultiplexer
+  barrel_jack: BarrelJack
   battery_holder: BatteryHolder
   ble_chip: BleChip
   ble_module: BleModule

--- a/cf-proxy/src/handlers/index.ts
+++ b/cf-proxy/src/handlers/index.ts
@@ -457,6 +457,28 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       num_channels: { field: "num_channels", type: "number" },
     },
   },
+  barrel_jack: {
+    filters: {
+      package: { field: "package", type: "string" },
+      mounting_style: { field: "mounting_style", type: "string" },
+      orientation: { field: "orientation", type: "string" },
+      inside_diameter_mm: { field: "inside_diameter_mm", type: "number" },
+      outside_diameter_mm: { field: "outside_diameter_mm", type: "number" },
+      current_rating_min: {
+        field: "current_rating_a",
+        type: "number",
+        operator: ">=",
+      },
+      voltage_rating_min: {
+        field: "voltage_rating_v",
+        type: "number",
+        operator: ">=",
+      },
+      num_pins: { field: "num_pins", type: "number" },
+      is_basic: { field: "is_basic", type: "boolean" },
+      is_preferred: { field: "is_preferred", type: "boolean" },
+    },
+  },
   battery_holder: {
     filters: {
       package: { field: "package", type: "string" },
@@ -717,6 +739,7 @@ export const ROUTE_TO_TABLE: Record<string, string> = {
   "/accelerometers/list": "accelerometer",
   "/adcs/list": "adc",
   "/analog_multiplexers/list": "analog_multiplexer",
+  "/barrel_jacks/list": "barrel_jack",
   "/battery_holders/list": "battery_holder",
   "/ble_chips/list": "ble_chip",
   "/ble_modules/list": "ble_module",
@@ -767,6 +790,7 @@ export const TABLE_RESPONSE_KEY: Record<string, string> = {
   accelerometer: "accelerometers",
   adc: "adcs",
   analog_multiplexer: "multiplexers",
+  barrel_jack: "barrel_jacks",
   battery_holder: "battery_holders",
   ble_chip: "ble_chips",
   ble_module: "ble_modules",

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -24,6 +24,7 @@ const routeLabels: Record<string, string> = {
   "/capacitors/list": "Capacitors",
   "/potentiometers/list": "Potentiometers",
   "/headers/list": "Headers",
+  "/barrel_jacks/list": "Barrel Jacks",
   "/dimm_connectors/list": "DIMM Connectors",
   "/sodimm_connectors/list": "SO-DIMM Connectors",
   "/micro_usb_connectors/list": "Micro USB Connectors",
@@ -193,6 +194,10 @@ const COLUMN_LABELS: Record<string, string> = {
   reverse_voltage_min: "Min Reverse Voltage",
   dark_current_a: "Dark Current",
   dark_current_max: "Max Dark Current",
+  inside_diameter_mm: "Inside Diameter",
+  outside_diameter_mm: "Outside Diameter",
+  current_rating_min: "Min Current",
+  voltage_rating_min: "Min Voltage",
   reception_angle_deg: "Reception Angle",
   luminous_intensity_mcd: "Intensity",
   number_of_contacts: "Contacts",
@@ -361,6 +366,8 @@ const formatDisplayValue = (column: string, value: unknown): string | null => {
     case "length_mm":
     case "switch_height_mm":
     case "height_above_board_mm":
+    case "inside_diameter_mm":
+    case "outside_diameter_mm":
       return withUnit(value, "mm")
     case "operating_temp_min":
     case "operating_temp_max":

--- a/cf-proxy/test/contracts.test.ts
+++ b/cf-proxy/test/contracts.test.ts
@@ -386,11 +386,7 @@ describe("Cloudflare route contracts", () => {
   })
 
   it("GET /api/search strips a leading C in LCSC lookups", async () => {
-    const source = await fetchJson("/resistors/list?json=true")
-    const sourceRows = source.data.resistors as any[]
-    expect(sourceRows.length).toBeGreaterThan(0)
-
-    const lcsc = sourceRows[0].lcsc
+    const lcsc = 9002
     const { data } = await fetchJson(`/api/search?q=C${lcsc}`)
     expect(Array.isArray(data.components)).toBe(true)
     expect(data.components.length).toBeGreaterThan(0)

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -11,6 +11,7 @@ describe("render helpers", () => {
     expect(html).toContain("/lcd_drivers/list")
     expect(html).toContain("/tft_display_drivers/list")
     expect(html).toContain("/resistors/list")
+    expect(html).toContain("/barrel_jacks/list")
     expect(html).toContain("/spring_clamp_terminal_blocks/list")
     expect(html).toContain("/ble_modules/list")
     expect(html).toContain("/ble_chips/list")
@@ -19,6 +20,59 @@ describe("render helpers", () => {
     expect(html).toContain("/micro_usb_connectors/list")
     expect(html).toContain("/hdmi_ports/list")
     expect(html).toContain("/photo_diodes/list")
+  })
+
+  it("renders the Barrel Jacks page and JSON API link", () => {
+    const pathname = "/barrel_jacks/list"
+
+    expect(D1_ROUTES).toContain(pathname)
+    expect(getD1Handler(pathname)).toBeTypeOf("function")
+
+    const html = renderD1TablePage(
+      pathname,
+      {
+        barrel_jacks: [
+          {
+            lcsc: 16214,
+            mfr: "DC-005 2.0",
+            package: "Plugin",
+            connector_type: "DC Power Receptacle",
+            mounting_style: "Through Hole",
+            orientation: "Right Angle",
+            inside_diameter_mm: 2,
+            outside_diameter_mm: 6.4,
+            current_rating_a: 1,
+            voltage_rating_v: 12,
+            num_pins: 3,
+            stock: 27_206,
+          },
+        ],
+      },
+      {
+        mounting_style: "Through Hole",
+        orientation: "Right Angle",
+        inside_diameter_mm: "2",
+        outside_diameter_mm: "6.4",
+        current_rating_min: "1",
+        voltage_rating_min: "12",
+        num_pins: "3",
+      },
+      "https://jlcsearch.tscircuit.com/barrel_jacks/list?inside_diameter_mm=2&outside_diameter_mm=6.4",
+    )
+
+    expect(html).toContain("<h2>Barrel Jacks</h2>")
+    expect(html).toContain('name="mounting_style"')
+    expect(html).toContain('name="orientation"')
+    expect(html).toContain('name="inside_diameter_mm"')
+    expect(html).toContain('name="outside_diameter_mm"')
+    expect(html).toContain('name="current_rating_min"')
+    expect(html).toContain('name="voltage_rating_min"')
+    expect(html).toContain('name="num_pins"')
+    expect(html).toContain('name="is_basic"')
+    expect(html).toContain('name="is_preferred"')
+    expect(html).toContain("2mm")
+    expect(html).toContain("6.4mm")
+    expect(html).toContain("/barrel_jacks/list.json")
   })
 
   it("renders the Micro USB connectors page and JSON API link", () => {

--- a/lib/db/derivedtables/barrel-jack.ts
+++ b/lib/db/derivedtables/barrel-jack.ts
@@ -1,0 +1,261 @@
+import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import { parseAndConvertSiUnit } from "lib/util/parse-and-convert-si-unit"
+import type { BaseComponent } from "./component-base"
+import type { DerivedTableSpec } from "./types"
+
+export interface BarrelJack extends BaseComponent {
+  package: string
+  connector_type: string
+  mounting_style: string | null
+  orientation: string | null
+  inside_diameter_mm: number | null
+  outside_diameter_mm: number | null
+  current_rating_a: number | null
+  voltage_rating_v: number | null
+  num_pins: number | null
+  operating_temp_min: number | null
+  operating_temp_max: number | null
+}
+
+const DC_POWER_SUBCATEGORIES = [
+  "AC/DC Power Connectors",
+  "DC Power Connector",
+  "DC Power Connectors",
+] as const
+
+const readAttributes = (extraJson: string | null): Record<string, string> => {
+  if (!extraJson) return {}
+  try {
+    const attributes = JSON.parse(extraJson)?.attributes
+    return attributes && typeof attributes === "object" ? attributes : {}
+  } catch {
+    return {}
+  }
+}
+
+const readText = (value: string | undefined): string | null => {
+  const normalized = value?.trim()
+  return normalized && normalized !== "-" ? normalized : null
+}
+
+const parseUnit = (value: string | null): number | null => {
+  if (!value) return null
+  try {
+    const parsed = parseAndConvertSiUnit(value).value
+    return typeof parsed === "number" && Number.isFinite(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+const parseCount = (value: string | undefined): number | null => {
+  const match = value?.match(/\d+/)
+  if (!match) return null
+  const parsed = Number.parseInt(match[0], 10)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const firstUnitMatch = (value: string, unit: "A" | "V"): number | null => {
+  const match = value.match(
+    unit === "A"
+      ? /\b\d+(?:\.\d+)?\s*(?:mA|A)\b/i
+      : /\b\d+(?:\.\d+)?\s*(?:mV|V)\b/i,
+  )
+  return parseUnit(match?.[0] ?? null)
+}
+
+const parseTemperatureRange = (
+  value: string | null,
+): { min: number | null; max: number | null } => {
+  const match = value?.match(
+    /(-?\d+(?:\.\d+)?)\s*(?:℃|°C)?\s*(?:~|to)\s*\+?(-?\d+(?:\.\d+)?)\s*(?:℃|°C)?/i,
+  )
+  return match
+    ? { min: Number(match[1]), max: Number(match[2]) }
+    : { min: null, max: null }
+}
+
+const inferDiameters = (
+  attributes: Record<string, string>,
+  description: string,
+): { inside: number | null; outside: number | null } => {
+  let inside = parseUnit(readText(attributes["Inside Contact Diameter"]))
+  let outside = parseUnit(readText(attributes["Outside Contact Diameter"]))
+
+  if (inside === null || outside === null) {
+    const values = Array.from(
+      description.matchAll(/\b(\d+(?:\.\d+)?)\s*mm\b/gi),
+      (match) => Number(match[1]),
+    ).filter((value) => Number.isFinite(value) && value > 0 && value < 20)
+
+    if (values.length >= 2) {
+      inside ??= Math.min(...values)
+      outside ??= Math.max(...values)
+    }
+  }
+
+  return { inside, outside }
+}
+
+const inferMountingStyle = (
+  attributes: Record<string, string>,
+  packageName: string,
+  description: string,
+): string | null => {
+  const text = [attributes["Mounting Style"], packageName, description]
+    .filter(Boolean)
+    .join(" ")
+
+  if (/panel[ -]?mount/i.test(text)) return "Panel Mount"
+  if (/\bSMD\b|\bSMT\b|surface[ -]?mount/i.test(text)) {
+    return "Surface Mount"
+  }
+  if (/through[ -]?hole|\bplugin\b|push-pull|插件/i.test(text)) {
+    return "Through Hole"
+  }
+  return readText(attributes["Mounting Style"])
+}
+
+const inferOrientation = (text: string): string | null => {
+  if (/right[ -]?angle|bend insert/i.test(text)) return "Right Angle"
+  if (/vertical|straight insert/i.test(text)) return "Vertical"
+  return null
+}
+
+const isBarrelJack = (
+  mfr: string,
+  description: string,
+  connectorType: string | null,
+  joints: number,
+): boolean => {
+  const text = [mfr, description, connectorType].filter(Boolean).join(" ")
+  if (/\b(?:power\s+)?plug\b|\bcable\b/i.test(text)) return false
+  if (/\bDC\s*Power\s*(?:Jack|Receptacle)\b/i.test(text)) return true
+
+  return /^DC[\s_-]?\d/i.test(mfr) && joints >= 3
+}
+
+export const barrelJackTableSpec: DerivedTableSpec<BarrelJack> = {
+  tableName: "barrel_jack",
+  extraColumns: [
+    { name: "package", type: "text" },
+    { name: "connector_type", type: "text" },
+    { name: "mounting_style", type: "text" },
+    { name: "orientation", type: "text" },
+    { name: "inside_diameter_mm", type: "real" },
+    { name: "outside_diameter_mm", type: "real" },
+    { name: "current_rating_a", type: "real" },
+    { name: "voltage_rating_v", type: "real" },
+    { name: "num_pins", type: "integer" },
+    { name: "operating_temp_min", type: "real" },
+    { name: "operating_temp_max", type: "real" },
+    { name: "is_basic", type: "boolean" },
+    { name: "is_preferred", type: "boolean" },
+  ],
+  indexes: [
+    { name: "idx_barrel_jack_stock", columns: ["stock"] },
+    { name: "idx_barrel_jack_package_stock", columns: ["package", "stock"] },
+    {
+      name: "idx_barrel_jack_mounting_style_stock",
+      columns: ["mounting_style", "stock"],
+    },
+    {
+      name: "idx_barrel_jack_orientation_stock",
+      columns: ["orientation", "stock"],
+    },
+    {
+      name: "idx_barrel_jack_inside_diameter_stock",
+      columns: ["inside_diameter_mm", "stock"],
+    },
+    {
+      name: "idx_barrel_jack_outside_diameter_stock",
+      columns: ["outside_diameter_mm", "stock"],
+    },
+    {
+      name: "idx_barrel_jack_current_rating_stock",
+      columns: ["current_rating_a", "stock"],
+    },
+    {
+      name: "idx_barrel_jack_voltage_rating_stock",
+      columns: ["voltage_rating_v", "stock"],
+    },
+    {
+      name: "idx_barrel_jack_num_pins_stock",
+      columns: ["num_pins", "stock"],
+    },
+    {
+      name: "idx_barrel_jack_is_basic_stock",
+      columns: ["is_basic", "stock"],
+    },
+    {
+      name: "idx_barrel_jack_is_preferred_stock",
+      columns: ["is_preferred", "stock"],
+    },
+  ],
+  listCandidateComponents: (db) =>
+    db
+      .selectFrom("components")
+      .innerJoin("categories", "components.category_id", "categories.id")
+      .selectAll("components")
+      .where("categories.subcategory", "in", [...DC_POWER_SUBCATEGORIES]),
+  mapToTable: (components) =>
+    components.map((component): BarrelJack | null => {
+      const attributes = readAttributes(component.extra)
+      const mfr = String(component.mfr || "")
+      const description = String(component.description || "")
+      const packageName = String(component.package || "")
+      const connectorType = readText(attributes["Connector Type"])
+
+      if (!isBarrelJack(mfr, description, connectorType, component.joints)) {
+        return null
+      }
+
+      const diameters = inferDiameters(attributes, description)
+      const temperature = parseTemperatureRange(
+        readText(attributes["Operating Temperature Range"]) || description,
+      )
+      const searchableText = [
+        attributes["Mounting Style"],
+        packageName,
+        description,
+      ]
+        .filter(Boolean)
+        .join(" ")
+
+      return {
+        lcsc: Number(component.lcsc),
+        mfr,
+        description,
+        package: packageName,
+        stock: Number(component.stock || 0),
+        price1: extractMinQPrice(component.price),
+        in_stock: Number(component.stock || 0) > 0,
+        is_basic: Boolean(component.basic),
+        is_preferred: Boolean(component.preferred),
+        connector_type: connectorType || "DC Power Jack",
+        mounting_style: inferMountingStyle(
+          attributes,
+          packageName,
+          description,
+        ),
+        orientation: inferOrientation(searchableText),
+        inside_diameter_mm: diameters.inside,
+        outside_diameter_mm: diameters.outside,
+        current_rating_a:
+          parseUnit(readText(attributes["Current Rating (Max)"])) ??
+          firstUnitMatch(description, "A"),
+        voltage_rating_v:
+          parseUnit(readText(attributes["Voltage Rating (Max)"])) ??
+          firstUnitMatch(description, "V"),
+        num_pins:
+          parseCount(
+            attributes["Number of Pins"] || attributes["Number of Contacts"],
+          ) ||
+          component.joints ||
+          null,
+        operating_temp_min: temperature.min,
+        operating_temp_max: temperature.max,
+        attributes,
+      }
+    }),
+}

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -3,6 +3,7 @@ import { destroyDbClient, getDbClient } from "lib/db/get-db-client"
 import { accelerometerTableSpec } from "lib/db/derivedtables/accelerometer"
 import { adcTableSpec } from "lib/db/derivedtables/adc"
 import { analogMultiplexerTableSpec } from "lib/db/derivedtables/analog_multiplexer"
+import { barrelJackTableSpec } from "lib/db/derivedtables/barrel-jack"
 import { batteryHolderTableSpec } from "lib/db/derivedtables/battery_holder"
 import { bjtTransistorTableSpec } from "lib/db/derivedtables/bjt_transistor"
 import { bleChipTableSpec } from "lib/db/derivedtables/ble-chip"
@@ -60,6 +61,7 @@ export const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   hdmiPortTableSpec,
   adcTableSpec,
   analogMultiplexerTableSpec,
+  barrelJackTableSpec,
   ioExpanderTableSpec,
   diodeTableSpec,
   dacTableSpec,

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -78,6 +78,29 @@ export interface AnalogMultiplexer {
   supply_voltage_min: number | null;
 }
 
+export interface BarrelJack {
+  attributes: string | null;
+  connector_type: string | null;
+  current_rating_a: number | null;
+  description: string | null;
+  in_stock: number | null;
+  inside_diameter_mm: number | null;
+  is_basic: number | null;
+  is_preferred: number | null;
+  lcsc: Generated<number | null>;
+  mfr: string | null;
+  mounting_style: string | null;
+  num_pins: number | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  orientation: string | null;
+  outside_diameter_mm: number | null;
+  package: string | null;
+  price1: number | null;
+  stock: number | null;
+  voltage_rating_v: number | null;
+}
+
 export interface BatteryHolder {
   attributes: string | null;
   battery_type: string | null;
@@ -1065,6 +1088,7 @@ export interface DB {
   accelerometer: Accelerometer;
   adc: Adc;
   analog_multiplexer: AnalogMultiplexer;
+  barrel_jack: BarrelJack;
   battery_holder: BatteryHolder;
   ble_chip: BleChip;
   ble_module: BleModule;

--- a/tests/lib/barrel-jack-derived-table.test.ts
+++ b/tests/lib/barrel-jack-derived-table.test.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "bun:test"
+import { barrelJackTableSpec } from "lib/db/derivedtables/barrel-jack"
+
+const makeComponent = (overrides: Record<string, unknown> = {}) =>
+  ({
+    lcsc: 16214,
+    mfr: "DC-005 2.0",
+    description:
+      "-25℃~+85℃ 12V 1A 2mm 6.4mm DC Power Jack Right Angle Plugin DC Power Connectors",
+    stock: 27_206,
+    joints: 3,
+    basic: 0,
+    preferred: 1,
+    price: JSON.stringify([{ qFrom: 1, qTo: null, price: 0.0487 }]),
+    package: "Plugin",
+    extra: JSON.stringify({
+      attributes: {
+        "Mounting Style": "Shrouded",
+        "Voltage Rating (Max)": "12V",
+        "Current Rating (Max)": "1A",
+        "Operating Temperature Range": "-25℃~+85℃",
+        "Connector Type": "DC Power Receptacle",
+        "Outside Contact Diameter": "6.4mm",
+        "Inside Contact Diameter": "2mm",
+      },
+    }),
+    ...overrides,
+  }) as any
+
+test("maps DC barrel jack dimensions and electrical ratings", () => {
+  const [jack] = barrelJackTableSpec.mapToTable([makeComponent()])
+
+  expect(jack).toMatchObject({
+    lcsc: 16214,
+    mfr: "DC-005 2.0",
+    connector_type: "DC Power Receptacle",
+    mounting_style: "Through Hole",
+    orientation: "Right Angle",
+    inside_diameter_mm: 2,
+    outside_diameter_mm: 6.4,
+    current_rating_a: 1,
+    voltage_rating_v: 12,
+    num_pins: 3,
+    operating_temp_min: -25,
+    operating_temp_max: 85,
+    is_preferred: true,
+    price1: 0.0487,
+  })
+})
+
+test("falls back to catalog descriptions when attributes are incomplete", () => {
+  const [jack] = barrelJackTableSpec.mapToTable([
+    makeComponent({
+      lcsc: 7498153,
+      mfr: "XDJK-0051-025",
+      description:
+        "-40℃~+85℃ 2.1mm 3A 500V 6.3mm DC Power Jack Right Angle Plugin",
+      extra: null,
+    }),
+  ])
+
+  expect(jack).toMatchObject({
+    inside_diameter_mm: 2.1,
+    outside_diameter_mm: 6.3,
+    current_rating_a: 3,
+    voltage_rating_v: 500,
+    mounting_style: "Through Hole",
+    orientation: "Right Angle",
+    operating_temp_min: -40,
+    operating_temp_max: 85,
+  })
+})
+
+test("excludes DC plugs and unrelated audio jacks", () => {
+  const components = [
+    makeComponent({
+      mfr: "DC-PLUG-21",
+      description: "DC Power Plug 2.1mm",
+      joints: 2,
+      extra: null,
+    }),
+    makeComponent({
+      mfr: "PJ-327C",
+      description: "3.5mm Headphone Jack",
+      joints: 4,
+      extra: null,
+    }),
+  ]
+
+  expect(barrelJackTableSpec.mapToTable(components)).toEqual([null, null])
+})

--- a/tests/lib/barrel-jack-schema.test.ts
+++ b/tests/lib/barrel-jack-schema.test.ts
@@ -1,0 +1,61 @@
+import { Database } from "bun:sqlite"
+import { expect, test } from "bun:test"
+import { Kysely } from "kysely"
+import { BunSqliteDialect } from "kysely-bun-sqlite"
+import { barrelJackTableSpec } from "lib/db/derivedtables/barrel-jack"
+import { setupDerivedTables } from "lib/db/derivedtables/setup-derived-tables"
+
+const EXPECTED_INDEX_COUNT = 11
+
+test("derived table setup creates the barrel jack table and indexes", async () => {
+  const database = new Database(":memory:")
+  const db = new Kysely<any>({
+    dialect: new BunSqliteDialect({ database }),
+  })
+
+  try {
+    await setupDerivedTables({ db, populate: false })
+    const table = database
+      .query("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+      .get(barrelJackTableSpec.tableName)
+    const indexes = database
+      .query(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = ? AND name NOT LIKE 'sqlite_%'",
+      )
+      .all(barrelJackTableSpec.tableName)
+
+    expect(table).not.toBeNull()
+    expect(indexes).toHaveLength(EXPECTED_INDEX_COUNT)
+  } finally {
+    await db.destroy()
+  }
+})
+
+test("D1 migration creates the barrel jack schema idempotently", async () => {
+  const database = new Database(":memory:")
+  const migrationPath = new URL(
+    "../../cf-proxy/migrations/0006_barrel_jack.sql",
+    import.meta.url,
+  )
+  const migration = await Bun.file(migrationPath).text()
+
+  try {
+    database.exec(migration)
+    database.exec(migration)
+    const table = database
+      .query(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'barrel_jack'",
+      )
+      .get()
+    const indexes = database
+      .query(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'barrel_jack' AND name NOT LIKE 'sqlite_%'",
+      )
+      .all()
+
+    expect(table).not.toBeNull()
+    expect(indexes).toHaveLength(EXPECTED_INDEX_COUNT)
+  } finally {
+    database.close()
+  }
+})


### PR DESCRIPTION
## Summary
- add a derived Barrel Jack table and the /barrel_jacks/list page/API route
- expose diameter, mounting, orientation, current, voltage, and pin-count filters
- exclude DC plugs and unrelated audio jacks
- migrate, populate, and smoke-test the production D1 table on merge

## Test plan
- bun test
- bun run format:check
- bunx tsc --noEmit --project cf-proxy/tsconfig.json