### PR TITLE
test(si-unit): add compound milli and micro prefix parsing specs

### DIFF
--- a/tests/day2-w17-si-unit-milli-micro-prefix.test.ts
+++ b/tests/day2-w17-si-unit-milli-micro-prefix.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse compound milli and micro prefix variations", () => {
+  expect(parseUnitToSiUnit("4.7mH")).toEqual({
+    value: 0.0047,
+    unit: "H",
+  })
+  expect(parseUnitToSiUnit("0.1uH")).toEqual({
+    value: 0.0000001,
+    unit: "H",
+  })
+  expect(parseUnitToSiUnit("2200uF")).toEqual({
+    value: 0.0022,
+    unit: "F",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` with mH, uH, and uF compound inductance/capacitance units.\n\n### Testing\n- Tested with `bun test tests/day2-w17-si-unit-milli-micro-prefix.test.ts`