### PR TITLE
Add is_extended_promotional filterable column

### DIFF
--- a/cf-proxy/src/components.ts
+++ b/cf-proxy/src/components.ts
@@ -1,6 +1,6 @@
 import type { Kysely } from "kysely"
 import type { DB } from "./db/types"
-import { searchIndex } from "./search"
+import { isExtendedPromotional, searchIndex } from "./search"
 
 export interface ComponentCatalogQueryParams {
   subcategory_name?: string
@@ -8,6 +8,7 @@ export interface ComponentCatalogQueryParams {
   search?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
 
 export async function queryComponentCatalog(
@@ -34,11 +35,13 @@ export async function queryComponentCatalog(
     subcategory_name: params.subcategory_name,
     is_basic: params.is_basic,
     is_preferred: params.is_preferred,
+    is_extended_promotional: params.is_extended_promotional,
     limit: "100",
   })
 
   return rows.map((row) => ({
     ...row,
+    is_extended_promotional: isExtendedPromotional(row.basic, row.preferred),
     extra: null,
   }))
 }

--- a/cf-proxy/src/d1-routes.ts
+++ b/cf-proxy/src/d1-routes.ts
@@ -1,5 +1,6 @@
 import type { Kysely } from "kysely"
 import type { DB } from "./db/types"
+import { isExtendedPromotional } from "./search"
 import {
   createDisplayDriverMaxResolutionResolver,
   getDisplayDriverMaxResolutionOptions,
@@ -347,6 +348,13 @@ const SPECIAL_D1_HANDLERS: Record<string, D1Handler> = {
       query = query.where("preferred", "=", 1)
     }
 
+    if (
+      params.is_extended_promotional === "true" ||
+      params.is_extended_promotional === "1"
+    ) {
+      query = query.where("preferred", "=", 1).where("basic", "=", 0)
+    }
+
     const [packages, resolutionSources, lcdDrivers] = await Promise.all([
       db
         .selectFrom("component_catalog")
@@ -391,6 +399,10 @@ const SPECIAL_D1_HANDLERS: Record<string, D1Handler> = {
             description: driver.description ?? "",
             is_basic: Boolean(driver.basic),
             is_preferred: Boolean(driver.preferred),
+            is_extended_promotional: isExtendedPromotional(
+              driver.basic,
+              driver.preferred,
+            ),
             stock: driver.stock ?? 0,
             price1: extractSmallQuantityPrice(driver.price),
             attributes: extractAttributes(driver.extra),
@@ -432,6 +444,13 @@ const SPECIAL_D1_HANDLERS: Record<string, D1Handler> = {
 
     if (params.is_preferred === "true" || params.is_preferred === "1") {
       query = query.where("preferred", "=", 1)
+    }
+
+    if (
+      params.is_extended_promotional === "true" ||
+      params.is_extended_promotional === "1"
+    ) {
+      query = query.where("preferred", "=", 1).where("basic", "=", 0)
     }
 
     const [packages, resolutionSources, tftDrivers] = await Promise.all([
@@ -479,6 +498,10 @@ const SPECIAL_D1_HANDLERS: Record<string, D1Handler> = {
             description: driver.description ?? "",
             is_basic: Boolean(driver.basic),
             is_preferred: Boolean(driver.preferred),
+            is_extended_promotional: isExtendedPromotional(
+              driver.basic,
+              driver.preferred,
+            ),
             stock: driver.stock ?? 0,
             price1: extractSmallQuantityPrice(driver.price),
             attributes: extractAttributes(driver.extra),

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -19,6 +19,7 @@ export interface Accelerometer {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>
   mfr: string | null
   operating_temp_max: number | null
@@ -87,6 +88,7 @@ export interface BarrelJack {
   inside_diameter_mm: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>
   mfr: string | null
   mounting_style: string | null
@@ -109,6 +111,7 @@ export interface BatteryHolder {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>
   mfr: string | null
   operating_temp_max: number | null
@@ -132,6 +135,7 @@ export interface BleChip {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>
   mfr: string | null
   operating_voltage_max: number | null
@@ -156,6 +160,7 @@ export interface BleModule {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>
   mfr: string | null
   operating_voltage_max: number | null
@@ -190,6 +195,7 @@ export interface BoostConverter {
   input_voltage_min: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   is_synchronous: number | null
   lcsc: Generated<number | null>
   mfr: string | null
@@ -212,6 +218,7 @@ export interface BuckBoostConverter {
   input_voltage_min: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   is_synchronous: number | null
   lcsc: Generated<number | null>
   mfr: string | null
@@ -250,6 +257,7 @@ export interface Capacitor {
   is_basic: number | null
   is_polarized: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   is_surface_mount: number | null
   lcsc: Generated<number | null>
   lifetime_hours: number | null
@@ -318,6 +326,7 @@ export interface DimmConnector {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   is_right_angle: number | null
   lcsc: Generated<number | null>
   mfr: string | null
@@ -338,6 +347,7 @@ export interface FpcConnector {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>
   locking_feature: string | null
   mfr: string | null
@@ -354,6 +364,7 @@ export interface Fpga {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>
   logic_array_blocks: number | null
   logic_elements: number | null
@@ -393,6 +404,7 @@ export interface GasSensor {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>
   measures_air_quality: number | null
   measures_carbon_monoxide: number | null
@@ -422,6 +434,7 @@ export interface Gyroscope {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>
   mfr: string | null
   operating_temp_max: number | null
@@ -469,6 +482,7 @@ export interface HdmiPort {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>
   mfr: string | null
   mounting_style: string | null
@@ -512,6 +526,7 @@ export interface JstConnector {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>
   mfr: string | null
   num_pins: number | null
@@ -547,6 +562,7 @@ export interface Ldo {
   is_basic: number | null
   is_positive: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>
   mfr: string | null
   operating_temp_max: number | null
@@ -661,6 +677,7 @@ export interface MicroUsbConnector {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>
   mfr: string | null
   mounting_style: string | null
@@ -747,6 +764,7 @@ export interface PcieM2Connector {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   is_right_angle: number | null
   key: string | null
   lcsc: Generated<number | null>
@@ -762,6 +780,7 @@ export interface PhotoDiode {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>
   mfr: string | null
   operating_temp_max: number | null
@@ -799,6 +818,7 @@ export interface Relay {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>
   max_switching_current: number | null
   max_switching_voltage: number | null
@@ -837,6 +857,7 @@ export interface Resistor {
   is_multi_resistor_chip: number | null
   is_potentiometer: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   is_surface_mount: number | null
   lcsc: Generated<number | null>
   max_overload_voltage: number | null
@@ -857,6 +878,7 @@ export interface ResistorArray {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   is_surface_mount: number | null
   lcsc: Generated<number | null>
   mfr: string | null
@@ -881,6 +903,7 @@ export interface Switch {
   is_basic: number | null
   is_latching: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>
   length_mm: number | null
   mfr: string | null
@@ -905,6 +928,7 @@ export interface SodimmConnector {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   is_right_angle: number | null
   lcsc: Generated<number | null>
   mfr: string | null
@@ -925,6 +949,7 @@ export interface SpringClampTerminalBlock {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>
   mfr: string | null
   mounting_style: string | null
@@ -946,6 +971,7 @@ export interface UsbCConnector {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>
   mfr: string | null
   mounting_style: string | null
@@ -1018,6 +1044,7 @@ export interface WireToBoardConnector {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
+  is_extended_promotional: number | null;
   is_smd: number | null
   lcsc: Generated<number | null>
   mfr: string | null

--- a/cf-proxy/src/db/types.ts
+++ b/cf-proxy/src/db/types.ts
@@ -19,7 +19,7 @@ export interface Accelerometer {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   operating_temp_max: number | null
@@ -88,7 +88,7 @@ export interface BarrelJack {
   inside_diameter_mm: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   mounting_style: string | null
@@ -111,7 +111,7 @@ export interface BatteryHolder {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   operating_temp_max: number | null
@@ -135,7 +135,7 @@ export interface BleChip {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   operating_voltage_max: number | null
@@ -160,7 +160,7 @@ export interface BleModule {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   operating_voltage_max: number | null
@@ -195,7 +195,7 @@ export interface BoostConverter {
   input_voltage_min: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   is_synchronous: number | null
   lcsc: Generated<number | null>
   mfr: string | null
@@ -218,7 +218,7 @@ export interface BuckBoostConverter {
   input_voltage_min: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   is_synchronous: number | null
   lcsc: Generated<number | null>
   mfr: string | null
@@ -257,7 +257,7 @@ export interface Capacitor {
   is_basic: number | null
   is_polarized: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   is_surface_mount: number | null
   lcsc: Generated<number | null>
   lifetime_hours: number | null
@@ -346,7 +346,7 @@ export interface DimmConnector {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   is_right_angle: number | null
   lcsc: Generated<number | null>
   mfr: string | null
@@ -367,7 +367,7 @@ export interface FpcConnector {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   locking_feature: string | null
   mfr: string | null
@@ -384,7 +384,7 @@ export interface Fpga {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   logic_array_blocks: number | null
   logic_elements: number | null
@@ -424,7 +424,7 @@ export interface GasSensor {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   measures_air_quality: number | null
   measures_carbon_monoxide: number | null
@@ -454,7 +454,7 @@ export interface Gyroscope {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   operating_temp_max: number | null
@@ -502,7 +502,7 @@ export interface HdmiPort {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   mounting_style: string | null
@@ -546,7 +546,7 @@ export interface JstConnector {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   num_pins: number | null
@@ -582,7 +582,7 @@ export interface Ldo {
   is_basic: number | null
   is_positive: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   operating_temp_max: number | null
@@ -697,7 +697,7 @@ export interface MicroUsbConnector {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   mounting_style: string | null
@@ -784,7 +784,7 @@ export interface PcieM2Connector {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   is_right_angle: number | null
   key: string | null
   lcsc: Generated<number | null>
@@ -800,7 +800,7 @@ export interface PhotoDiode {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   operating_temp_max: number | null
@@ -838,7 +838,7 @@ export interface Relay {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   max_switching_current: number | null
   max_switching_voltage: number | null
@@ -877,7 +877,7 @@ export interface Resistor {
   is_multi_resistor_chip: number | null
   is_potentiometer: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   is_surface_mount: number | null
   lcsc: Generated<number | null>
   max_overload_voltage: number | null
@@ -898,7 +898,7 @@ export interface ResistorArray {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   is_surface_mount: number | null
   lcsc: Generated<number | null>
   mfr: string | null
@@ -923,7 +923,7 @@ export interface Switch {
   is_basic: number | null
   is_latching: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   length_mm: number | null
   mfr: string | null
@@ -948,7 +948,7 @@ export interface SodimmConnector {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   is_right_angle: number | null
   lcsc: Generated<number | null>
   mfr: string | null
@@ -969,7 +969,7 @@ export interface SpringClampTerminalBlock {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   mounting_style: string | null
@@ -991,7 +991,7 @@ export interface UsbCConnector {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   lcsc: Generated<number | null>
   mfr: string | null
   mounting_style: string | null
@@ -1064,7 +1064,7 @@ export interface WireToBoardConnector {
   in_stock: number | null
   is_basic: number | null
   is_preferred: number | null
-  is_extended_promotional: number | null;
+  is_extended_promotional: number | null
   is_smd: number | null
   lcsc: Generated<number | null>
   mfr: string | null

--- a/cf-proxy/src/handlers/index.ts
+++ b/cf-proxy/src/handlers/index.ts
@@ -264,7 +264,10 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       package: { field: "package", type: "string" },
       is_basic: { field: "is_basic", type: "boolean" },
       is_preferred: { field: "is_preferred", type: "boolean" },
-      is_extended_promotional: { field: "is_extended_promotional", type: "boolean" },
+      is_extended_promotional: {
+        field: "is_extended_promotional",
+        type: "boolean",
+      },
       resistance: { field: "resistance", type: "number_tolerance" },
     },
   },
@@ -273,7 +276,10 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       package: { field: "package", type: "string" },
       is_basic: { field: "is_basic", type: "boolean" },
       is_preferred: { field: "is_preferred", type: "boolean" },
-      is_extended_promotional: { field: "is_extended_promotional", type: "boolean" },
+      is_extended_promotional: {
+        field: "is_extended_promotional",
+        type: "boolean",
+      },
       capacitance: { field: "capacitance_farads", type: "number_tolerance" },
     },
   },
@@ -295,7 +301,10 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       gender: { field: "gender", type: "string" },
       is_basic: { field: "is_basic", type: "boolean" },
       is_preferred: { field: "is_preferred", type: "boolean" },
-      is_extended_promotional: { field: "is_extended_promotional", type: "boolean" },
+      is_extended_promotional: {
+        field: "is_extended_promotional",
+        type: "boolean",
+      },
     },
   },
   ldo: {
@@ -364,7 +373,10 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       },
       is_basic: { field: "is_basic", type: "boolean" },
       is_preferred: { field: "is_preferred", type: "boolean" },
-      is_extended_promotional: { field: "is_extended_promotional", type: "boolean" },
+      is_extended_promotional: {
+        field: "is_extended_promotional",
+        type: "boolean",
+      },
     },
   },
   dimm_connector: {
@@ -378,7 +390,10 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       is_right_angle: { field: "is_right_angle", type: "boolean" },
       is_basic: { field: "is_basic", type: "boolean" },
       is_preferred: { field: "is_preferred", type: "boolean" },
-      is_extended_promotional: { field: "is_extended_promotional", type: "boolean" },
+      is_extended_promotional: {
+        field: "is_extended_promotional",
+        type: "boolean",
+      },
     },
   },
   mosfet: {
@@ -482,7 +497,10 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       num_pins: { field: "num_pins", type: "number" },
       is_basic: { field: "is_basic", type: "boolean" },
       is_preferred: { field: "is_preferred", type: "boolean" },
-      is_extended_promotional: { field: "is_extended_promotional", type: "boolean" },
+      is_extended_promotional: {
+        field: "is_extended_promotional",
+        type: "boolean",
+      },
     },
   },
   battery_holder: {
@@ -593,7 +611,10 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       number_of_pins: { field: "number_of_pins", type: "number" },
       is_basic: { field: "is_basic", type: "boolean" },
       is_preferred: { field: "is_preferred", type: "boolean" },
-      is_extended_promotional: { field: "is_extended_promotional", type: "boolean" },
+      is_extended_promotional: {
+        field: "is_extended_promotional",
+        type: "boolean",
+      },
     },
   },
   gyroscope: {
@@ -689,7 +710,10 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       is_right_angle: { field: "is_right_angle", type: "boolean" },
       is_basic: { field: "is_basic", type: "boolean" },
       is_preferred: { field: "is_preferred", type: "boolean" },
-      is_extended_promotional: { field: "is_extended_promotional", type: "boolean" },
+      is_extended_promotional: {
+        field: "is_extended_promotional",
+        type: "boolean",
+      },
     },
   },
   spring_clamp_terminal_block: {

--- a/cf-proxy/src/handlers/index.ts
+++ b/cf-proxy/src/handlers/index.ts
@@ -264,6 +264,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       package: { field: "package", type: "string" },
       is_basic: { field: "is_basic", type: "boolean" },
       is_preferred: { field: "is_preferred", type: "boolean" },
+      is_extended_promotional: { field: "is_extended_promotional", type: "boolean" },
       resistance: { field: "resistance", type: "number_tolerance" },
     },
   },
@@ -272,6 +273,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       package: { field: "package", type: "string" },
       is_basic: { field: "is_basic", type: "boolean" },
       is_preferred: { field: "is_preferred", type: "boolean" },
+      is_extended_promotional: { field: "is_extended_promotional", type: "boolean" },
       capacitance: { field: "capacitance_farads", type: "number_tolerance" },
     },
   },
@@ -293,6 +295,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       gender: { field: "gender", type: "string" },
       is_basic: { field: "is_basic", type: "boolean" },
       is_preferred: { field: "is_preferred", type: "boolean" },
+      is_extended_promotional: { field: "is_extended_promotional", type: "boolean" },
     },
   },
   ldo: {
@@ -361,6 +364,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       },
       is_basic: { field: "is_basic", type: "boolean" },
       is_preferred: { field: "is_preferred", type: "boolean" },
+      is_extended_promotional: { field: "is_extended_promotional", type: "boolean" },
     },
   },
   dimm_connector: {
@@ -374,6 +378,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       is_right_angle: { field: "is_right_angle", type: "boolean" },
       is_basic: { field: "is_basic", type: "boolean" },
       is_preferred: { field: "is_preferred", type: "boolean" },
+      is_extended_promotional: { field: "is_extended_promotional", type: "boolean" },
     },
   },
   mosfet: {
@@ -477,6 +482,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       num_pins: { field: "num_pins", type: "number" },
       is_basic: { field: "is_basic", type: "boolean" },
       is_preferred: { field: "is_preferred", type: "boolean" },
+      is_extended_promotional: { field: "is_extended_promotional", type: "boolean" },
     },
   },
   battery_holder: {
@@ -573,6 +579,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       number_of_pins: { field: "number_of_pins", type: "number" },
       is_basic: { field: "is_basic", type: "boolean" },
       is_preferred: { field: "is_preferred", type: "boolean" },
+      is_extended_promotional: { field: "is_extended_promotional", type: "boolean" },
     },
   },
   gyroscope: {
@@ -668,6 +675,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       is_right_angle: { field: "is_right_angle", type: "boolean" },
       is_basic: { field: "is_basic", type: "boolean" },
       is_preferred: { field: "is_preferred", type: "boolean" },
+      is_extended_promotional: { field: "is_extended_promotional", type: "boolean" },
     },
   },
   spring_clamp_terminal_block: {

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -582,7 +582,10 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
-        is_extended_promotional: isExtendedPromotional(row.basic, row.preferred),
+        is_extended_promotional: isExtendedPromotional(
+          row.basic,
+          row.preferred,
+        ),
       })),
     }
 

--- a/cf-proxy/src/index.ts
+++ b/cf-proxy/src/index.ts
@@ -4,7 +4,7 @@ import { getD1Handler } from "./d1-routes"
 import { getD1Client } from "./db/get-d1-client"
 import { handleEasyEdaComponentCache } from "./easyeda-component-cache"
 import { renderD1TablePage, renderHomePage } from "./render"
-import { searchIndex } from "./search"
+import { isExtendedPromotional, searchIndex } from "./search"
 
 export interface Env {
   CACHE_KV: KVNamespace
@@ -456,6 +456,7 @@ async function handleD1Search(
       package: row.package ?? "",
       is_basic: Boolean(row.basic),
       is_preferred: Boolean(row.preferred),
+      is_extended_promotional: isExtendedPromotional(row.basic, row.preferred),
       description: row.description ?? "",
       stock: row.stock ?? 0,
       price: row.price1 ?? extractSmallQuantityPrice(row.price),
@@ -581,6 +582,7 @@ async function handleD1ComponentsList(
         subcategory: row.subcategory ?? "",
         is_basic: Boolean(row.basic),
         is_preferred: Boolean(row.preferred),
+        is_extended_promotional: isExtendedPromotional(row.basic, row.preferred),
       })),
     }
 

--- a/cf-proxy/src/render.ts
+++ b/cf-proxy/src/render.ts
@@ -175,6 +175,7 @@ const COLUMN_LABELS: Record<string, string> = {
   in_stock: "In Stock",
   is_basic: "Basic",
   is_preferred: "Preferred",
+  is_extended_promotional: "Extended Promotional",
   capacitance_farads: "Capacitance",
   tolerance_fraction: "Tolerance",
   voltage_rating: "Voltage",
@@ -596,6 +597,9 @@ const renderCustomFilters = (
         <div>
           <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
         </div>
+        <div>
+          <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
+        </div>
         <button type="submit">Filter</button>
       </form>`
     }
@@ -640,6 +644,9 @@ const renderCustomFilters = (
         </div>
         <div>
           <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
+        </div>
+        <div>
+          <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
         </div>
         <button type="submit">Filter</button>
       </form>`
@@ -709,6 +716,9 @@ const renderComponentsFilters = (
   </div>
   <div>
     <label>Preferred Part:<input type="checkbox" name="is_preferred" value="true"${params.is_preferred === "true" ? " checked" : ""} /></label>
+  </div>
+  <div>
+    <label>Extended Promotional:<input type="checkbox" name="is_extended_promotional" value="true"${params.is_extended_promotional === "true" ? " checked" : ""} /></label>
   </div>
   <button type="submit">Filter</button>
 </form>`

--- a/cf-proxy/src/search.ts
+++ b/cf-proxy/src/search.ts
@@ -9,7 +9,13 @@ export interface SearchQueryParams {
   limit?: string
   is_basic?: string
   is_preferred?: string
+  is_extended_promotional?: string
 }
+
+export const isExtendedPromotional = (
+  basic: number | null,
+  preferred: number | null,
+): boolean => Boolean(preferred) && !Boolean(basic)
 
 interface SearchRow {
   lcsc: number | null
@@ -108,6 +114,14 @@ export async function searchIndex(
 
   if (params.is_preferred === "true" || params.is_preferred === "1") {
     conditions.push(sql`search_index.preferred = 1`)
+  }
+
+  if (
+    params.is_extended_promotional === "true" ||
+    params.is_extended_promotional === "1"
+  ) {
+    conditions.push(sql`search_index.preferred = 1`)
+    conditions.push(sql`search_index.basic = 0`)
   }
 
   const raw = params.q?.trim()

--- a/cf-proxy/test/lcd-drivers-route.test.ts
+++ b/cf-proxy/test/lcd-drivers-route.test.ts
@@ -113,6 +113,7 @@ describe("LCD driver route", () => {
               description: "LCD driver",
               is_basic: false,
               is_preferred: true,
+              is_extended_promotional: true,
               stock: 18416,
               price1: 0.464285714,
               attributes:

--- a/cf-proxy/test/tft-display-drivers-route.test.ts
+++ b/cf-proxy/test/tft-display-drivers-route.test.ts
@@ -158,6 +158,7 @@ describe("TFT display driver route", () => {
           description: "TFT LCD controller",
           is_basic: false,
           is_preferred: true,
+          is_extended_promotional: true,
           stock: 604,
           price1: 5.845714286,
           attributes: '{"Interface":"8080/6800"}',

--- a/lib/db/derivedtables/accelerometer.ts
+++ b/lib/db/derivedtables/accelerometer.ts
@@ -103,7 +103,7 @@ export const accelerometerTableSpec: DerivedTableSpec<Accelerometer> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
-        is_extended_promotional: Boolean(c.is_extended_promotional),
+        is_extended_promotional: Boolean(c.preferred && !c.basic),
         package: c.package || "",
         supply_voltage_min: voltageMin,
         supply_voltage_max: voltageMax,

--- a/lib/db/derivedtables/accelerometer.ts
+++ b/lib/db/derivedtables/accelerometer.ts
@@ -28,6 +28,7 @@ export const accelerometerTableSpec: DerivedTableSpec<Accelerometer> = {
     { name: "has_uart", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -102,6 +103,7 @@ export const accelerometerTableSpec: DerivedTableSpec<Accelerometer> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         supply_voltage_min: voltageMin,
         supply_voltage_max: voltageMax,

--- a/lib/db/derivedtables/adc.ts
+++ b/lib/db/derivedtables/adc.ts
@@ -116,7 +116,7 @@ export const adcTableSpec: DerivedTableSpec<Adc> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
-        is_extended_promotional: Boolean(c.is_extended_promotional),
+        is_extended_promotional: Boolean(c.preferred && !c.basic),
         package: c.package || "",
         resolution_bits: resolution,
         sampling_rate_hz: samplingRate,

--- a/lib/db/derivedtables/adc.ts
+++ b/lib/db/derivedtables/adc.ts
@@ -40,6 +40,7 @@ export const adcTableSpec: DerivedTableSpec<Adc> = {
     { name: "operating_temp_max", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -115,6 +116,7 @@ export const adcTableSpec: DerivedTableSpec<Adc> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         resolution_bits: resolution,
         sampling_rate_hz: samplingRate,

--- a/lib/db/derivedtables/analog_multiplexer.ts
+++ b/lib/db/derivedtables/analog_multiplexer.ts
@@ -40,6 +40,7 @@ export const analogMultiplexerTableSpec: DerivedTableSpec<AnalogMultiplexer> = {
     { name: "channel_type", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -144,6 +145,7 @@ export const analogMultiplexerTableSpec: DerivedTableSpec<AnalogMultiplexer> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         num_channels: numChannels,
         num_bits: numBits,

--- a/lib/db/derivedtables/analog_multiplexer.ts
+++ b/lib/db/derivedtables/analog_multiplexer.ts
@@ -145,7 +145,7 @@ export const analogMultiplexerTableSpec: DerivedTableSpec<AnalogMultiplexer> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
-        is_extended_promotional: Boolean(c.is_extended_promotional),
+        is_extended_promotional: Boolean(c.preferred && !c.basic),
         package: c.package || "",
         num_channels: numChannels,
         num_bits: numBits,

--- a/lib/db/derivedtables/barrel-jack.ts
+++ b/lib/db/derivedtables/barrel-jack.ts
@@ -233,7 +233,9 @@ export const barrelJackTableSpec: DerivedTableSpec<BarrelJack> = {
         in_stock: Number(component.stock || 0) > 0,
         is_basic: Boolean(component.basic),
         is_preferred: Boolean(component.preferred),
-        is_extended_promotional: Boolean(component.is_extended_promotional),
+        is_extended_promotional: Boolean(
+          Number(component.preferred) === 1 && Number(component.basic) === 0,
+        ),
         connector_type: connectorType || "DC Power Jack",
         mounting_style: inferMountingStyle(
           attributes,

--- a/lib/db/derivedtables/barrel-jack.ts
+++ b/lib/db/derivedtables/barrel-jack.ts
@@ -151,6 +151,7 @@ export const barrelJackTableSpec: DerivedTableSpec<BarrelJack> = {
     { name: "operating_temp_max", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   indexes: [
     { name: "idx_barrel_jack_stock", columns: ["stock"] },
@@ -232,6 +233,7 @@ export const barrelJackTableSpec: DerivedTableSpec<BarrelJack> = {
         in_stock: Number(component.stock || 0) > 0,
         is_basic: Boolean(component.basic),
         is_preferred: Boolean(component.preferred),
+        is_extended_promotional: Boolean(component.is_extended_promotional),
         connector_type: connectorType || "DC Power Jack",
         mounting_style: inferMountingStyle(
           attributes,

--- a/lib/db/derivedtables/battery_holder.ts
+++ b/lib/db/derivedtables/battery_holder.ts
@@ -32,6 +32,7 @@ export const batteryHolderTableSpec: DerivedTableSpec<BatteryHolder> = {
     { name: "operating_temp_max", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -74,6 +75,7 @@ export const batteryHolderTableSpec: DerivedTableSpec<BatteryHolder> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: String(c.package || ""),
           connector_type: attrs["Connector Type"] || null,
           battery_type: attrs["Battery Type"] || null,

--- a/lib/db/derivedtables/battery_holder.ts
+++ b/lib/db/derivedtables/battery_holder.ts
@@ -75,7 +75,7 @@ export const batteryHolderTableSpec: DerivedTableSpec<BatteryHolder> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
-          is_extended_promotional: Boolean(c.is_extended_promotional),
+          is_extended_promotional: Boolean(c.preferred && !c.basic),
           package: String(c.package || ""),
           connector_type: attrs["Connector Type"] || null,
           battery_type: attrs["Battery Type"] || null,

--- a/lib/db/derivedtables/bjt_transistor.ts
+++ b/lib/db/derivedtables/bjt_transistor.ts
@@ -75,7 +75,7 @@ export const bjtTransistorTableSpec: DerivedTableSpec<BJTTransistor> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
-          is_extended_promotional: Boolean(c.is_extended_promotional),
+          is_extended_promotional: Boolean(c.preferred && !c.basic),
           package: c.package || "",
           current_gain: current_gain,
           collector_current: collector_current,

--- a/lib/db/derivedtables/bjt_transistor.ts
+++ b/lib/db/derivedtables/bjt_transistor.ts
@@ -26,6 +26,7 @@ export const bjtTransistorTableSpec: DerivedTableSpec<BJTTransistor> = {
     { name: "temperature_range", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -74,6 +75,7 @@ export const bjtTransistorTableSpec: DerivedTableSpec<BJTTransistor> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: c.package || "",
           current_gain: current_gain,
           collector_current: collector_current,

--- a/lib/db/derivedtables/ble-chip.ts
+++ b/lib/db/derivedtables/ble-chip.ts
@@ -59,6 +59,7 @@ export const bleChipTableSpec: DerivedTableSpec<BleChip> = {
     { name: "has_usb", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db

--- a/lib/db/derivedtables/ble-module.ts
+++ b/lib/db/derivedtables/ble-module.ts
@@ -28,6 +28,7 @@ export const bleModuleTableSpec: DerivedTableSpec<BleModule> = {
     { name: "has_usb", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db

--- a/lib/db/derivedtables/ble-utils.ts
+++ b/lib/db/derivedtables/ble-utils.ts
@@ -181,6 +181,7 @@ export const mapBleFields = (
     in_stock: component.stock > 0,
     is_basic: Boolean(component.basic),
     is_preferred: Boolean(component.preferred),
+    is_extended_promotional: Boolean(component.is_extended_promotional),
     package: component.package || "",
     core_processor: getFirstAttribute(attributes, [
       "Core Processor",

--- a/lib/db/derivedtables/ble-utils.ts
+++ b/lib/db/derivedtables/ble-utils.ts
@@ -181,7 +181,7 @@ export const mapBleFields = (
     in_stock: component.stock > 0,
     is_basic: Boolean(component.basic),
     is_preferred: Boolean(component.preferred),
-    is_extended_promotional: Boolean(component.is_extended_promotional),
+    is_extended_promotional: Boolean(component.preferred && !component.basic),
     package: component.package || "",
     core_processor: getFirstAttribute(attributes, [
       "Core Processor",

--- a/lib/db/derivedtables/boost_converter.ts
+++ b/lib/db/derivedtables/boost_converter.ts
@@ -118,7 +118,7 @@ export const boostConverterTableSpec: DerivedTableSpec<BoostConverter> = {
           in_stock: c.stock > 0,
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
-          is_extended_promotional: Boolean(c.is_extended_promotional),
+          is_extended_promotional: Boolean(c.preferred && !c.basic),
           package: c.package || "",
           input_voltage_min: inputMin,
           input_voltage_max: inputMax,

--- a/lib/db/derivedtables/boost_converter.ts
+++ b/lib/db/derivedtables/boost_converter.ts
@@ -31,6 +31,7 @@ export const boostConverterTableSpec: DerivedTableSpec<BoostConverter> = {
     { name: "number_of_outputs", type: "integer" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -117,6 +118,7 @@ export const boostConverterTableSpec: DerivedTableSpec<BoostConverter> = {
           in_stock: c.stock > 0,
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: c.package || "",
           input_voltage_min: inputMin,
           input_voltage_max: inputMax,

--- a/lib/db/derivedtables/buck_boost_converter.ts
+++ b/lib/db/derivedtables/buck_boost_converter.ts
@@ -32,7 +32,7 @@ export const buckBoostConverterTableSpec: DerivedTableSpec<BuckBoostConverter> =
       { name: "number_of_outputs", type: "integer" },
       { name: "is_basic", type: "boolean" },
       { name: "is_preferred", type: "boolean" },
-    { name: "is_extended_promotional", type: "boolean" },
+      { name: "is_extended_promotional", type: "boolean" },
     ],
     listCandidateComponents: (db) =>
       db

--- a/lib/db/derivedtables/buck_boost_converter.ts
+++ b/lib/db/derivedtables/buck_boost_converter.ts
@@ -122,7 +122,7 @@ export const buckBoostConverterTableSpec: DerivedTableSpec<BuckBoostConverter> =
             in_stock: c.stock > 0,
             is_basic: Boolean(c.basic),
             is_preferred: Boolean(c.preferred),
-            is_extended_promotional: Boolean(c.is_extended_promotional),
+            is_extended_promotional: Boolean(c.preferred && !c.basic),
             package: c.package || "",
             input_voltage_min: inputMin,
             input_voltage_max: inputMax,

--- a/lib/db/derivedtables/buck_boost_converter.ts
+++ b/lib/db/derivedtables/buck_boost_converter.ts
@@ -32,6 +32,7 @@ export const buckBoostConverterTableSpec: DerivedTableSpec<BuckBoostConverter> =
       { name: "number_of_outputs", type: "integer" },
       { name: "is_basic", type: "boolean" },
       { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
     ],
     listCandidateComponents: (db) =>
       db
@@ -121,6 +122,7 @@ export const buckBoostConverterTableSpec: DerivedTableSpec<BuckBoostConverter> =
             in_stock: c.stock > 0,
             is_basic: Boolean(c.basic),
             is_preferred: Boolean(c.preferred),
+            is_extended_promotional: Boolean(c.is_extended_promotional),
             package: c.package || "",
             input_voltage_min: inputMin,
             input_voltage_max: inputMax,

--- a/lib/db/derivedtables/capacitor.ts
+++ b/lib/db/derivedtables/capacitor.ts
@@ -116,7 +116,7 @@ export const capacitorTableSpec: DerivedTableSpec<Capacitor> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
-        is_extended_promotional: Boolean(c.is_extended_promotional),
+        is_extended_promotional: Boolean(c.preferred && !c.basic),
         capacitance_farads: capacitance,
         tolerance_fraction: tolerance,
         voltage_rating: voltage,

--- a/lib/db/derivedtables/capacitor.ts
+++ b/lib/db/derivedtables/capacitor.ts
@@ -34,6 +34,7 @@ export const capacitorTableSpec: DerivedTableSpec<Capacitor> = {
     { name: "capacitor_type", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -115,6 +116,7 @@ export const capacitorTableSpec: DerivedTableSpec<Capacitor> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         capacitance_farads: capacitance,
         tolerance_fraction: tolerance,
         voltage_rating: voltage,

--- a/lib/db/derivedtables/component-base.ts
+++ b/lib/db/derivedtables/component-base.ts
@@ -7,5 +7,6 @@ export interface BaseComponent {
   in_stock: boolean
   is_basic: boolean
   is_preferred: boolean
+  is_extended_promotional: boolean
   attributes: Record<string, string>
 }

--- a/lib/db/derivedtables/dac.ts
+++ b/lib/db/derivedtables/dac.ts
@@ -38,6 +38,7 @@ export const dacTableSpec: DerivedTableSpec<Dac> = {
     { name: "nonlinearity_lsb", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -129,6 +130,7 @@ export const dacTableSpec: DerivedTableSpec<Dac> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         resolution_bits: resolution,
         num_channels: numChannels,

--- a/lib/db/derivedtables/dac.ts
+++ b/lib/db/derivedtables/dac.ts
@@ -130,7 +130,7 @@ export const dacTableSpec: DerivedTableSpec<Dac> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
-        is_extended_promotional: Boolean(c.is_extended_promotional),
+        is_extended_promotional: Boolean(c.preferred && !c.basic),
         package: c.package || "",
         resolution_bits: resolution,
         num_channels: numChannels,

--- a/lib/db/derivedtables/diode.ts
+++ b/lib/db/derivedtables/diode.ts
@@ -40,6 +40,7 @@ export const diodeTableSpec: DerivedTableSpec<Diode> = {
     { name: "configuration", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -159,6 +160,7 @@ export const diodeTableSpec: DerivedTableSpec<Diode> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         forward_voltage: forwardVoltage,
         reverse_voltage: reverseVoltage,

--- a/lib/db/derivedtables/diode.ts
+++ b/lib/db/derivedtables/diode.ts
@@ -160,7 +160,7 @@ export const diodeTableSpec: DerivedTableSpec<Diode> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
-        is_extended_promotional: Boolean(c.is_extended_promotional),
+        is_extended_promotional: Boolean(c.preferred && !c.basic),
         package: c.package || "",
         forward_voltage: forwardVoltage,
         reverse_voltage: reverseVoltage,

--- a/lib/db/derivedtables/dram.ts
+++ b/lib/db/derivedtables/dram.ts
@@ -72,6 +72,7 @@ export const dramTableSpec: DerivedTableSpec<Dram> = {
     { name: "operating_temp_max", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   indexes: [
     { name: "idx_dram_stock", columns: ["stock"] },
@@ -149,6 +150,9 @@ export const dramTableSpec: DerivedTableSpec<Dram> = {
           in_stock: Number(component.stock ?? 0) > 0,
           is_basic: Boolean(component.basic),
           is_preferred: Boolean(component.preferred),
+          is_extended_promotional: Boolean(
+            Number(component.preferred) === 1 && Number(component.basic) === 0,
+          ),
           package: String(extra?.package ?? component.package ?? ""),
           memory_type: inferMemoryType(searchableText, subcategory),
           memory_size_mbit: parseMemorySizeMbit(sizeSource),

--- a/lib/db/derivedtables/fpc_connector.ts
+++ b/lib/db/derivedtables/fpc_connector.ts
@@ -56,7 +56,7 @@ export const fpcConnectorTableSpec: DerivedTableSpec<FpcConnector> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
-          is_extended_promotional: Boolean(c.is_extended_promotional),
+          is_extended_promotional: Boolean(c.preferred && !c.basic),
           pitch_mm: parseNum(attrs["Pitch"]),
           number_of_contacts: isNaN(contacts) ? null : contacts,
           contact_type: attrs["Contact Type"] || null,

--- a/lib/db/derivedtables/fpc_connector.ts
+++ b/lib/db/derivedtables/fpc_connector.ts
@@ -20,6 +20,7 @@ export const fpcConnectorTableSpec: DerivedTableSpec<FpcConnector> = {
     { name: "locking_feature", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -55,6 +56,7 @@ export const fpcConnectorTableSpec: DerivedTableSpec<FpcConnector> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           pitch_mm: parseNum(attrs["Pitch"]),
           number_of_contacts: isNaN(contacts) ? null : contacts,
           contact_type: attrs["Contact Type"] || null,

--- a/lib/db/derivedtables/fpga.ts
+++ b/lib/db/derivedtables/fpga.ts
@@ -68,6 +68,7 @@ export const fpgaTableSpec: DerivedTableSpec<FPGA> = {
     { name: "logic_gates", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -99,6 +100,7 @@ export const fpgaTableSpec: DerivedTableSpec<FPGA> = {
           in_stock: Boolean((c.stock ?? 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: extra?.package ?? c.package ?? "",
           type: attrs["Type"] ?? null,
           logic_array_blocks: parseNumericValue(attrs["Logic Array Blocks"]),

--- a/lib/db/derivedtables/fpga.ts
+++ b/lib/db/derivedtables/fpga.ts
@@ -100,7 +100,7 @@ export const fpgaTableSpec: DerivedTableSpec<FPGA> = {
           in_stock: Boolean((c.stock ?? 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
-          is_extended_promotional: Boolean(c.is_extended_promotional),
+          is_extended_promotional: Boolean(c.preferred && !c.basic),
           package: extra?.package ?? c.package ?? "",
           type: attrs["Type"] ?? null,
           logic_array_blocks: parseNumericValue(attrs["Logic Array Blocks"]),

--- a/lib/db/derivedtables/fuse.ts
+++ b/lib/db/derivedtables/fuse.ts
@@ -130,7 +130,7 @@ export const fuseTableSpec: DerivedTableSpec<Fuse> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
-          is_extended_promotional: Boolean(c.is_extended_promotional),
+          is_extended_promotional: Boolean(c.preferred && !c.basic),
           current_rating: current_rating as number,
           voltage_rating: voltage_rating as number,
           response_time,

--- a/lib/db/derivedtables/fuse.ts
+++ b/lib/db/derivedtables/fuse.ts
@@ -37,6 +37,7 @@ export const fuseTableSpec: DerivedTableSpec<Fuse> = {
     { name: "is_resettable", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -129,6 +130,7 @@ export const fuseTableSpec: DerivedTableSpec<Fuse> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           current_rating: current_rating as number,
           voltage_rating: voltage_rating as number,
           response_time,

--- a/lib/db/derivedtables/gas_sensor.ts
+++ b/lib/db/derivedtables/gas_sensor.ts
@@ -36,6 +36,7 @@ export const gasSensorTableSpec: DerivedTableSpec<GasSensor> = {
     { name: "measures_explosive_gases", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db) {
     return db
@@ -82,6 +83,7 @@ export const gasSensorTableSpec: DerivedTableSpec<GasSensor> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         sensor_type: sensorType,
         measures_air_quality: measuresAirQuality,

--- a/lib/db/derivedtables/gas_sensor.ts
+++ b/lib/db/derivedtables/gas_sensor.ts
@@ -83,7 +83,7 @@ export const gasSensorTableSpec: DerivedTableSpec<GasSensor> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
-        is_extended_promotional: Boolean(c.is_extended_promotional),
+        is_extended_promotional: Boolean(c.preferred && !c.basic),
         package: c.package || "",
         sensor_type: sensorType,
         measures_air_quality: measuresAirQuality,

--- a/lib/db/derivedtables/gyroscope.ts
+++ b/lib/db/derivedtables/gyroscope.ts
@@ -28,6 +28,7 @@ export const gyroscopeTableSpec: DerivedTableSpec<Gyroscope> = {
     { name: "has_uart", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -106,6 +107,7 @@ export const gyroscopeTableSpec: DerivedTableSpec<Gyroscope> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         supply_voltage_min: voltageMin,
         supply_voltage_max: voltageMax,

--- a/lib/db/derivedtables/gyroscope.ts
+++ b/lib/db/derivedtables/gyroscope.ts
@@ -107,7 +107,7 @@ export const gyroscopeTableSpec: DerivedTableSpec<Gyroscope> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
-        is_extended_promotional: Boolean(c.is_extended_promotional),
+        is_extended_promotional: Boolean(c.preferred && !c.basic),
         package: c.package || "",
         supply_voltage_min: voltageMin,
         supply_voltage_max: voltageMax,

--- a/lib/db/derivedtables/hdmi-port.ts
+++ b/lib/db/derivedtables/hdmi-port.ts
@@ -93,6 +93,7 @@ export const hdmiPortTableSpec: DerivedTableSpec<HdmiPort> = {
     { name: "operating_temp_max", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   indexes: [
     { name: "idx_hdmi_port_stock", columns: ["stock"] },
@@ -169,6 +170,7 @@ export const hdmiPortTableSpec: DerivedTableSpec<HdmiPort> = {
           in_stock: Boolean((component.stock || 0) > 0),
           is_basic: Boolean(component.basic),
           is_preferred: Boolean(component.preferred),
+          is_extended_promotional: Boolean(component.is_extended_promotional),
           package: packageName,
           mounting_style: inferMountingStyle(attrs, packageName, description),
           orientation: inferOrientation(description),

--- a/lib/db/derivedtables/hdmi-port.ts
+++ b/lib/db/derivedtables/hdmi-port.ts
@@ -170,7 +170,9 @@ export const hdmiPortTableSpec: DerivedTableSpec<HdmiPort> = {
           in_stock: Boolean((component.stock || 0) > 0),
           is_basic: Boolean(component.basic),
           is_preferred: Boolean(component.preferred),
-          is_extended_promotional: Boolean(component.is_extended_promotional),
+          is_extended_promotional: Boolean(
+            Number(component.preferred) === 1 && Number(component.basic) === 0,
+          ),
           package: packageName,
           mounting_style: inferMountingStyle(attrs, packageName, description),
           orientation: inferOrientation(description),

--- a/lib/db/derivedtables/header.ts
+++ b/lib/db/derivedtables/header.ts
@@ -48,6 +48,7 @@ export const headerTableSpec: DerivedTableSpec<Header> = {
     { name: "is_right_angle", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -227,6 +228,7 @@ export const headerTableSpec: DerivedTableSpec<Header> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         price1: extractMinQPrice(c.price)!,
         package: c.package || "",
         pitch_mm: pitch,

--- a/lib/db/derivedtables/header.ts
+++ b/lib/db/derivedtables/header.ts
@@ -228,7 +228,7 @@ export const headerTableSpec: DerivedTableSpec<Header> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
-        is_extended_promotional: Boolean(c.is_extended_promotional),
+        is_extended_promotional: Boolean(c.preferred && !c.basic),
         price1: extractMinQPrice(c.price)!,
         package: c.package || "",
         pitch_mm: pitch,

--- a/lib/db/derivedtables/io_expander.ts
+++ b/lib/db/derivedtables/io_expander.ts
@@ -40,6 +40,7 @@ export const ioExpanderTableSpec: DerivedTableSpec<IoExpander> = {
     { name: "source_current_ma", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -139,6 +140,7 @@ export const ioExpanderTableSpec: DerivedTableSpec<IoExpander> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         num_gpios: numGpios,
         supply_voltage_min: voltageMin,

--- a/lib/db/derivedtables/io_expander.ts
+++ b/lib/db/derivedtables/io_expander.ts
@@ -140,7 +140,7 @@ export const ioExpanderTableSpec: DerivedTableSpec<IoExpander> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
-        is_extended_promotional: Boolean(c.is_extended_promotional),
+        is_extended_promotional: Boolean(c.preferred && !c.basic),
         package: c.package || "",
         num_gpios: numGpios,
         supply_voltage_min: voltageMin,

--- a/lib/db/derivedtables/jst_connector.ts
+++ b/lib/db/derivedtables/jst_connector.ts
@@ -22,6 +22,7 @@ export const jstConnectorTableSpec: DerivedTableSpec<JstConnector> = {
     { name: "reference_series", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -69,6 +70,7 @@ export const jstConnectorTableSpec: DerivedTableSpec<JstConnector> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: String(c.package || ""),
           pitch_mm: parseNum(attrs["Pitch"]),
           num_rows: isNaN(numRows) ? null : numRows,

--- a/lib/db/derivedtables/jst_connector.ts
+++ b/lib/db/derivedtables/jst_connector.ts
@@ -70,7 +70,7 @@ export const jstConnectorTableSpec: DerivedTableSpec<JstConnector> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
-          is_extended_promotional: Boolean(c.is_extended_promotional),
+          is_extended_promotional: Boolean(c.preferred && !c.basic),
           package: String(c.package || ""),
           pitch_mm: parseNum(attrs["Pitch"]),
           num_rows: isNaN(numRows) ? null : numRows,

--- a/lib/db/derivedtables/lcd_display.ts
+++ b/lib/db/derivedtables/lcd_display.ts
@@ -25,6 +25,7 @@ export const lcdDisplayTableSpec: DerivedTableSpec<LCDDisplay> = {
     { name: "display_type", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -70,6 +71,7 @@ export const lcdDisplayTableSpec: DerivedTableSpec<LCDDisplay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: String(c.package || ""),
           display_size,
           resolution,

--- a/lib/db/derivedtables/lcd_display.ts
+++ b/lib/db/derivedtables/lcd_display.ts
@@ -71,7 +71,7 @@ export const lcdDisplayTableSpec: DerivedTableSpec<LCDDisplay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
-          is_extended_promotional: Boolean(c.is_extended_promotional),
+          is_extended_promotional: Boolean(c.preferred && !c.basic),
           package: String(c.package || ""),
           display_size,
           resolution,

--- a/lib/db/derivedtables/led.ts
+++ b/lib/db/derivedtables/led.ts
@@ -166,7 +166,7 @@ export const ledTableSpec: DerivedTableSpec<Led> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
-        is_extended_promotional: Boolean(c.is_extended_promotional),
+        is_extended_promotional: Boolean(c.preferred && !c.basic),
         package: c.package || "",
         forward_voltage: forwardVoltage,
         forward_current: forwardCurrent,

--- a/lib/db/derivedtables/led.ts
+++ b/lib/db/derivedtables/led.ts
@@ -37,6 +37,7 @@ export const ledTableSpec: DerivedTableSpec<Led> = {
     { name: "is_rgb", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -165,6 +166,7 @@ export const ledTableSpec: DerivedTableSpec<Led> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         forward_voltage: forwardVoltage,
         forward_current: forwardCurrent,

--- a/lib/db/derivedtables/led_dot_matrix_display.ts
+++ b/lib/db/derivedtables/led_dot_matrix_display.ts
@@ -18,7 +18,7 @@ export const ledDotMatrixDisplayTableSpec: DerivedTableSpec<LEDDotMatrixDisplay>
       { name: "color", type: "text" },
       { name: "is_basic", type: "boolean" },
       { name: "is_preferred", type: "boolean" },
-    { name: "is_extended_promotional", type: "boolean" },
+      { name: "is_extended_promotional", type: "boolean" },
     ],
     listCandidateComponents(db: KyselyDatabaseInstance) {
       return db

--- a/lib/db/derivedtables/led_dot_matrix_display.ts
+++ b/lib/db/derivedtables/led_dot_matrix_display.ts
@@ -58,7 +58,7 @@ export const ledDotMatrixDisplayTableSpec: DerivedTableSpec<LEDDotMatrixDisplay>
             in_stock: Boolean((c.stock || 0) > 0),
             is_basic: Boolean(c.basic),
             is_preferred: Boolean(c.preferred),
-            is_extended_promotional: Boolean(c.is_extended_promotional),
+            is_extended_promotional: Boolean(c.preferred && !c.basic),
             package: String(c.package || ""),
             matrix_size,
             color,

--- a/lib/db/derivedtables/led_dot_matrix_display.ts
+++ b/lib/db/derivedtables/led_dot_matrix_display.ts
@@ -18,6 +18,7 @@ export const ledDotMatrixDisplayTableSpec: DerivedTableSpec<LEDDotMatrixDisplay>
       { name: "color", type: "text" },
       { name: "is_basic", type: "boolean" },
       { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
     ],
     listCandidateComponents(db: KyselyDatabaseInstance) {
       return db
@@ -57,6 +58,7 @@ export const ledDotMatrixDisplayTableSpec: DerivedTableSpec<LEDDotMatrixDisplay>
             in_stock: Boolean((c.stock || 0) > 0),
             is_basic: Boolean(c.basic),
             is_preferred: Boolean(c.preferred),
+            is_extended_promotional: Boolean(c.is_extended_promotional),
             package: String(c.package || ""),
             matrix_size,
             color,

--- a/lib/db/derivedtables/led_driver.ts
+++ b/lib/db/derivedtables/led_driver.ts
@@ -42,6 +42,7 @@ export const ledDriverTableSpec: DerivedTableSpec<LedDriver> = {
     { name: "mounting_style", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -77,6 +78,7 @@ export const ledDriverTableSpec: DerivedTableSpec<LedDriver> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: String(c.package || ""),
           supply_voltage_min: parseValue(attrs["Input Voltage"]?.split("~")[0]),
           supply_voltage_max: parseValue(attrs["Input Voltage"]?.split("~")[1]),

--- a/lib/db/derivedtables/led_driver.ts
+++ b/lib/db/derivedtables/led_driver.ts
@@ -78,7 +78,7 @@ export const ledDriverTableSpec: DerivedTableSpec<LedDriver> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
-          is_extended_promotional: Boolean(c.is_extended_promotional),
+          is_extended_promotional: Boolean(c.preferred && !c.basic),
           package: String(c.package || ""),
           supply_voltage_min: parseValue(attrs["Input Voltage"]?.split("~")[0]),
           supply_voltage_max: parseValue(attrs["Input Voltage"]?.split("~")[1]),

--- a/lib/db/derivedtables/led_segment_display.ts
+++ b/lib/db/derivedtables/led_segment_display.ts
@@ -92,7 +92,7 @@ export const ledSegmentDisplayTableSpec: DerivedTableSpec<LEDSegmentDisplay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
-          is_extended_promotional: Boolean(c.is_extended_promotional),
+          is_extended_promotional: Boolean(c.preferred && !c.basic),
           package: String(c.package || ""),
           positions,
           type,

--- a/lib/db/derivedtables/led_segment_display.ts
+++ b/lib/db/derivedtables/led_segment_display.ts
@@ -26,6 +26,7 @@ export const ledSegmentDisplayTableSpec: DerivedTableSpec<LEDSegmentDisplay> = {
     { name: "color", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
 
   listCandidateComponents(db: KyselyDatabaseInstance) {
@@ -91,6 +92,7 @@ export const ledSegmentDisplayTableSpec: DerivedTableSpec<LEDSegmentDisplay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: String(c.package || ""),
           positions,
           type,

--- a/lib/db/derivedtables/led_with_ic.ts
+++ b/lib/db/derivedtables/led_with_ic.ts
@@ -100,7 +100,7 @@ export const ledWithICTableSpec: DerivedTableSpec<LEDWithIC> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
-          is_extended_promotional: Boolean(c.is_extended_promotional),
+          is_extended_promotional: Boolean(c.preferred && !c.basic),
           package: String(c.package || ""),
           forward_voltage: forwardVoltage,
           forward_current: forwardCurrent,

--- a/lib/db/derivedtables/led_with_ic.ts
+++ b/lib/db/derivedtables/led_with_ic.ts
@@ -27,6 +27,7 @@ export const ledWithICTableSpec: DerivedTableSpec<LEDWithIC> = {
     { name: "protocol", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -99,6 +100,7 @@ export const ledWithICTableSpec: DerivedTableSpec<LEDWithIC> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: String(c.package || ""),
           forward_voltage: forwardVoltage,
           forward_current: forwardCurrent,

--- a/lib/db/derivedtables/memory-connector.ts
+++ b/lib/db/derivedtables/memory-connector.ts
@@ -245,7 +245,9 @@ const createMemoryConnectorTableSpec = (
         in_stock: Number(component.stock || 0) > 0,
         is_basic: Boolean(component.basic),
         is_preferred: Boolean(component.preferred),
-        is_extended_promotional: Boolean(component.is_extended_promotional),
+        is_extended_promotional: Boolean(
+          Number(component.preferred) === 1 && Number(component.basic) === 0,
+        ),
         package: packageName,
         ddr_standard: ddrStandard,
         num_pins: numPins,

--- a/lib/db/derivedtables/memory-connector.ts
+++ b/lib/db/derivedtables/memory-connector.ts
@@ -156,6 +156,7 @@ const createMemoryConnectorTableSpec = (
     { name: "is_right_angle", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   indexes: [
     { name: `idx_${tableName}_stock`, columns: ["stock"] },
@@ -244,6 +245,7 @@ const createMemoryConnectorTableSpec = (
         in_stock: Number(component.stock || 0) > 0,
         is_basic: Boolean(component.basic),
         is_preferred: Boolean(component.preferred),
+        is_extended_promotional: Boolean(component.is_extended_promotional),
         package: packageName,
         ddr_standard: ddrStandard,
         num_pins: numPins,

--- a/lib/db/derivedtables/micro-usb-connector.ts
+++ b/lib/db/derivedtables/micro-usb-connector.ts
@@ -184,7 +184,9 @@ export const microUsbConnectorTableSpec: DerivedTableSpec<MicroUsbConnector> = {
         in_stock: Number(component.stock || 0) > 0,
         is_basic: Boolean(component.basic),
         is_preferred: Boolean(component.preferred),
-        is_extended_promotional: Boolean(component.is_extended_promotional),
+        is_extended_promotional: Boolean(
+          Number(component.preferred) === 1 && Number(component.basic) === 0,
+        ),
         connector_type: connectorType || "Micro USB",
         usb_standard: firstAttribute(attributes, [
           "USB Standard",

--- a/lib/db/derivedtables/micro-usb-connector.ts
+++ b/lib/db/derivedtables/micro-usb-connector.ts
@@ -114,6 +114,7 @@ export const microUsbConnectorTableSpec: DerivedTableSpec<MicroUsbConnector> = {
     { name: "operating_temp_max", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   indexes: [
     { name: "idx_micro_usb_connector_stock", columns: ["stock"] },
@@ -183,6 +184,7 @@ export const microUsbConnectorTableSpec: DerivedTableSpec<MicroUsbConnector> = {
         in_stock: Number(component.stock || 0) > 0,
         is_basic: Boolean(component.basic),
         is_preferred: Boolean(component.preferred),
+        is_extended_promotional: Boolean(component.is_extended_promotional),
         connector_type: connectorType || "Micro USB",
         usb_standard: firstAttribute(attributes, [
           "USB Standard",

--- a/lib/db/derivedtables/microcontroller.ts
+++ b/lib/db/derivedtables/microcontroller.ts
@@ -62,6 +62,7 @@ export const microcontrollerTableSpec: DerivedTableSpec<Microcontroller> = {
     { name: "dac_resolution_bits", type: "integer" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -228,6 +229,7 @@ export const microcontrollerTableSpec: DerivedTableSpec<Microcontroller> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         cpu_core: cpuCore,
         cpu_speed_hz: cpuSpeed,

--- a/lib/db/derivedtables/microcontroller.ts
+++ b/lib/db/derivedtables/microcontroller.ts
@@ -229,7 +229,7 @@ export const microcontrollerTableSpec: DerivedTableSpec<Microcontroller> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
-        is_extended_promotional: Boolean(c.is_extended_promotional),
+        is_extended_promotional: Boolean(c.preferred && !c.basic),
         package: c.package || "",
         cpu_core: cpuCore,
         cpu_speed_hz: cpuSpeed,

--- a/lib/db/derivedtables/mosfet.ts
+++ b/lib/db/derivedtables/mosfet.ts
@@ -35,6 +35,7 @@ export const mosfetTableSpec: DerivedTableSpec<Mosfet> = {
     { name: "mounting_style", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -68,6 +69,7 @@ export const mosfetTableSpec: DerivedTableSpec<Mosfet> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: String(c.package || ""),
           drain_source_voltage: parseValue(
             attrs["Drain Source Voltage (Vdss)"],

--- a/lib/db/derivedtables/mosfet.ts
+++ b/lib/db/derivedtables/mosfet.ts
@@ -69,7 +69,7 @@ export const mosfetTableSpec: DerivedTableSpec<Mosfet> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
-          is_extended_promotional: Boolean(c.is_extended_promotional),
+          is_extended_promotional: Boolean(c.preferred && !c.basic),
           package: String(c.package || ""),
           drain_source_voltage: parseValue(
             attrs["Drain Source Voltage (Vdss)"],

--- a/lib/db/derivedtables/oled_display.ts
+++ b/lib/db/derivedtables/oled_display.ts
@@ -66,7 +66,7 @@ export const oledDisplayTableSpec: DerivedTableSpec<OLEDDisplay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
-          is_extended_promotional: Boolean(c.is_extended_promotional),
+          is_extended_promotional: Boolean(c.preferred && !c.basic),
           package: String(c.package || ""),
           protocol: protocol || undefined,
           display_width,

--- a/lib/db/derivedtables/oled_display.ts
+++ b/lib/db/derivedtables/oled_display.ts
@@ -19,6 +19,7 @@ export const oledDisplayTableSpec: DerivedTableSpec<OLEDDisplay> = {
     { name: "pixel_resolution", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
 
   listCandidateComponents(db: KyselyDatabaseInstance) {
@@ -65,6 +66,7 @@ export const oledDisplayTableSpec: DerivedTableSpec<OLEDDisplay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: String(c.package || ""),
           protocol: protocol || undefined,
           display_width,

--- a/lib/db/derivedtables/pcie_m2_connector.ts
+++ b/lib/db/derivedtables/pcie_m2_connector.ts
@@ -50,7 +50,7 @@ export const pcieM2ConnectorTableSpec: DerivedTableSpec<PcieM2Connector> = {
         in_stock: Boolean((c.stock || 0) > 0),
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
-        is_extended_promotional: Boolean(c.is_extended_promotional),
+        is_extended_promotional: Boolean(c.preferred && !c.basic),
         key,
         is_right_angle: isRightAngle,
         attributes: attrs,

--- a/lib/db/derivedtables/pcie_m2_connector.ts
+++ b/lib/db/derivedtables/pcie_m2_connector.ts
@@ -14,6 +14,7 @@ export const pcieM2ConnectorTableSpec: DerivedTableSpec<PcieM2Connector> = {
     { name: "is_right_angle", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -49,6 +50,7 @@ export const pcieM2ConnectorTableSpec: DerivedTableSpec<PcieM2Connector> = {
         in_stock: Boolean((c.stock || 0) > 0),
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         key,
         is_right_angle: isRightAngle,
         attributes: attrs,

--- a/lib/db/derivedtables/photo-diode.ts
+++ b/lib/db/derivedtables/photo-diode.ts
@@ -100,6 +100,7 @@ export const photoDiodeTableSpec: DerivedTableSpec<PhotoDiode> = {
     { name: "operating_temp_max", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   indexes: [
     { name: "idx_photo_diode_stock", columns: ["stock"] },
@@ -168,6 +169,7 @@ export const photoDiodeTableSpec: DerivedTableSpec<PhotoDiode> = {
           in_stock: Boolean((component.stock || 0) > 0),
           is_basic: Boolean(component.basic),
           is_preferred: Boolean(component.preferred),
+          is_extended_promotional: Boolean(component.is_extended_promotional),
           package: String(component.package || ""),
           peak_wavelength_nm: parseWavelength(peakWavelengthSource),
           spectral_range_min_nm: spectralRangeMin,

--- a/lib/db/derivedtables/photo-diode.ts
+++ b/lib/db/derivedtables/photo-diode.ts
@@ -169,7 +169,9 @@ export const photoDiodeTableSpec: DerivedTableSpec<PhotoDiode> = {
           in_stock: Boolean((component.stock || 0) > 0),
           is_basic: Boolean(component.basic),
           is_preferred: Boolean(component.preferred),
-          is_extended_promotional: Boolean(component.is_extended_promotional),
+          is_extended_promotional: Boolean(
+            Number(component.preferred) === 1 && Number(component.basic) === 0,
+          ),
           package: String(component.package || ""),
           peak_wavelength_nm: parseWavelength(peakWavelengthSource),
           spectral_range_min_nm: spectralRangeMin,

--- a/lib/db/derivedtables/potentiometer.ts
+++ b/lib/db/derivedtables/potentiometer.ts
@@ -19,6 +19,7 @@ export const potentiometerTableSpec: DerivedTableSpec<Potentiometer> = {
     { name: "is_surface_mount", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -67,6 +68,7 @@ export const potentiometerTableSpec: DerivedTableSpec<Potentiometer> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         max_resistance: maxResistance,
         pin_variant: pinVariant,
         package: c.package || "",

--- a/lib/db/derivedtables/potentiometer.ts
+++ b/lib/db/derivedtables/potentiometer.ts
@@ -68,7 +68,7 @@ export const potentiometerTableSpec: DerivedTableSpec<Potentiometer> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
-        is_extended_promotional: Boolean(c.is_extended_promotional),
+        is_extended_promotional: Boolean(c.preferred && !c.basic),
         max_resistance: maxResistance,
         pin_variant: pinVariant,
         package: c.package || "",

--- a/lib/db/derivedtables/relay.ts
+++ b/lib/db/derivedtables/relay.ts
@@ -63,7 +63,7 @@ export const relayTableSpec: DerivedTableSpec<Relay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
-          is_extended_promotional: Boolean(c.is_extended_promotional),
+          is_extended_promotional: Boolean(c.preferred && !c.basic),
           package: String(c.package || ""),
           relay_type: (c as any).subcategory || "",
           contact_form: attrs["Contact Form"] || null,

--- a/lib/db/derivedtables/relay.ts
+++ b/lib/db/derivedtables/relay.ts
@@ -29,6 +29,7 @@ export const relayTableSpec: DerivedTableSpec<Relay> = {
     { name: "pin_number", type: "integer" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -62,6 +63,7 @@ export const relayTableSpec: DerivedTableSpec<Relay> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: String(c.package || ""),
           relay_type: (c as any).subcategory || "",
           contact_form: attrs["Contact Form"] || null,

--- a/lib/db/derivedtables/resistor.ts
+++ b/lib/db/derivedtables/resistor.ts
@@ -31,6 +31,7 @@ export const resistorTableSpec: DerivedTableSpec<Resistor> = {
     { name: "is_multi_resistor_chip", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -82,6 +83,7 @@ export const resistorTableSpec: DerivedTableSpec<Resistor> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         resistance: resistance,
         tolerance_fraction: tolerance,
         power_watts,

--- a/lib/db/derivedtables/resistor.ts
+++ b/lib/db/derivedtables/resistor.ts
@@ -83,7 +83,7 @@ export const resistorTableSpec: DerivedTableSpec<Resistor> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
-        is_extended_promotional: Boolean(c.is_extended_promotional),
+        is_extended_promotional: Boolean(c.preferred && !c.basic),
         resistance: resistance,
         tolerance_fraction: tolerance,
         power_watts,

--- a/lib/db/derivedtables/resistor_array.ts
+++ b/lib/db/derivedtables/resistor_array.ts
@@ -125,7 +125,9 @@ export const resistorArrayTableSpec: DerivedTableSpec<ResistorArray> = {
         in_stock: component.stock > 0,
         is_basic: Boolean(component.basic),
         is_preferred: Boolean(component.preferred),
-        is_extended_promotional: Boolean(component.is_extended_promotional),
+        is_extended_promotional: Boolean(
+          Number(component.preferred) === 1 && Number(component.basic) === 0,
+        ),
         package: component.package ?? "",
         resistance,
         tolerance_fraction: tolerance,

--- a/lib/db/derivedtables/resistor_array.ts
+++ b/lib/db/derivedtables/resistor_array.ts
@@ -69,6 +69,7 @@ export const resistorArrayTableSpec: DerivedTableSpec<ResistorArray> = {
     { name: "is_surface_mount", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -124,6 +125,7 @@ export const resistorArrayTableSpec: DerivedTableSpec<ResistorArray> = {
         in_stock: component.stock > 0,
         is_basic: Boolean(component.basic),
         is_preferred: Boolean(component.preferred),
+        is_extended_promotional: Boolean(component.is_extended_promotional),
         package: component.package ?? "",
         resistance,
         tolerance_fraction: tolerance,

--- a/lib/db/derivedtables/spring-clamp-terminal-block.ts
+++ b/lib/db/derivedtables/spring-clamp-terminal-block.ts
@@ -69,7 +69,7 @@ export const springClampTerminalBlockTableSpec: DerivedTableSpec<SpringClampTerm
             in_stock: Boolean((c.stock || 0) > 0),
             is_basic: Boolean(c.basic),
             is_preferred: Boolean(c.preferred),
-            is_extended_promotional: Boolean(c.is_extended_promotional),
+            is_extended_promotional: Boolean(c.preferred && !c.basic),
             package: String(c.package || ""),
             pitch_mm: parseUnit(attrs["Pitch"]),
             num_pins: parseInteger(attrs["Number of PINs Per Row"]),

--- a/lib/db/derivedtables/spring-clamp-terminal-block.ts
+++ b/lib/db/derivedtables/spring-clamp-terminal-block.ts
@@ -41,7 +41,7 @@ export const springClampTerminalBlockTableSpec: DerivedTableSpec<SpringClampTerm
       { name: "mounting_style", type: "text" },
       { name: "is_basic", type: "boolean" },
       { name: "is_preferred", type: "boolean" },
-    { name: "is_extended_promotional", type: "boolean" },
+      { name: "is_extended_promotional", type: "boolean" },
     ],
     listCandidateComponents(db: KyselyDatabaseInstance) {
       return db

--- a/lib/db/derivedtables/spring-clamp-terminal-block.ts
+++ b/lib/db/derivedtables/spring-clamp-terminal-block.ts
@@ -41,6 +41,7 @@ export const springClampTerminalBlockTableSpec: DerivedTableSpec<SpringClampTerm
       { name: "mounting_style", type: "text" },
       { name: "is_basic", type: "boolean" },
       { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
     ],
     listCandidateComponents(db: KyselyDatabaseInstance) {
       return db
@@ -68,6 +69,7 @@ export const springClampTerminalBlockTableSpec: DerivedTableSpec<SpringClampTerm
             in_stock: Boolean((c.stock || 0) > 0),
             is_basic: Boolean(c.basic),
             is_preferred: Boolean(c.preferred),
+            is_extended_promotional: Boolean(c.is_extended_promotional),
             package: String(c.package || ""),
             pitch_mm: parseUnit(attrs["Pitch"]),
             num_pins: parseInteger(attrs["Number of PINs Per Row"]),

--- a/lib/db/derivedtables/switch.ts
+++ b/lib/db/derivedtables/switch.ts
@@ -92,7 +92,7 @@ export const switchTableSpec: DerivedTableSpec<Switch> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
-        is_extended_promotional: Boolean(c.is_extended_promotional),
+        is_extended_promotional: Boolean(c.preferred && !c.basic),
         package: c.package || "",
         switch_type: (c as any).subcategory || "",
         circuit: attrs["Circuit"] || null,

--- a/lib/db/derivedtables/switch.ts
+++ b/lib/db/derivedtables/switch.ts
@@ -37,6 +37,7 @@ export const switchTableSpec: DerivedTableSpec<Switch> = {
     { name: "switch_height_mm", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db) {
     return db
@@ -91,6 +92,7 @@ export const switchTableSpec: DerivedTableSpec<Switch> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         switch_type: (c as any).subcategory || "",
         circuit: attrs["Circuit"] || null,

--- a/lib/db/derivedtables/usb_c_connector.ts
+++ b/lib/db/derivedtables/usb_c_connector.ts
@@ -70,7 +70,7 @@ export const usbCConnectorTableSpec: DerivedTableSpec<UsbCConnector> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
-          is_extended_promotional: Boolean(c.is_extended_promotional),
+          is_extended_promotional: Boolean(c.preferred && !c.basic),
           package: String(c.package || ""),
           mounting_style: attrs["Mounting Style"] || null,
           current_rating_a: parseNum(attrs["Current Rating - Power (Max)"]),

--- a/lib/db/derivedtables/usb_c_connector.ts
+++ b/lib/db/derivedtables/usb_c_connector.ts
@@ -28,6 +28,7 @@ export const usbCConnectorTableSpec: DerivedTableSpec<UsbCConnector> = {
     { name: "operating_temp_max", type: "real" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents(db: KyselyDatabaseInstance) {
     return db
@@ -69,6 +70,7 @@ export const usbCConnectorTableSpec: DerivedTableSpec<UsbCConnector> = {
           in_stock: Boolean((c.stock || 0) > 0),
           is_basic: Boolean(c.basic),
           is_preferred: Boolean(c.preferred),
+          is_extended_promotional: Boolean(c.is_extended_promotional),
           package: String(c.package || ""),
           mounting_style: attrs["Mounting Style"] || null,
           current_rating_a: parseNum(attrs["Current Rating - Power (Max)"]),

--- a/lib/db/derivedtables/voltage_regulator.ts
+++ b/lib/db/derivedtables/voltage_regulator.ts
@@ -185,7 +185,7 @@ export const voltageRegulatorTableSpec: DerivedTableSpec<VoltageRegulator> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
-        is_extended_promotional: Boolean(c.is_extended_promotional),
+        is_extended_promotional: Boolean(c.preferred && !c.basic),
         package: c.package || "",
         output_type: outputType,
         output_voltage_min: voltageMin,

--- a/lib/db/derivedtables/voltage_regulator.ts
+++ b/lib/db/derivedtables/voltage_regulator.ts
@@ -43,6 +43,7 @@ export const voltageRegulatorTableSpec: DerivedTableSpec<VoltageRegulator> = {
     { name: "topology", type: "text" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -184,6 +185,7 @@ export const voltageRegulatorTableSpec: DerivedTableSpec<VoltageRegulator> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         output_type: outputType,
         output_voltage_min: voltageMin,

--- a/lib/db/derivedtables/wifi_module.ts
+++ b/lib/db/derivedtables/wifi_module.ts
@@ -141,7 +141,7 @@ export const wifiModuleTableSpec: DerivedTableSpec<WifiModule> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
-        is_extended_promotional: Boolean(c.is_extended_promotional),
+        is_extended_promotional: Boolean(c.preferred && !c.basic),
         package: c.package || "",
         core_processor: attrs["Core Processor"] || null,
         antenna_type: attrs["Antenna Type"] || null,

--- a/lib/db/derivedtables/wifi_module.ts
+++ b/lib/db/derivedtables/wifi_module.ts
@@ -45,6 +45,7 @@ export const wifiModuleTableSpec: DerivedTableSpec<WifiModule> = {
     { name: "has_pwm", type: "boolean" },
     { name: "is_basic", type: "boolean" },
     { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
   ],
   listCandidateComponents: (db) =>
     db
@@ -140,6 +141,7 @@ export const wifiModuleTableSpec: DerivedTableSpec<WifiModule> = {
         in_stock: c.stock > 0,
         is_basic: Boolean(c.basic),
         is_preferred: Boolean(c.preferred),
+        is_extended_promotional: Boolean(c.is_extended_promotional),
         package: c.package || "",
         core_processor: attrs["Core Processor"] || null,
         antenna_type: attrs["Antenna Type"] || null,

--- a/lib/db/derivedtables/wire_to_board_connector.ts
+++ b/lib/db/derivedtables/wire_to_board_connector.ts
@@ -61,7 +61,7 @@ export const wireToBoardConnectorTableSpec: DerivedTableSpec<WireToBoardConnecto
       { name: "is_smd", type: "boolean" },
       { name: "is_basic", type: "boolean" },
       { name: "is_preferred", type: "boolean" },
-    { name: "is_extended_promotional", type: "boolean" },
+      { name: "is_extended_promotional", type: "boolean" },
     ],
     listCandidateComponents(db: KyselyDatabaseInstance) {
       return db

--- a/lib/db/derivedtables/wire_to_board_connector.ts
+++ b/lib/db/derivedtables/wire_to_board_connector.ts
@@ -61,6 +61,7 @@ export const wireToBoardConnectorTableSpec: DerivedTableSpec<WireToBoardConnecto
       { name: "is_smd", type: "boolean" },
       { name: "is_basic", type: "boolean" },
       { name: "is_preferred", type: "boolean" },
+    { name: "is_extended_promotional", type: "boolean" },
     ],
     listCandidateComponents(db: KyselyDatabaseInstance) {
       return db
@@ -100,6 +101,7 @@ export const wireToBoardConnectorTableSpec: DerivedTableSpec<WireToBoardConnecto
             in_stock: Boolean((c.stock || 0) > 0),
             is_basic: Boolean(c.basic),
             is_preferred: Boolean(c.preferred),
+            is_extended_promotional: Boolean(c.is_extended_promotional),
             package: String(c.package || ""),
             pitch_mm: pitchMm,
             num_rows: numRows,

--- a/lib/db/derivedtables/wire_to_board_connector.ts
+++ b/lib/db/derivedtables/wire_to_board_connector.ts
@@ -101,7 +101,7 @@ export const wireToBoardConnectorTableSpec: DerivedTableSpec<WireToBoardConnecto
             in_stock: Boolean((c.stock || 0) > 0),
             is_basic: Boolean(c.basic),
             is_preferred: Boolean(c.preferred),
-            is_extended_promotional: Boolean(c.is_extended_promotional),
+            is_extended_promotional: Boolean(c.preferred && !c.basic),
             package: String(c.package || ""),
             pitch_mm: pitchMm,
             num_rows: numRows,

--- a/lib/db/generated/kysely.ts
+++ b/lib/db/generated/kysely.ts
@@ -19,6 +19,7 @@ export interface Accelerometer {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
@@ -87,6 +88,7 @@ export interface BarrelJack {
   inside_diameter_mm: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   mounting_style: string | null;
@@ -109,6 +111,7 @@ export interface BatteryHolder {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
@@ -132,6 +135,7 @@ export interface BleChip {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   operating_voltage_max: number | null;
@@ -156,6 +160,7 @@ export interface BleModule {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   operating_voltage_max: number | null;
@@ -190,6 +195,7 @@ export interface BoostConverter {
   input_voltage_min: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_synchronous: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
@@ -212,6 +218,7 @@ export interface BuckBoostConverter {
   input_voltage_min: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_synchronous: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
@@ -236,6 +243,7 @@ export interface Capacitor {
   is_basic: number | null;
   is_polarized: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_surface_mount: number | null;
   lcsc: Generated<number | null>;
   lifetime_hours: number | null;
@@ -365,6 +373,7 @@ export interface DimmConnector {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_right_angle: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
@@ -385,6 +394,7 @@ export interface FpcConnector {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   locking_feature: string | null;
   mfr: string | null;
@@ -401,6 +411,7 @@ export interface Fpga {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   logic_array_blocks: number | null;
   logic_elements: number | null;
@@ -425,6 +436,7 @@ export interface SodimmConnector {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_right_angle: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
@@ -445,6 +457,7 @@ export interface SpringClampTerminalBlock {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   mounting_style: string | null;
@@ -481,6 +494,7 @@ export interface GasSensor {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   measures_air_quality: number | null;
   measures_carbon_monoxide: number | null;
@@ -510,6 +524,7 @@ export interface Gyroscope {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
@@ -557,6 +572,7 @@ export interface HdmiPort {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   mounting_style: string | null;
@@ -600,6 +616,7 @@ export interface JstConnector {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   num_pins: number | null;
@@ -635,6 +652,7 @@ export interface Ldo {
   is_basic: number | null;
   is_positive: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
@@ -754,6 +772,7 @@ export interface MicroUsbConnector {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   mounting_style: string | null;
@@ -840,6 +859,7 @@ export interface PcieM2Connector {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_right_angle: number | null;
   key: string | null;
   lcsc: Generated<number | null>;
@@ -855,6 +875,7 @@ export interface PhotoDiode {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   operating_temp_max: number | null;
@@ -892,6 +913,7 @@ export interface Relay {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   max_switching_current: number | null;
   max_switching_voltage: number | null;
@@ -911,6 +933,7 @@ export interface Resistor {
   is_multi_resistor_chip: number | null;
   is_potentiometer: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_surface_mount: number | null;
   lcsc: Generated<number | null>;
   max_overload_voltage: number | null;
@@ -931,6 +954,7 @@ export interface ResistorArray {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_surface_mount: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
@@ -955,6 +979,7 @@ export interface Switch {
   is_basic: number | null;
   is_latching: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   length_mm: number | null;
   mfr: string | null;
@@ -979,6 +1004,7 @@ export interface UsbCConnector {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;
   mounting_style: string | null;
@@ -1070,6 +1096,7 @@ export interface WireToBoardConnector {
   in_stock: number | null;
   is_basic: number | null;
   is_preferred: number | null;
+  is_extended_promotional: number | null;
   is_smd: number | null;
   lcsc: Generated<number | null>;
   mfr: string | null;

--- a/scripts/build-derived-sync-db.ts
+++ b/scripts/build-derived-sync-db.ts
@@ -85,6 +85,7 @@ export const buildDerivedSyncDatabase = async ({
       0 AS manufacturer_id,
       CASE WHEN j.library_type = 'base' THEN 1 ELSE 0 END AS basic,
       j.preferred,
+      CASE WHEN j.library_type != 'base' AND j.preferred = 1 THEN 1 ELSE 0 END AS is_extended_promotional,
       j.description,
       j.datasheet,
       j.stock,

--- a/tests/lib/extended-promotional.test.ts
+++ b/tests/lib/extended-promotional.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, test } from "bun:test"
+import { Database } from "bun:sqlite"
+import { afterEach, beforeEach } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { headerTableSpec } from "../../lib/db/derivedtables/header"
+import { buildDerivedSyncDatabase } from "../../scripts/build-derived-sync-db"
+
+// ---------------------------------------------------------------------------
+// Unit tests: mapToTable derives is_extended_promotional from the component row
+// ---------------------------------------------------------------------------
+
+const makeComponent = (overrides: Record<string, unknown> = {}) =>
+  ({
+    lcsc: 123,
+    mfr: "TEST-PART",
+    description: "",
+    stock: 100,
+    basic: 0,
+    preferred: 0,
+    is_extended_promotional: 0,
+    price: JSON.stringify([{ qFrom: 1, qTo: null, price: 0.1 }]),
+    package: "TH",
+    extra: JSON.stringify({
+      attributes: {
+        Pitch: "2.54mm",
+        "Number of Pins": "16P",
+        "Mounting Type": "Straight",
+      },
+    }),
+    source_subcategory: "Pin Headers",
+    ...overrides,
+  }) as any
+
+describe("is_extended_promotional mapping", () => {
+  test("basic + preferred maps to false", () => {
+    const [row] = headerTableSpec.mapToTable([
+      makeComponent({ basic: 1, preferred: 1 }),
+    ])
+
+    expect(row?.is_basic).toBe(true)
+    expect(row?.is_preferred).toBe(true)
+    expect(row?.is_extended_promotional).toBe(false)
+  })
+
+  test("extended-library + preferred maps to true", () => {
+    // is_extended_promotional is derived upstream by the components temp view
+    // (library_type != 'base' AND preferred = 1); the fixture simulates its output
+    const [row] = headerTableSpec.mapToTable([
+      makeComponent({ basic: 0, preferred: 1, is_extended_promotional: 1 }),
+    ])
+
+    expect(row?.is_basic).toBe(false)
+    expect(row?.is_preferred).toBe(true)
+    expect(row?.is_extended_promotional).toBe(true)
+  })
+
+  test("extended-library + non-preferred maps to false", () => {
+    const [row] = headerTableSpec.mapToTable([
+      makeComponent({ basic: 0, preferred: 0 }),
+    ])
+
+    expect(row?.is_basic).toBe(false)
+    expect(row?.is_preferred).toBe(false)
+    expect(row?.is_extended_promotional).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Integration test: the derived sync DB temp view computes the flag from
+// library_type != 'base' AND preferred = 1 without new upstream fields
+// ---------------------------------------------------------------------------
+
+let tempDirectory: string
+
+beforeEach(async () => {
+  tempDirectory = await mkdtemp(path.join(tmpdir(), "jlcsearch-extpromo-"))
+})
+
+afterEach(async () => {
+  await rm(tempDirectory, { recursive: true, force: true })
+})
+
+const insertJlcComponent = (
+  source: Database,
+  {
+    lcsc,
+    libraryType,
+    preferred,
+  }: { lcsc: number; libraryType: string; preferred: number },
+) => {
+  source
+    .query(
+      `INSERT INTO jlc_components (
+        lcsc, fetched_at, present, sync_seen, category, subcategory, mfr,
+        package, joints, manufacturer, library_type, preferred, last_on_stock,
+        description, datasheet, stock, price, attributes
+      ) VALUES (
+        ?, unixepoch(), 1, 1, 'Connectors',
+        'HDMI Connectors', ?, 'SMD', 19, 'Example', ?, ?,
+        unixepoch(), 'HDMI Female 19 Pins horizontal attachment', '', 250,
+        '1-9:1.25,10-:0.75',
+        '{"Connector Type":"HDMI","Number of Pins":"19"}'
+      )`,
+    )
+    .run(lcsc, `HDMI-${lcsc}`, libraryType, preferred)
+}
+
+test("derived sync db computes is_extended_promotional in hdmi_port", async () => {
+  const sourcePath = path.join(tempDirectory, "source.sqlite3")
+  const outputPath = path.join(tempDirectory, "derived.sqlite3")
+  const source = new Database(sourcePath, { create: true })
+
+  source.exec(`
+    CREATE TABLE jlc_components (
+      lcsc INTEGER PRIMARY KEY,
+      fetched_at INTEGER NOT NULL,
+      present INTEGER NOT NULL,
+      sync_seen INTEGER NOT NULL,
+      category TEXT NOT NULL,
+      subcategory TEXT NOT NULL,
+      mfr TEXT NOT NULL,
+      package TEXT NOT NULL,
+      joints INTEGER NOT NULL,
+      manufacturer TEXT NOT NULL,
+      library_type TEXT NOT NULL,
+      preferred INTEGER NOT NULL,
+      last_on_stock INTEGER NOT NULL,
+      description TEXT NOT NULL,
+      datasheet TEXT NOT NULL,
+      stock INTEGER NOT NULL,
+      price TEXT NOT NULL,
+      attributes TEXT NOT NULL
+    );
+
+    CREATE TABLE lcsc_components (
+      lcsc INTEGER PRIMARY KEY,
+      fetched_at INTEGER NOT NULL,
+      manufacturer TEXT NOT NULL,
+      attributes TEXT NOT NULL,
+      image TEXT,
+      url_slug TEXT
+    );
+  `)
+
+  // Basic (base library) + preferred -> not extended promotional
+  insertJlcComponent(source, {
+    lcsc: 12345,
+    libraryType: "base",
+    preferred: 1,
+  })
+  // Extended library + preferred -> extended promotional
+  insertJlcComponent(source, {
+    lcsc: 12346,
+    libraryType: "expand",
+    preferred: 1,
+  })
+  // Extended library + non-preferred -> not extended promotional
+  insertJlcComponent(source, {
+    lcsc: 12347,
+    libraryType: "expand",
+    preferred: 0,
+  })
+
+  for (const lcsc of [12345, 12346, 12347]) {
+    source
+      .query(
+        `INSERT INTO lcsc_components (
+          lcsc, fetched_at, manufacturer, attributes, image, url_slug
+        ) VALUES (
+          ?, unixepoch(), 'Example Inc.',
+          '{"Gender":"Female","Mounting Style":"Surface Mount"}',
+          'example.jpg', ?
+        )`,
+      )
+      .run(lcsc, `hdmi-${lcsc}`)
+  }
+  source.close()
+
+  await buildDerivedSyncDatabase({
+    sourcePath,
+    outputPath,
+    tableNames: ["hdmi_port"],
+    logger: () => {},
+  })
+
+  const output = new Database(outputPath, { readonly: true })
+  const rows = output
+    .query(
+      `SELECT lcsc, is_basic, is_preferred, is_extended_promotional
+       FROM hdmi_port
+       ORDER BY lcsc`,
+    )
+    .all() as Array<Record<string, unknown>>
+
+  expect(rows).toEqual([
+    {
+      lcsc: 12345,
+      is_basic: 1,
+      is_preferred: 1,
+      is_extended_promotional: 0,
+    },
+    {
+      lcsc: 12346,
+      is_basic: 0,
+      is_preferred: 1,
+      is_extended_promotional: 1,
+    },
+    {
+      lcsc: 12347,
+      is_basic: 0,
+      is_preferred: 0,
+      is_extended_promotional: 0,
+    },
+  ])
+  output.close()
+})


### PR DESCRIPTION
Fixes #92

/claim #92

## What
Adds `is_extended_promotional` as a filterable boolean column, following the PR #99 (`is_preferred`) pattern:

- Derived as `preferred = 1 AND basic = 0` per issue-thread consensus (parts acting as basic only for a limited time)
- Wired through all derived-table specs + row mappers + `BaseComponent`
- DB index optimization registered
- Filter query-param + response field + HTML checkboxes in search/list routes
- Regression tests included

## Verification
- Full test suite: **153 pass / 0 fail** in cf-proxy