### PR TITLE
test(units): add voltage SI unit parsing and conversion specs

### DIFF
--- a/tests/lib/parse-and-convert-si-unit.test.ts
+++ b/tests/lib/parse-and-convert-si-unit.test.ts
@@ -15,3 +15,19 @@ describe("parseAndConvertSiUnit byte values", () => {
     })
   })
 })
+
+describe("parseAndConvertSiUnit voltage values", () => {
+  test.each([
+    ["5V", 5],
+    ["3.3V", 3.3],
+    ["500mV", 0.5],
+    ["12kV", 12000],
+  ])("converts %s to volts", (rawValue, expectedValue) => {
+    expect(parseAndConvertSiUnit(rawValue)).toEqual({
+      parsedUnit: rawValue.replace(/[\d.]/g, ""),
+      unitOfValue: "V",
+      value: expectedValue,
+    })
+  })
+})
+


### PR DESCRIPTION
### Summary
- Adds unit tests for voltage conversion (`mV`, `V`, `kV`) in `parseAndConvertSiUnit` across standard electronic thresholds (3.3V, 5V, 500mV, 12kV).
- Verifies extracted `unitOfValue` matches `V` and numerical values reflect proper SI scaling.

### Testing
- Asserts parsed unit extraction and converted float values.