### PR TITLE
test(search): add hyphenated compound token normalization invariant test

### DIFF
--- a/tests/lib/search-token-groups.test.ts
+++ b/tests/lib/search-token-groups.test.ts
@@ -26,3 +26,12 @@ test("search token groups preserve non-barrel-jack terms", () => {
     ["receptacle"],
   ])
 })
+
+test("search token groups normalize hyphens and uppercase terms consistently", () => {
+  expect(buildSearchTokenGroups("TYPE-C USB")).toEqual([
+    ["type"],
+    ["c"],
+    ["usb"],
+  ])
+})
+


### PR DESCRIPTION
### Summary
- Adds unit test to `tests/lib/search-token-groups.test.ts` asserting that hyphenated compound terms (e.g. `TYPE-C`) are normalized into clean search token groups.