### PR TITLE
test(si-unit): add high-current ampere parsing specs

### DIFF
--- a/tests/day2-w26-ampere.test.ts
+++ b/tests/day2-w26-ampere.test.ts
@@ -1,0 +1,8 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse high-current ampere ratings", () => {
+  expect(parseUnitToSiUnit("10A")).toEqual({ value: 10.0, unit: "A" })
+  expect(parseUnitToSiUnit("2.5A")).toEqual({ value: 2.5, unit: "A" })
+  expect(parseUnitToSiUnit("100mA")).toEqual({ value: 0.1, unit: "A" })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing multi-ampere rating values.\n\n### Testing\n- Tested with bun test.