### PR TITLE
test(si-unit): add decibel gain parsing specs

### DIFF
--- a/tests/day2-w27-decibel.test.ts
+++ b/tests/day2-w27-decibel.test.ts
@@ -1,0 +1,8 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse decibel gain specifications", () => {
+  expect(parseUnitToSiUnit("20dB")).toEqual({ value: 20.0, unit: "dB" })
+  expect(parseUnitToSiUnit("3dB")).toEqual({ value: 3.0, unit: "dB" })
+  expect(parseUnitToSiUnit("-10dB")).toEqual({ value: -10.0, unit: "dB" })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing positive and negative decibel (dB) values.\n\n### Testing\n- Tested with bun test.