### PR TITLE
Add DRAM parts page

### DIFF
--- a/.github/workflows/d1-migrations.yml
+++ b/.github/workflows/d1-migrations.yml
@@ -31,7 +31,7 @@ on:
       derived_tables:
         description: Comma-separated derived tables to rebuild and upload
         required: true
-        default: photo_diode
+        default: dram
         type: string
       cache_bust_url:
         description: Production URL to refresh after the D1 upload
@@ -60,7 +60,7 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       SYNC_SCOPE: ${{ github.event_name == 'schedule' && 'stock_only' || inputs.sync_scope || 'derived' }}
-      DERIVED_TABLES_LIST: ${{ inputs.derived_tables || 'photo_diode,micro_usb_connector,barrel_jack' }}
+      DERIVED_TABLES_LIST: ${{ inputs.derived_tables || 'photo_diode,micro_usb_connector,barrel_jack,dram' }}
       SMOKE_TEST_LCSC: ${{ inputs.smoke_test_lcsc || '7512' }}
 
     steps:

--- a/cf-proxy/migrations/0007_dram.sql
+++ b/cf-proxy/migrations/0007_dram.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS dram (
+  lcsc INTEGER PRIMARY KEY,
+  mfr TEXT,
+  description TEXT,
+  stock INTEGER,
+  price1 REAL,
+  in_stock BOOLEAN,
+  package TEXT,
+  memory_type TEXT,
+  memory_size_mbit REAL,
+  clock_frequency_mhz REAL,
+  supply_voltage_min REAL,
+  supply_voltage_max REAL,
+  operating_temp_min REAL,
+  operating_temp_max REAL,
+  is_basic BOOLEAN,
+  is_preferred BOOLEAN,
+  attributes TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_dram_stock
+  ON dram (stock);
+CREATE INDEX IF NOT EXISTS idx_dram_package_stock
+  ON dram (package, stock);
+CREATE INDEX IF NOT EXISTS idx_dram_memory_type_stock
+  ON dram (memory_type, stock);
+CREATE INDEX IF NOT EXISTS idx_dram_memory_size_stock
+  ON dram (memory_size_mbit, stock);
+CREATE INDEX IF NOT EXISTS idx_dram_clock_frequency_stock
+  ON dram (clock_frequency_mhz, stock);
+CREATE INDEX IF NOT EXISTS idx_dram_is_basic_stock
+  ON dram (is_basic, stock);
+CREATE INDEX IF NOT EXISTS idx_dram_is_preferred_stock
+  ON dram (is_preferred, stock);

--- a/cf-proxy/scripts/sync-db.sh
+++ b/cf-proxy/scripts/sync-db.sh
@@ -36,6 +36,7 @@ DERIVED_TABLES=(
   capacitor
   dac
   diode
+  dram
   dimm_connector
   fpc_connector
   fpga

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -286,6 +286,26 @@ export interface Dac {
   supply_voltage_min: number | null
 }
 
+export interface Dram {
+  attributes: string | null
+  clock_frequency_mhz: number | null
+  description: string | null
+  in_stock: number | null
+  is_basic: number | null
+  is_preferred: number | null
+  lcsc: Generated<number | null>
+  memory_size_mbit: number | null
+  memory_type: string | null
+  mfr: string | null
+  operating_temp_max: number | null
+  operating_temp_min: number | null
+  package: string | null
+  price1: number | null
+  stock: number | null
+  supply_voltage_max: number | null
+  supply_voltage_min: number | null
+}
+
 export interface Diode {
   attributes: string | null
   configuration: string | null
@@ -1053,6 +1073,7 @@ export interface DB {
   capacitor: Capacitor
   component_catalog: ComponentCatalog
   dac: Dac
+  dram: Dram
   diode: Diode
   dimm_connector: DimmConnector
   fpc_connector: FpcConnector

--- a/cf-proxy/src/handlers/index.ts
+++ b/cf-proxy/src/handlers/index.ts
@@ -540,6 +540,20 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       num_channels: { field: "num_channels", type: "number" },
     },
   },
+  dram: {
+    filters: {
+      package: { field: "package", type: "string" },
+      memory_type: { field: "memory_type", type: "string" },
+      memory_size_mbit: { field: "memory_size_mbit", type: "number" },
+      clock_frequency_min_mhz: {
+        field: "clock_frequency_mhz",
+        type: "number",
+        operator: ">=",
+      },
+      is_basic: { field: "is_basic", type: "boolean" },
+      is_preferred: { field: "is_preferred", type: "boolean" },
+    },
+  },
   fpc_connector: {
     filters: {
       pitch_mm: { field: "pitch_mm", type: "number" },
@@ -747,6 +761,7 @@ export const ROUTE_TO_TABLE: Record<string, string> = {
   "/boost_converters/list": "boost_converter",
   "/buck_boost_converters/list": "buck_boost_converter",
   "/dacs/list": "dac",
+  "/drams/list": "dram",
   "/dimm_connectors/list": "dimm_connector",
   "/fpc_connectors/list": "fpc_connector",
   "/fpgas/list": "fpga",
@@ -798,6 +813,7 @@ export const TABLE_RESPONSE_KEY: Record<string, string> = {
   boost_converter: "boost_converters",
   buck_boost_converter: "buck_boost_converters",
   dac: "dacs",
+  dram: "drams",
   dimm_connector: "dimm_connectors",
   fpc_connector: "fpc_connectors",
   fpga: "fpgas",

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -26,6 +26,7 @@ const routeLabels: Record<string, string> = {
   "/headers/list": "Headers",
   "/barrel_jacks/list": "Barrel Jacks",
   "/dimm_connectors/list": "DIMM Connectors",
+  "/drams/list": "DRAM",
   "/sodimm_connectors/list": "SO-DIMM Connectors",
   "/micro_usb_connectors/list": "Micro USB Connectors",
   "/usb_c_connectors/list": "USB-C Connectors",
@@ -197,6 +198,9 @@ const COLUMN_LABELS: Record<string, string> = {
   inside_diameter_mm: "Inside Diameter",
   outside_diameter_mm: "Outside Diameter",
   current_rating_min: "Min Current",
+  memory_size_mbit: "Memory Size",
+  clock_frequency_mhz: "Clock Frequency",
+  clock_frequency_min_mhz: "Min Clock Frequency",
   voltage_rating_min: "Min Voltage",
   reception_angle_deg: "Reception Angle",
   luminous_intensity_mcd: "Intensity",
@@ -304,6 +308,10 @@ const formatDisplayValue = (column: string, value: unknown): string | null => {
       return `${formatSiUnit(value)}Hz`
     case "frequency_ghz":
       return withUnit(value, "GHz")
+    case "memory_size_mbit":
+      return withUnit(value, "Mbit")
+    case "clock_frequency_mhz":
+      return withUnit(value, "MHz")
     case "data_rate_mbps":
       return withUnit(value, "Mbps")
     case "wavelength_nm":

--- a/cf-proxy/test/render.test.ts
+++ b/cf-proxy/test/render.test.ts
@@ -12,6 +12,7 @@ describe("render helpers", () => {
     expect(html).toContain("/tft_display_drivers/list")
     expect(html).toContain("/resistors/list")
     expect(html).toContain("/barrel_jacks/list")
+    expect(html).toContain("/drams/list")
     expect(html).toContain("/spring_clamp_terminal_blocks/list")
     expect(html).toContain("/ble_modules/list")
     expect(html).toContain("/ble_chips/list")
@@ -20,6 +21,48 @@ describe("render helpers", () => {
     expect(html).toContain("/micro_usb_connectors/list")
     expect(html).toContain("/hdmi_ports/list")
     expect(html).toContain("/photo_diodes/list")
+  })
+
+  it("renders the DRAM page and JSON API link", () => {
+    const pathname = "/drams/list"
+
+    expect(D1_ROUTES).toContain(pathname)
+    expect(getD1Handler(pathname)).toBeTypeOf("function")
+
+    const html = renderD1TablePage(
+      pathname,
+      {
+        drams: [
+          {
+            lcsc: 500275,
+            mfr: "K4B4G1646E-BYMA",
+            package: "FBGA-96(7.5x13.3)",
+            memory_type: "DDR3L",
+            memory_size_mbit: 4096,
+            clock_frequency_mhz: 933,
+            stock: 5739,
+          },
+        ],
+      },
+      {
+        package: "FBGA-96(7.5x13.3)",
+        memory_type: "DDR3L",
+        memory_size_mbit: "4096",
+        clock_frequency_min_mhz: "800",
+      },
+      "https://jlcsearch.tscircuit.com/drams/list?memory_type=DDR3L",
+    )
+
+    expect(html).toContain("<h2>DRAM</h2>")
+    expect(html).toContain('name="package"')
+    expect(html).toContain('name="memory_type"')
+    expect(html).toContain('name="memory_size_mbit"')
+    expect(html).toContain('name="clock_frequency_min_mhz"')
+    expect(html).toContain('name="is_basic"')
+    expect(html).toContain('name="is_preferred"')
+    expect(html).toContain("4096Mbit")
+    expect(html).toContain("933MHz")
+    expect(html).toContain("/drams/list.json")
   })
 
   it("renders the Barrel Jacks page and JSON API link", () => {

--- a/lib/db/derivedtables/dram.ts
+++ b/lib/db/derivedtables/dram.ts
@@ -1,0 +1,166 @@
+import { extractMinQPrice } from "lib/util/extract-min-quantity-price"
+import type { BaseComponent } from "./component-base"
+import type { DerivedTableSpec } from "./types"
+
+export interface Dram extends BaseComponent {
+  package: string
+  memory_type: string
+  memory_size_mbit: number | null
+  clock_frequency_mhz: number | null
+  supply_voltage_min: number | null
+  supply_voltage_max: number | null
+  operating_temp_min: number | null
+  operating_temp_max: number | null
+}
+
+const DRAM_SUBCATEGORIES = ["DDR SDRAM", "SDRAM"] as const
+
+const parseRange = (
+  value?: string | null,
+): { min: number | null; max: number | null } => {
+  const matches = value?.match(/-?\d+(?:\.\d+)?/g)
+  if (!matches?.length) return { min: null, max: null }
+
+  const values = matches.map(Number).filter(Number.isFinite)
+  return values.length
+    ? { min: Math.min(...values), max: Math.max(...values) }
+    : { min: null, max: null }
+}
+
+const parseMemorySizeMbit = (value?: string | null): number | null => {
+  const match = value?.match(/(\d+(?:\.\d+)?)\s*([KMG])bit\b/i)
+  if (!match) return null
+
+  const amount = Number(match[1])
+  if (!Number.isFinite(amount)) return null
+  switch (match[2]?.toUpperCase()) {
+    case "K":
+      return amount / 1024
+    case "G":
+      return amount * 1024
+    default:
+      return amount
+  }
+}
+
+const parseClockFrequencyMhz = (value?: string | null): number | null => {
+  const match = value?.match(/(\d+(?:\.\d+)?)\s*([MG])Hz\b/i)
+  if (!match) return null
+
+  const amount = Number(match[1])
+  if (!Number.isFinite(amount)) return null
+  return match[2]?.toUpperCase() === "G" ? amount * 1000 : amount
+}
+
+const inferMemoryType = (text: string, subcategory?: string | null): string => {
+  const normalized = text.toUpperCase()
+  const match = normalized.match(/\b(LPDDR[2-5X]*|DDR[2-5]L?|DDR)\b/)
+  if (match) return match[1]!
+  return subcategory === "DDR SDRAM" ? "DDR" : "SDRAM"
+}
+
+export const dramTableSpec: DerivedTableSpec<Dram> = {
+  tableName: "dram",
+  extraColumns: [
+    { name: "package", type: "text" },
+    { name: "memory_type", type: "text" },
+    { name: "memory_size_mbit", type: "real" },
+    { name: "clock_frequency_mhz", type: "real" },
+    { name: "supply_voltage_min", type: "real" },
+    { name: "supply_voltage_max", type: "real" },
+    { name: "operating_temp_min", type: "real" },
+    { name: "operating_temp_max", type: "real" },
+    { name: "is_basic", type: "boolean" },
+    { name: "is_preferred", type: "boolean" },
+  ],
+  indexes: [
+    { name: "idx_dram_stock", columns: ["stock"] },
+    { name: "idx_dram_package_stock", columns: ["package", "stock"] },
+    {
+      name: "idx_dram_memory_type_stock",
+      columns: ["memory_type", "stock"],
+    },
+    {
+      name: "idx_dram_memory_size_stock",
+      columns: ["memory_size_mbit", "stock"],
+    },
+    {
+      name: "idx_dram_clock_frequency_stock",
+      columns: ["clock_frequency_mhz", "stock"],
+    },
+    { name: "idx_dram_is_basic_stock", columns: ["is_basic", "stock"] },
+    {
+      name: "idx_dram_is_preferred_stock",
+      columns: ["is_preferred", "stock"],
+    },
+  ],
+  listCandidateComponents: (db) =>
+    db
+      .selectFrom("components")
+      .innerJoin("categories", "components.category_id", "categories.id")
+      .selectAll()
+      .where((eb) =>
+        eb.or(
+          DRAM_SUBCATEGORIES.map((subcategory) =>
+            eb("categories.subcategory", "=", subcategory),
+          ),
+        ),
+      ),
+  mapToTable: (components) =>
+    components.map((component) => {
+      try {
+        const extra = component.extra ? JSON.parse(component.extra) : null
+        const attributes: Record<string, string> = extra?.attributes ?? {}
+        const description = String(component.description ?? "")
+        const subcategory = (
+          component as typeof component & { subcategory?: string | null }
+        ).subcategory
+        const searchableText = [
+          description,
+          attributes["Memory Type"],
+          attributes.Technology,
+          attributes.Type,
+        ]
+          .filter(Boolean)
+          .join(" ")
+        const sizeSource =
+          attributes["Memory Size"] ?? attributes.Density ?? description
+        const frequencySource =
+          attributes["Clock Frequency (fc)"] ??
+          attributes["Clock Frequency"] ??
+          description
+        const supplyRange = parseRange(
+          attributes["Supply Voltage"] ??
+            attributes["Supply Voltage Range"] ??
+            description.match(/\d+(?:\.\d+)?V~\d+(?:\.\d+)?V/)?.[0],
+        )
+        const temperatureRange = parseRange(
+          attributes["Operating Temperature"] ??
+            attributes["Operating Temperature Range"] ??
+            description.match(/-?\d+(?:\.\d+)?℃~\+?\d+(?:\.\d+)?℃/)?.[0],
+        )
+
+        return {
+          lcsc: Number(component.lcsc),
+          mfr: String(component.mfr ?? ""),
+          description,
+          stock: Number(component.stock ?? 0),
+          price1: extractMinQPrice(component.price),
+          in_stock: Number(component.stock ?? 0) > 0,
+          is_basic: Boolean(component.basic),
+          is_preferred: Boolean(component.preferred),
+          package: String(extra?.package ?? component.package ?? ""),
+          memory_type: inferMemoryType(searchableText, subcategory),
+          memory_size_mbit: parseMemorySizeMbit(sizeSource),
+          clock_frequency_mhz: parseClockFrequencyMhz(frequencySource),
+          supply_voltage_min: supplyRange.min,
+          supply_voltage_max: supplyRange.max,
+          operating_temp_min: temperatureRange.min,
+          operating_temp_max: temperatureRange.max,
+          attributes,
+        }
+      } catch {
+        return null
+      }
+    }),
+}

--- a/lib/db/derivedtables/setup-derived-tables.ts
+++ b/lib/db/derivedtables/setup-derived-tables.ts
@@ -13,6 +13,7 @@ import { buckBoostConverterTableSpec } from "lib/db/derivedtables/buck_boost_con
 import { capacitorTableSpec } from "lib/db/derivedtables/capacitor"
 import { dacTableSpec } from "lib/db/derivedtables/dac"
 import { diodeTableSpec } from "lib/db/derivedtables/diode"
+import { dramTableSpec } from "lib/db/derivedtables/dram"
 import {
   dimmConnectorTableSpec,
   sodimmConnectorTableSpec,
@@ -64,6 +65,7 @@ export const DERIVED_TABLES: DerivedTableSpec<any>[] = [
   barrelJackTableSpec,
   ioExpanderTableSpec,
   diodeTableSpec,
+  dramTableSpec,
   dacTableSpec,
   dimmConnectorTableSpec,
   sodimmConnectorTableSpec,

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -333,6 +333,26 @@ export interface Dac {
   supply_voltage_min: number | null;
 }
 
+export interface Dram {
+  attributes: string | null;
+  clock_frequency_mhz: number | null;
+  description: string | null;
+  in_stock: number | null;
+  is_basic: number | null;
+  is_preferred: number | null;
+  lcsc: Generated<number | null>;
+  memory_size_mbit: number | null;
+  memory_type: string | null;
+  mfr: string | null;
+  operating_temp_max: number | null;
+  operating_temp_min: number | null;
+  package: string | null;
+  price1: number | null;
+  stock: number | null;
+  supply_voltage_max: number | null;
+  supply_voltage_min: number | null;
+}
+
 export interface Diode {
   attributes: string | null;
   configuration: string | null;
@@ -1105,6 +1125,7 @@ export interface DB {
   components_fts_docsize: ComponentsFtsDocsize;
   components_fts_idx: ComponentsFtsIdx;
   dac: Dac;
+  dram: Dram;
   diode: Diode;
   dimm_connector: DimmConnector;
   fpc_connector: FpcConnector;

--- a/tests/lib/dram-derived-table.test.ts
+++ b/tests/lib/dram-derived-table.test.ts
@@ -1,0 +1,158 @@
+import { Database } from "bun:sqlite"
+import { expect, test } from "bun:test"
+import { Kysely } from "kysely"
+import { BunSqliteDialect } from "kysely-bun-sqlite"
+import { dramTableSpec } from "lib/db/derivedtables/dram"
+import { setupDerivedTables } from "lib/db/derivedtables/setup-derived-tables"
+
+const makeComponent = (overrides: Record<string, unknown> = {}) =>
+  ({
+    lcsc: 500275,
+    mfr: "K4B4G1646E-BYMA",
+    description:
+      "-40℃~+95℃ 1.28V~1.45V 4Gbit 933MHz DDR3L SDRAM FBGA-96 DDR SDRAM ROHS",
+    stock: 5739,
+    basic: 0,
+    preferred: 1,
+    price: JSON.stringify([{ qFrom: 1, qTo: null, price: 16.8479 }]),
+    package: "FBGA-96(7.5x13.3)",
+    subcategory: "DDR SDRAM",
+    extra: JSON.stringify({
+      package: "FBGA-96(7.5x13.3)",
+      attributes: {},
+    }),
+    ...overrides,
+  }) as any
+
+const EXPECTED_INDEX_COLUMNS = [
+  "stock",
+  "package,stock",
+  "memory_type,stock",
+  "memory_size_mbit,stock",
+  "clock_frequency_mhz,stock",
+  "is_basic,stock",
+  "is_preferred,stock",
+]
+
+test("DRAM table maps DDR attributes embedded in descriptions", () => {
+  const [dram] = dramTableSpec.mapToTable([makeComponent()])
+
+  expect(dram).toMatchObject({
+    lcsc: 500275,
+    mfr: "K4B4G1646E-BYMA",
+    memory_type: "DDR3L",
+    memory_size_mbit: 4096,
+    clock_frequency_mhz: 933,
+    supply_voltage_min: 1.28,
+    supply_voltage_max: 1.45,
+    operating_temp_min: -40,
+    operating_temp_max: 95,
+    is_preferred: true,
+    price1: 16.8479,
+  })
+})
+
+test("DRAM table maps plain SDRAM attributes", () => {
+  const [dram] = dramTableSpec.mapToTable([
+    makeComponent({
+      lcsc: 62379,
+      subcategory: "SDRAM",
+      description: "128Mbit 166MHz 3V~3.6V SDRAM ROHS",
+      extra: JSON.stringify({
+        attributes: {
+          "Operating Temperature": "0℃~+70℃",
+          "Memory Size": "128Mbit",
+          "Clock Frequency (fc)": "166MHz",
+        },
+      }),
+    }),
+  ])
+
+  expect(dram).toMatchObject({
+    memory_type: "SDRAM",
+    memory_size_mbit: 128,
+    clock_frequency_mhz: 166,
+    operating_temp_min: 0,
+    operating_temp_max: 70,
+  })
+})
+
+test("DRAM table selects DRAM IC categories but not memory connectors", async () => {
+  const database = new Database(":memory:")
+  const db = new Kysely<any>({
+    dialect: new BunSqliteDialect({ database }),
+  })
+
+  try {
+    await db.schema
+      .createTable("categories")
+      .addColumn("id", "integer", (column) => column.primaryKey())
+      .addColumn("subcategory", "text", (column) => column.notNull())
+      .execute()
+    await db.schema
+      .createTable("components")
+      .addColumn("lcsc", "integer", (column) => column.primaryKey())
+      .addColumn("category_id", "integer", (column) => column.notNull())
+      .execute()
+    await db
+      .insertInto("categories")
+      .values([
+        { id: 1, subcategory: "DDR SDRAM" },
+        { id: 2, subcategory: "SDRAM" },
+        { id: 3, subcategory: "Memory Connector (DDR)" },
+      ])
+      .execute()
+    await db
+      .insertInto("components")
+      .values([
+        { lcsc: 1, category_id: 1 },
+        { lcsc: 2, category_id: 2 },
+        { lcsc: 3, category_id: 3 },
+      ])
+      .execute()
+
+    const candidates = await dramTableSpec.listCandidateComponents(db).execute()
+    expect(candidates.map((candidate) => candidate.lcsc)).toEqual([1, 2])
+  } finally {
+    await db.destroy()
+  }
+})
+
+test("DRAM schema and migration create query indexes idempotently", async () => {
+  expect(
+    dramTableSpec.indexes?.map((index) => index.columns.join(",")),
+  ).toEqual(EXPECTED_INDEX_COLUMNS)
+
+  const database = new Database(":memory:")
+  const db = new Kysely<any>({
+    dialect: new BunSqliteDialect({ database }),
+  })
+  try {
+    await setupDerivedTables({ db, populate: false, tableNames: ["dram"] })
+    const indexes = database
+      .query(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'dram' AND name NOT LIKE 'sqlite_%'",
+      )
+      .all()
+    expect(indexes).toHaveLength(EXPECTED_INDEX_COLUMNS.length)
+  } finally {
+    await db.destroy()
+  }
+
+  const migrationDatabase = new Database(":memory:")
+  const migration = await Bun.file(
+    new URL("../../cf-proxy/migrations/0007_dram.sql", import.meta.url),
+  ).text()
+  try {
+    migrationDatabase.exec(migration)
+    migrationDatabase.exec(migration)
+    const indexes = migrationDatabase
+      .query(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'dram' AND name NOT LIKE 'sqlite_%'",
+      )
+      .all()
+    expect(indexes).toHaveLength(EXPECTED_INDEX_COLUMNS.length)
+  } finally {
+    migrationDatabase.close()
+  }
+})


### PR DESCRIPTION
## Summary

- add `/drams/list` and JSON routes for in-stock SDRAM and DDR SDRAM ICs
- derive memory type, density, clock, voltage, and temperature fields from JLC catalog metadata
- add package, memory type, density, clock, basic, and preferred filters
- add the D1 schema, sync wiring, deployment population, and route/schema tests

## Validation

- `bun test tests/lib` (55 passed)
- `bunx tsc --noEmit`
- `bunx vitest run --exclude test/contracts.test.ts` in `cf-proxy` (68 passed)
- `bunx tsc --noEmit` in `cf-proxy`
- Biome formatting and `git diff --check`