### PR TITLE
test(search): add redundant whitespace deduplication token test

### DIFF
--- a/tests/lib/search-token-groups.test.ts
+++ b/tests/lib/search-token-groups.test.ts
@@ -26,3 +26,12 @@ test("search token groups preserve non-barrel-jack terms", () => {
     ["receptacle"],
   ])
 })
+
+test("search token groups ignore redundant consecutive whitespace", () => {
+  expect(buildSearchTokenGroups("usb    c    header")).toEqual([
+    ["usb"],
+    ["c"],
+    ["header"],
+  ])
+})
+


### PR DESCRIPTION
### Summary
- Adds unit test to `tests/lib/search-token-groups.test.ts` verifying that queries containing multiple consecutive spaces are collapsed cleanly without producing empty search tokens.