### PR TITLE
test(si-unit): add MHz and kHz frequency parsing specs

### DIFF
--- a/tests/day2-w24-mhz-khz.test.ts
+++ b/tests/day2-w24-mhz-khz.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse MHz and kHz crystal frequency specifications", () => {
+  expect(parseUnitToSiUnit("16MHz")).toEqual({
+    value: 16000000,
+    unit: "Hz",
+  })
+  expect(parseUnitToSiUnit("32.768kHz")).toEqual({
+    value: 32768,
+    unit: "Hz",
+  })
+  expect(parseUnitToSiUnit("8MHz")).toEqual({
+    value: 8000000,
+    unit: "Hz",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing 16MHz, 8MHz, and 32.768kHz crystal oscillator values.\n\n### Testing\n- Tested with bun test.