### PR TITLE
test(units): add resistance SI unit parsing and conversion specs

### DIFF
--- a/tests/lib/parse-and-convert-si-unit.test.ts
+++ b/tests/lib/parse-and-convert-si-unit.test.ts
@@ -15,3 +15,19 @@ describe("parseAndConvertSiUnit byte values", () => {
     })
   })
 })
+
+describe("parseAndConvertSiUnit resistance values", () => {
+  test.each([
+    ["100Ω", 100],
+    ["4.7kΩ", 4700],
+    ["1MΩ", 1e6],
+    ["20mΩ", 0.02],
+  ])("converts %s to ohms", (rawValue, expectedValue) => {
+    expect(parseAndConvertSiUnit(rawValue)).toEqual({
+      parsedUnit: rawValue.replace(/[\d.]/g, ""),
+      unitOfValue: "Ω",
+      value: expectedValue,
+    })
+  })
+})
+


### PR DESCRIPTION
### Summary
- Extends test coverage in `tests/lib/parse-and-convert-si-unit.test.ts` to verify resistance value normalization across SI prefixes (`mΩ`, `Ω`, `kΩ`, `MΩ`).
- Validates that `unitOfValue` accurately identifies ohms (`Ω`) and factors match electronic engineering standards.

### Testing
- Asserts parsed unit extraction and converted numerical values.