### PR TITLE
Make D1 cache keys comma-safe

### DIFF
--- a/.github/workflows/d1-migrations.yml
+++ b/.github/workflows/d1-migrations.yml
@@ -104,14 +104,16 @@ jobs:
 
       - name: Generate daily database cache key
         id: cache-date
-        run: echo "bucket=$(($(date -u +%s) / 86400))" >> "${GITHUB_OUTPUT}"
+        run: |
+          echo "bucket=$(($(date -u +%s) / 86400))" >> "${GITHUB_OUTPUT}"
+          echo "tables=${DERIVED_TABLES_LIST//,/-}" >> "${GITHUB_OUTPUT}"
 
       - name: Cache prepared SQLite database
         id: cache-database
         uses: actions/cache@v4
         with:
           path: db.sqlite3
-          key: prepared-db-${{ runner.os }}-${{ env.SYNC_SCOPE }}-${{ env.DERIVED_TABLES_LIST }}-${{ steps.cache-date.outputs.bucket }}-${{ hashFiles('package.json', 'bunfig.toml', 'scripts/**', 'lib/**') }}
+          key: prepared-db-${{ runner.os }}-${{ env.SYNC_SCOPE }}-${{ steps.cache-date.outputs.tables }}-${{ steps.cache-date.outputs.bucket }}-${{ hashFiles('package.json', 'bunfig.toml', 'scripts/**', 'lib/**') }}
 
       - name: Build prepared SQLite database
         if: steps.cache-database.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary

- sanitize the comma-separated derived-table list before putting it in the Actions cache key
- prevent the Build and Sync D1 workflow from failing before migrations run

## Root cause

The DRAM deployment selected `photo_diode,micro_usb_connector,barrel_jack,dram`. `actions/cache` rejects keys containing commas, so the workflow stopped before applying `0007_dram.sql`, leaving the deployed `/drams/list` route without its D1 table.

## Recovery

A DRAM-only workflow dispatch is running separately to apply and populate the production migration immediately.

## Validation

- verified `photo_diode,micro_usb_connector,barrel_jack,dram` normalizes to `photo_diode-micro_usb_connector-barrel_jack-dram`
- `git diff --check`