### PR TITLE
test(units): add frequency SI unit parsing and conversion specs

### DIFF
--- a/tests/lib/parse-and-convert-si-unit.test.ts
+++ b/tests/lib/parse-and-convert-si-unit.test.ts
@@ -15,3 +15,19 @@ describe("parseAndConvertSiUnit byte values", () => {
     })
   })
 })
+
+describe("parseAndConvertSiUnit frequency values", () => {
+  test.each([
+    ["50Hz", 50],
+    ["32.768kHz", 32768],
+    ["16MHz", 16e6],
+    ["100MHz", 100e6],
+  ])("converts %s to hertz", (rawValue, expectedValue) => {
+    expect(parseAndConvertSiUnit(rawValue)).toEqual({
+      parsedUnit: rawValue.replace(/[\d.]/g, ""),
+      unitOfValue: "Hz",
+      value: expectedValue,
+    })
+  })
+})
+


### PR DESCRIPTION
### Summary
- Extends test coverage in `tests/lib/parse-and-convert-si-unit.test.ts` to verify frequency normalization across standard clock thresholds (`Hz`, `kHz`, `MHz`).
- Validates extracted `unitOfValue` matches `Hz` and multiplier factors reflect standard SI orders.

### Testing
- Asserts parsed unit extraction and converted float values.