### PR TITLE
test(si-unit): add fractional voltage and current parsing specs

### DIFF
--- a/tests/day2-w21-fractional-voltage.test.ts
+++ b/tests/day2-w21-fractional-voltage.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse fractional voltage and current variations", () => {
+  expect(parseUnitToSiUnit("3.3V")).toEqual({
+    value: 3.3,
+    unit: "V",
+  })
+  expect(parseUnitToSiUnit("500mA")).toEqual({
+    value: 0.5,
+    unit: "A",
+  })
+  expect(parseUnitToSiUnit("1.8V")).toEqual({
+    value: 1.8,
+    unit: "V",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing 3.3V, 1.8V, and 500mA ratings.\n\n### Testing\n- Tested with bun test.