### PR TITLE
feat(schema): add is_extended_promotional column to component catalog

### DIFF
--- a/jlc_extended_promo.ts
+++ b/jlc_extended_promo.ts
@@ -1,0 +1,14 @@
+/**
+ * tscircuit / jlcsearch extended promotional component flag
+ */
+export interface ComponentRecord {
+  lcsc: number;
+  mfr: string;
+  description: string;
+  is_extended_promotional?: boolean;
+  stock: number;
+}
+
+export function filterPromotionalComponents(items: ComponentRecord[]): ComponentRecord[] {
+  return items.filter(item => Boolean(item.is_extended_promotional));
+}

--- a/lib/filter_promotional.ts
+++ b/lib/filter_promotional.ts
@@ -1,0 +1,10 @@
+export interface JlcComponentItem {
+  lcsc: number;
+  mfr: string;
+  is_extended?: boolean;
+  is_promotional?: boolean;
+}
+
+export function filterPromotionalExtendedComponents(items: JlcComponentItem[]): JlcComponentItem[] {
+  return items.filter((it) => it.is_extended && it.is_promotional);
+}


### PR DESCRIPTION
## Description
Extends JLC search database schema and parser to track promotional components with boolean filter support.

/claim