### PR TITLE
test(units): add gigabyte and kbytes memory size conversion specs

### DIFF
--- a/tests/lib/parse-and-convert-si-unit.test.ts
+++ b/tests/lib/parse-and-convert-si-unit.test.ts
@@ -7,6 +7,9 @@ describe("parseAndConvertSiUnit byte values", () => {
     ["64KB", 64 * 1024],
     ["2.25KB", 2.25 * 1024],
     ["1MB", 1024 * 1024],
+    ["2GB", 2 * 1024 * 1024 * 1024],
+    ["4GByte", 4 * 1024 * 1024 * 1024],
+    ["512KBytes", 512 * 1024],
   ])("converts %s to bytes", (rawValue, expectedValue) => {
     expect(parseAndConvertSiUnit(rawValue)).toEqual({
       parsedUnit: rawValue.replace(/[\d.]/g, ""),


### PR DESCRIPTION
### Summary
- Extends test matrix in `tests/lib/parse-and-convert-si-unit.test.ts` to assert proper byte conversions for `GB`, `GByte`, and `KBytes` variants.
- Verifies that large scale component memory parameters parse correctly into byte counts.

### Testing
- Asserts calculated base units and conversion factors.