### PR TITLE
test(si-unit): add kilo and mega ohm symbol parsing specs

### DIFF
--- a/tests/day2-w22-kilo-mega-tolerance.test.ts
+++ b/tests/day2-w22-kilo-mega-tolerance.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse kilo and mega resistance with unit suffix", () => {
+  expect(parseUnitToSiUnit("10kΩ")).toEqual({
+    value: 10000,
+    unit: "Ω",
+  })
+  expect(parseUnitToSiUnit("100kΩ")).toEqual({
+    value: 100000,
+    unit: "Ω",
+  })
+  expect(parseUnitToSiUnit("1MΩ")).toEqual({
+    value: 1000000,
+    unit: "Ω",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing unicode Ohm (Ω) symbol resistance strings.\n\n### Testing\n- Tested with bun test.