### PR TITLE
test(si-unit): add watt and milliwatt power parsing specs

### DIFF
--- a/tests/day2-w25-watt.test.ts
+++ b/tests/day2-w25-watt.test.ts
@@ -1,0 +1,8 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse watt and milliwatt power dissipation specs", () => {
+  expect(parseUnitToSiUnit("250mW")).toEqual({ value: 0.25, unit: "W" })
+  expect(parseUnitToSiUnit("1W")).toEqual({ value: 1.0, unit: "W" })
+  expect(parseUnitToSiUnit("125mW")).toEqual({ value: 0.125, unit: "W" })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing mW and W power ratings.\n\n### Testing\n- Tested with bun test.