### PR TITLE
test(si-unit): add nano prefix parsing specs for H and F

### DIFF
--- a/tests/day2-w18-si-unit-nano-prefix.test.ts
+++ b/tests/day2-w18-si-unit-nano-prefix.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse nano prefix variations for H and F", () => {
+  expect(parseUnitToSiUnit("10nH")).toEqual({
+    value: 1e-8,
+    unit: "H",
+  })
+  expect(parseUnitToSiUnit("47nF")).toEqual({
+    value: 4.7e-8,
+    unit: "F",
+  })
+  expect(parseUnitToSiUnit("0.5nH")).toEqual({
+    value: 5e-10,
+    unit: "H",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing nano (n) prefix inductance and capacitance values.\n\n### Testing\n- Tested with `bun test tests/day2-w18-si-unit-nano-prefix.test.ts`