### PR TITLE
test(si-unit): add capacitance nF, uF, and pF parsing unit specs

### DIFF
--- a/tests/lib/parse-and-convert-si-unit.test.ts
+++ b/tests/lib/parse-and-convert-si-unit.test.ts
@@ -15,3 +15,16 @@ describe("parseAndConvertSiUnit byte values", () => {
     })
   })
 })
+describe("parseAndConvertSiUnit multi-unit precision formats", () => {
+  test.each([
+    ["100nF", 100e-9, "F"],
+    ["4.7uF", 4.7e-6, "F"],
+    ["10pF", 10e-12, "F"],
+  ])("converts capacitance %s accurately", (rawValue, expectedValue, expectedUnit) => {
+    expect(parseAndConvertSiUnit(rawValue)).toEqual({
+      parsedUnit: rawValue.replace(/[\d.]/g, ""),
+      unitOfValue: expectedUnit,
+      value: expectedValue,
+    })
+  })
+})


### PR DESCRIPTION
### Summary
- Adds parameterized test cases for `parseAndConvertSiUnit` covering nanoFarad, microFarad, and picoFarad SI notations.
- Validates extracted value and unit normalization.

### Testing
- Tested against standard conversions.