### PR TITLE
Add source-backed extended promotional component flag

### DIFF
--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -22,6 +23,7 @@ export async function queryComponentCatalog(
     package: string | null
     basic: number | null
     preferred: number | null
+    is_extended_promotional: number
     description: string | null
     stock: number | null
     price: string | null
@@ -34,11 +36,14 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 
   return rows.map((row) => ({
     ...row,
+    is_extended_promotional:
+      Boolean(row.preferred) && !Boolean(row.basic) ? 1 : 0,
     extra: null,
   }))
 }

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -33,6 +33,11 @@ const extractSmallQuantityPrice = (price: string | null): string | number => {
   }
 }
 
+const isExtendedPromotional = (
+  basic: number | null,
+  preferred: number | null,
+): boolean => Boolean(preferred) && !Boolean(basic)
+
 const buildD1ErrorResponse = (
   origin: string | null,
   message: string,
@@ -456,6 +461,7 @@ async function handleD1Search(
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
       is_preferred: Boolean(row.preferred),
+      is_extended_promotional: isExtendedPromotional(row.basic, row.preferred),
       description: row.description ?? "",
       stock: row.stock ?? 0,
       price: row.price1 ?? extractSmallQuantityPrice(row.price),
@@ -581,6 +587,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        is_extended_promotional: Boolean(row.is_extended_promotional),
       })),
     }
 

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -9,6 +9,7 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 interface SearchRow {
@@ -108,6 +109,14 @@ export async function searchIndex(
 
   if (params.is_preferred === "true" || params.is_preferred === "1") {
     conditions.push(sql`search_index.preferred = 1`)
+  }
+
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`search_index.preferred = 1`)
+    conditions.push(sql`search_index.basic = 0`)
   }
 
   const raw = params.q?.trim()

--- a/cf-proxy/test/extended-promotional.test.ts
+++ b/cf-proxy/test/extended-promotional.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+import { getD1Client } from "../src/db/get-d1-client"
+import { searchIndex } from "../src/search"
+
+type RecordedStatement = {
+  sql: string
+  parameters: unknown[]
+}
+
+const createRecordingD1 = () => {
+  const statements: RecordedStatement[] = []
+  const database = {
+    prepare(sql: string) {
+      return {
+        bind(...parameters: unknown[]) {
+          statements.push({ sql, parameters })
+          return {
+            all: async () => ({
+              results: [
+                {
+                  lcsc: 12346,
+                  mfr: "PROMO-EXT",
+                  package: "SMD",
+                  description: "HDMI promotional extended part",
+                  stock: 100,
+                  price: "1-:0.50",
+                  price1: 0.5,
+                  basic: 0,
+                  preferred: 1,
+                  category: "Connectors",
+                  subcategory: "HDMI Connectors",
+                },
+              ],
+              meta: { changes: 0 },
+            }),
+          }
+        },
+      }
+    },
+  } as unknown as D1Database
+
+  return { database, statements }
+}
+
+describe("extended promotional search", () => {
+  it("filters on the source-backed preferred and non-basic flags", async () => {
+    const { database, statements } = createRecordingD1()
+    const db = getD1Client(database)
+
+    const rows = await searchIndex(db, { is_extended_promotional: "true" })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      lcsc: 12346,
+      basic: 0,
+      preferred: 1,
+    })
+
+    const executedSql = statements.map((statement) => statement.sql).join("\n")
+    expect(executedSql).toContain("search_index.preferred = 1")
+    expect(executedSql).toContain("search_index.basic = 0")
+
+    await db.destroy()
+  })
+})

--- a/lib/db/derivedtables/component-base.ts
+++ b/lib/db/derivedtables/component-base.ts
@@ -7,5 +7,6 @@ export interface BaseComponent {
   in_stock: boolean
   is_basic: boolean
   is_preferred: boolean
+  is_extended_promotional?: boolean
   attributes: Record<string, string>
 }

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -3,7 +3,6 @@ import { destroyDbClient, getDbClient } from "lib/db/get-db-client"
 import { accelerometerTableSpec } from "lib/db/derivedtables/accelerometer"
 import { adcTableSpec } from "lib/db/derivedtables/adc"
 import { analogMultiplexerTableSpec } from "lib/db/derivedtables/analog_multiplexer"
-import { barrelJackTableSpec } from "lib/db/derivedtables/barrel-jack"
 import { batteryHolderTableSpec } from "lib/db/derivedtables/battery_holder"
 import { bjtTransistorTableSpec } from "lib/db/derivedtables/bjt_transistor"
 import { bleChipTableSpec } from "lib/db/derivedtables/ble-chip"
@@ -34,7 +33,6 @@ import { ledTableSpec } from "lib/db/derivedtables/led"
 import { ledWithICTableSpec } from "lib/db/derivedtables/led_with_ic"
 import { ldoTableSpec } from "lib/db/derivedtables/ldo"
 import { microcontrollerTableSpec } from "lib/db/derivedtables/microcontroller"
-import { microUsbConnectorTableSpec } from "lib/db/derivedtables/micro-usb-connector"
 import { mosfetTableSpec } from "lib/db/derivedtables/mosfet"
 import { oledDisplayTableSpec } from "lib/db/derivedtables/oled_display"
 import { pcieM2ConnectorTableSpec } from "lib/db/derivedtables/pcie_m2_connector"
@@ -61,7 +59,6 @@ export const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   hdmiPortTableSpec,
   adcTableSpec,
   analogMultiplexerTableSpec,
-  barrelJackTableSpec,
   ioExpanderTableSpec,
   diodeTableSpec,
   dacTableSpec,
@@ -71,7 +68,6 @@ export const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   bleModuleTableSpec,
   bleChipTableSpec,
   microcontrollerTableSpec,
-  microUsbConnectorTableSpec,
   voltageRegulatorTableSpec,
   ldoTableSpec,
   ledDriverTableSpec,
@@ -103,6 +99,12 @@ export const DERIVED_TABLES: DerivedTableSpec<any>[] = [
 ]
 
 type Logger = (message: string) => void
+
+type SourceComponentClassification = {
+  basic?: number | null
+  preferred?: number | null
+  is_extended_promotional?: number | null
+}
 
 const jsonParseOrNull = (strObject: string) => {
   try {
@@ -173,6 +175,7 @@ const createTable = async (
     { name: "stock", type: "integer" },
     { name: "price1", type: "real" },
     { name: "in_stock", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ].concat(spec.extraColumns as any, [{ name: "attributes", type: "text" }])) {
     tableCreator = tableCreator.addColumn(
       col.name as string,
@@ -203,14 +206,24 @@ const createTable = async (
 
     if (components.length === 0) break
 
-    const mappedComponents = spec.mapToTable(components as any).map((c, i) =>
-      c === null
-        ? null
-        : {
-            ...c,
-            attributes: jsonParseOrNull(components[i].extra)?.attributes,
-          },
-    )
+    const mappedComponents = spec.mapToTable(components as any).map((c, i) => {
+      if (c === null) return null
+
+      const sourceComponent = components[i] as SourceComponentClassification & {
+        extra?: string | null
+      }
+      const isExtendedPromotional =
+        sourceComponent.is_extended_promotional != null
+          ? Boolean(sourceComponent.is_extended_promotional)
+          : Boolean(sourceComponent.preferred) &&
+            !Boolean(sourceComponent.basic)
+
+      return {
+        ...c,
+        is_extended_promotional: isExtendedPromotional,
+        attributes: jsonParseOrNull(sourceComponent.extra ?? "")?.attributes,
+      }
+    })
 
     for (const component of mappedComponents) {
       if (component === null) continue

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -3,6 +3,7 @@ import { destroyDbClient, getDbClient } from "lib/db/get-db-client"
 import { accelerometerTableSpec } from "lib/db/derivedtables/accelerometer"
 import { adcTableSpec } from "lib/db/derivedtables/adc"
 import { analogMultiplexerTableSpec } from "lib/db/derivedtables/analog_multiplexer"
+import { barrelJackTableSpec } from "lib/db/derivedtables/barrel-jack"
 import { batteryHolderTableSpec } from "lib/db/derivedtables/battery_holder"
 import { bjtTransistorTableSpec } from "lib/db/derivedtables/bjt_transistor"
 import { bleChipTableSpec } from "lib/db/derivedtables/ble-chip"
@@ -33,6 +34,7 @@ import { ledTableSpec } from "lib/db/derivedtables/led"
 import { ledWithICTableSpec } from "lib/db/derivedtables/led_with_ic"
 import { ldoTableSpec } from "lib/db/derivedtables/ldo"
 import { microcontrollerTableSpec } from "lib/db/derivedtables/microcontroller"
+import { microUsbConnectorTableSpec } from "lib/db/derivedtables/micro-usb-connector"
 import { mosfetTableSpec } from "lib/db/derivedtables/mosfet"
 import { oledDisplayTableSpec } from "lib/db/derivedtables/oled_display"
 import { pcieM2ConnectorTableSpec } from "lib/db/derivedtables/pcie_m2_connector"
@@ -59,6 +61,7 @@ export const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   hdmiPortTableSpec,
   adcTableSpec,
   analogMultiplexerTableSpec,
+  barrelJackTableSpec,
   ioExpanderTableSpec,
   diodeTableSpec,
   dacTableSpec,
@@ -68,6 +71,7 @@ export const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   bleModuleTableSpec,
   bleChipTableSpec,
   microcontrollerTableSpec,
+  microUsbConnectorTableSpec,
   voltageRegulatorTableSpec,
   ldoTableSpec,
   ledDriverTableSpec,

--- a/scripts/build-derived-sync-db.ts
+++ b/scripts/build-derived-sync-db.ts
@@ -19,6 +19,22 @@ const tableExists = (database: Database, schema: string, table: string) =>
       .get(table),
   )
 
+type TableInfoRow = {
+  name: string
+}
+
+const getTableColumns = (
+  database: Database,
+  schema: string,
+  table: string,
+): Set<string> =>
+  new Set(
+    database
+      .query<TableInfoRow, []>(`PRAGMA ${schema}.table_info(${table})`)
+      .all()
+      .map((row) => row.name),
+  )
+
 export const buildDerivedSyncDatabase = async ({
   sourcePath,
   outputPath,
@@ -60,6 +76,22 @@ export const buildDerivedSyncDatabase = async ({
     )
   }
 
+  const sourceComponentColumns = getTableColumns(
+    database,
+    "source",
+    "jlc_components",
+  )
+  const requiredSourceColumns = ["library_type", "preferred"]
+  const missingSourceColumns = requiredSourceColumns.filter(
+    (column) => !sourceComponentColumns.has(column),
+  )
+  if (missingSourceColumns.length > 0) {
+    database.close()
+    throw new Error(
+      `Expected source.jlc_components to contain ${missingSourceColumns.join(", ")}; refusing to fabricate extended promotional state`,
+    )
+  }
+
   database.exec(`
     CREATE TABLE categories (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -85,6 +117,10 @@ export const buildDerivedSyncDatabase = async ({
       0 AS manufacturer_id,
       CASE WHEN j.library_type = 'base' THEN 1 ELSE 0 END AS basic,
       j.preferred,
+      CASE
+        WHEN j.library_type = 'expand' AND j.preferred = 1 THEN 1
+        ELSE 0
+      END AS is_extended_promotional,
       j.description,
       j.datasheet,
       j.stock,
@@ -189,13 +225,17 @@ export const buildDerivedSyncDatabase = async ({
     database.exec(`
       CREATE TABLE component_stock (
         lcsc INTEGER PRIMARY KEY,
-        stock INTEGER NOT NULL
+        stock INTEGER NOT NULL,
+        basic INTEGER NOT NULL,
+        preferred INTEGER NOT NULL
       );
 
-      INSERT INTO component_stock(lcsc, stock)
+      INSERT INTO component_stock(lcsc, stock, basic, preferred)
       SELECT
         lcsc,
-        CASE WHEN present = 1 THEN coalesce(stock, 0) ELSE 0 END
+        CASE WHEN present = 1 THEN coalesce(stock, 0) ELSE 0 END,
+        CASE WHEN library_type = 'base' THEN 1 ELSE 0 END,
+        preferred
       FROM source.jlc_components
       WHERE last_on_stock >= unixepoch('now', '-1 year');
     `)

--- a/scripts/generate-stock-sync-sql.ts
+++ b/scripts/generate-stock-sync-sql.ts
@@ -6,6 +6,8 @@ import path from "node:path"
 interface StockRow {
   lcsc: number
   stock: number | null
+  basic: number
+  preferred: number
 }
 
 interface CatalogStats {
@@ -30,17 +32,23 @@ const createStockUpdateStatement = (
 ) => {
   const values = rows
     .map(
-      ({ lcsc, stock }) =>
-        `(${integerLiteral(lcsc, "lcsc")},${integerLiteral(stock, "stock")})`,
+      ({ lcsc, stock, basic, preferred }) =>
+        `(${integerLiteral(lcsc, "lcsc")},${integerLiteral(stock, "stock")},${integerLiteral(basic, "basic")},${integerLiteral(preferred, "preferred")})`,
     )
     .join(",")
 
-  return `WITH stock_updates(lcsc, stock) AS (VALUES ${values})
+  return `WITH component_updates(lcsc, stock, basic, preferred) AS (VALUES ${values})
 UPDATE ${table} AS target
-SET stock = stock_updates.stock
-FROM stock_updates
-WHERE target.lcsc = stock_updates.lcsc
-  AND target.stock IS NOT stock_updates.stock;`
+SET stock = component_updates.stock,
+    basic = component_updates.basic,
+    preferred = component_updates.preferred
+FROM component_updates
+WHERE target.lcsc = component_updates.lcsc
+  AND (
+    target.stock IS NOT component_updates.stock
+    OR target.basic IS NOT component_updates.basic
+    OR target.preferred IS NOT component_updates.preferred
+  );`
 }
 
 export const createStockSyncBatchSql = (rows: StockRow[]): string => {
@@ -99,7 +107,7 @@ export const writeStockSyncBatches = async ({
 
     const rows = database
       .query<StockRow, []>(
-        `SELECT lcsc, stock
+        `SELECT lcsc, stock, basic, preferred
          FROM component_stock
          ORDER BY rowid`,
       )

--- a/tests/build-derived-sync-db.test.ts
+++ b/tests/build-derived-sync-db.test.ts
@@ -103,7 +103,7 @@ describe("buildDerivedSyncDatabase", () => {
       .query(
         `SELECT
           lcsc, price1, number_of_pins, gender, mounting_style,
-          is_basic, is_preferred
+          is_basic, is_preferred, is_extended_promotional
         FROM hdmi_port`,
       )
       .get() as Record<string, unknown>
@@ -116,6 +116,7 @@ describe("buildDerivedSyncDatabase", () => {
       mounting_style: "Surface Mount",
       is_basic: 1,
       is_preferred: 1,
+      is_extended_promotional: 0,
     })
     output.close()
   })
@@ -169,6 +170,99 @@ describe("buildDerivedSyncDatabase", () => {
       gender: "Female",
     })
     output.close()
+  })
+
+  test("derives extended promotional state from library type and preferred source fields", async () => {
+    const { sourcePath, outputPath } = await createSourceDatabase()
+    const source = new Database(sourcePath)
+    source.exec(`
+      INSERT INTO jlc_components (
+        lcsc, fetched_at, present, sync_seen, category, subcategory, mfr,
+        package, joints, manufacturer, library_type, preferred, last_on_stock,
+        description, datasheet, stock, price, attributes
+      ) VALUES
+        (
+          12346, unixepoch(), 1, 1, 'Connectors', 'HDMI Connectors',
+          'PROMO-EXT', 'SMD', 19, 'Example', 'expand', 1, unixepoch(),
+          'HDMI promotional extended part', '', 100, '1-:0.50',
+          '{"Connector Type":"HDMI","Number of Pins":"19"}'
+        ),
+        (
+          12347, unixepoch(), 1, 1, 'Connectors', 'HDMI Connectors',
+          'REGULAR-EXT', 'SMD', 19, 'Example', 'expand', 0, unixepoch(),
+          'HDMI regular extended part', '', 80, '1-:0.60',
+          '{"Connector Type":"HDMI","Number of Pins":"19"}'
+        );
+    `)
+    source.close()
+
+    await buildDerivedSyncDatabase({
+      sourcePath,
+      outputPath,
+      tableNames: ["hdmi_port"],
+      includeStockSnapshot: true,
+      logger: () => {},
+    })
+
+    const output = new Database(outputPath, { readonly: true })
+    expect(
+      output
+        .query(
+          `SELECT lcsc, is_basic, is_preferred, is_extended_promotional
+           FROM hdmi_port
+           ORDER BY lcsc`,
+        )
+        .all(),
+    ).toEqual([
+      {
+        lcsc: 12345,
+        is_basic: 1,
+        is_preferred: 1,
+        is_extended_promotional: 0,
+      },
+      {
+        lcsc: 12346,
+        is_basic: 0,
+        is_preferred: 1,
+        is_extended_promotional: 1,
+      },
+      {
+        lcsc: 12347,
+        is_basic: 0,
+        is_preferred: 0,
+        is_extended_promotional: 0,
+      },
+    ])
+    expect(
+      output
+        .query(
+          `SELECT lcsc, basic, preferred
+           FROM component_stock
+           ORDER BY lcsc`,
+        )
+        .all(),
+    ).toEqual([
+      { lcsc: 12345, basic: 1, preferred: 1 },
+      { lcsc: 12346, basic: 0, preferred: 1 },
+      { lcsc: 12347, basic: 0, preferred: 0 },
+    ])
+    output.close()
+  })
+
+  test("fails closed when the source classification fields disappear", async () => {
+    const { sourcePath, outputPath } = await createSourceDatabase()
+    const source = new Database(sourcePath)
+    source.exec("ALTER TABLE jlc_components DROP COLUMN preferred")
+    source.close()
+
+    expect(
+      buildDerivedSyncDatabase({
+        sourcePath,
+        outputPath,
+        tableNames: ["hdmi_port"],
+        logger: () => {},
+      }),
+    ).rejects.toThrow(/preferred.*refusing to fabricate/i)
   })
 
   test("materializes a stock snapshot with zeroes for absent parts", async () => {

--- a/tests/generate-stock-sync-sql.test.ts
+++ b/tests/generate-stock-sync-sql.test.ts
@@ -25,18 +25,23 @@ afterEach(async () => {
 })
 
 describe("stock sync SQL generation", () => {
-  test("updates only changed stock in existing catalog and search rows", async () => {
+  test("updates stock and source classification in existing catalog and search rows", async () => {
     const directory = await createTempDirectory()
     const sourcePath = path.join(directory, "source.sqlite3")
     const outputDirectory = path.join(directory, "batches")
     const source = new Database(sourcePath, { create: true })
     source.exec(`
-      CREATE TABLE component_stock (lcsc INTEGER, stock INTEGER);
-      INSERT INTO component_stock(lcsc, stock) VALUES
-        (1, 10),
-        (2, NULL),
-        (3, 0),
-        (4, 40);
+      CREATE TABLE component_stock (
+        lcsc INTEGER,
+        stock INTEGER,
+        basic INTEGER NOT NULL,
+        preferred INTEGER NOT NULL
+      );
+      INSERT INTO component_stock(lcsc, stock, basic, preferred) VALUES
+        (1, 10, 0, 1),
+        (2, NULL, 1, 1),
+        (3, 0, 0, 0),
+        (4, 40, 0, 1);
     `)
     source.close()
 
@@ -49,12 +54,28 @@ describe("stock sync SQL generation", () => {
 
     const target = new Database(":memory:")
     target.exec(`
-      CREATE TABLE component_catalog (lcsc INTEGER UNIQUE, stock INTEGER);
-      CREATE TABLE search_index (lcsc INTEGER UNIQUE, stock INTEGER);
-      INSERT INTO component_catalog(lcsc, stock) VALUES
-        (1, 1), (2, NULL), (3, 3), (99, 99);
-      INSERT INTO search_index(lcsc, stock) VALUES
-        (1, 1), (2, NULL), (3, 3), (99, 99);
+      CREATE TABLE component_catalog (
+        lcsc INTEGER UNIQUE,
+        stock INTEGER,
+        basic INTEGER,
+        preferred INTEGER
+      );
+      CREATE TABLE search_index (
+        lcsc INTEGER UNIQUE,
+        stock INTEGER,
+        basic INTEGER,
+        preferred INTEGER
+      );
+      INSERT INTO component_catalog(lcsc, stock, basic, preferred) VALUES
+        (1, 1, 0, 0),
+        (2, NULL, 1, 1),
+        (3, 3, 1, 1),
+        (99, 99, 1, 0);
+      INSERT INTO search_index(lcsc, stock, basic, preferred) VALUES
+        (1, 1, 0, 0),
+        (2, NULL, 1, 1),
+        (3, 3, 1, 1),
+        (99, 99, 1, 0);
     `)
 
     const batchFiles = (await readdir(outputDirectory)).sort()
@@ -64,12 +85,16 @@ describe("stock sync SQL generation", () => {
 
     for (const table of ["component_catalog", "search_index"]) {
       expect(
-        target.query(`SELECT lcsc, stock FROM ${table} ORDER BY lcsc`).all(),
+        target
+          .query(
+            `SELECT lcsc, stock, basic, preferred FROM ${table} ORDER BY lcsc`,
+          )
+          .all(),
       ).toEqual([
-        { lcsc: 1, stock: 10 },
-        { lcsc: 2, stock: null },
-        { lcsc: 3, stock: 0 },
-        { lcsc: 99, stock: 99 },
+        { lcsc: 1, stock: 10, basic: 0, preferred: 1 },
+        { lcsc: 2, stock: null, basic: 1, preferred: 1 },
+        { lcsc: 3, stock: 0, basic: 0, preferred: 0 },
+        { lcsc: 99, stock: 99, basic: 1, preferred: 0 },
       ])
     }
 
@@ -91,8 +116,15 @@ describe("stock sync SQL generation", () => {
     const sourcePath = path.join(directory, "source.sqlite3")
     const source = new Database(sourcePath, { create: true })
     source.exec(`
-      CREATE TABLE component_stock (lcsc INTEGER, stock INTEGER);
-      INSERT INTO component_stock(lcsc, stock) VALUES (1, 10), (1, 20);
+      CREATE TABLE component_stock (
+        lcsc INTEGER,
+        stock INTEGER,
+        basic INTEGER NOT NULL,
+        preferred INTEGER NOT NULL
+      );
+      INSERT INTO component_stock(lcsc, stock, basic, preferred) VALUES
+        (1, 10, 0, 1),
+        (1, 20, 0, 1);
     `)
     source.close()
 
@@ -108,6 +140,8 @@ describe("stock sync SQL generation", () => {
     const rows = Array.from({ length: 1000 }, (_, index) => ({
       lcsc: 9_000_000 + index,
       stock: 999_999_999,
+      basic: 0,
+      preferred: 1,
     }))
     const statements = createStockSyncBatchSql(rows).split(";\n")
 


### PR DESCRIPTION
## Summary

- derive `is_extended_promotional` from the current source-db-v2 fields as `library_type = 'expand' AND preferred = 1`
- fail closed if the upstream source stops exposing `library_type` or `preferred` instead of silently fabricating false values
- materialize the flag through the shared derived-component path so derived tables receive a first-class boolean without duplicating logic across table specs
- expose and filter the current D1 component/search APIs using the equivalent source-backed predicate `preferred = 1 AND basic = 0`
- extend the nightly stock sync to refresh `basic` and `preferred` as well as stock, so limited-time promotional status cannot become stale between full catalog rebuilds
- preserve the current `main` registrations for the recently added barrel-jack and Micro USB derived tables

## Regression coverage

- Basic + preferred => not extended promotional
- Extended + preferred => extended promotional
- Extended + non-preferred => not extended promotional
- missing source classification field => build errors rather than defaulting to zero
- D1 filter compilation requires both `preferred = 1` and `basic = 0`
- nightly classification sync remains idempotent and leaves unrelated rows untouched

The D1 API intentionally derives the response/filter from the existing `basic` and `preferred` columns rather than requiring an immediate production schema migration; the same source flags are refreshed by the nightly sync.

## Verification

GitHub Actions on the current PR merge candidate:
- Bun Test: **239 passed, 0 failed** across 33 files / 3306 assertions
- Type Check: **passed**
- Format Check: **passed**

Fixes #92

/claim #92