### PR TITLE
test(units): add capacitance SI unit parsing and conversion specs

### DIFF
--- a/tests/lib/parse-and-convert-si-unit.test.ts
+++ b/tests/lib/parse-and-convert-si-unit.test.ts
@@ -15,3 +15,20 @@ describe("parseAndConvertSiUnit byte values", () => {
     })
   })
 })
+
+describe("parseAndConvertSiUnit capacitance values", () => {
+  test.each([
+    ["100pF", 100e-12],
+    ["10nF", 10e-9],
+    ["4.7uF", 4.7e-6],
+    ["100µF", 100e-6],
+    ["1mF", 1e-3],
+  ])("converts %s to farads", (rawValue, expectedValue) => {
+    expect(parseAndConvertSiUnit(rawValue)).toEqual({
+      parsedUnit: rawValue.replace(/[\d.]/g, ""),
+      unitOfValue: "F",
+      value: expectedValue,
+    })
+  })
+})
+


### PR DESCRIPTION
### Summary
- Extends test matrix in `tests/lib/parse-and-convert-si-unit.test.ts` for capacitance values across standard electronic orders (`pF`, `nF`, `uF`, `µF`, `mF`).
- Validates farad base unit normalization and conversion factor accuracy.

### Testing
- Asserts parsed unit extraction and converted float magnitudes.