### PR TITLE
test(si-unit): add temperature coefficient parsing specs

### DIFF
--- a/tests/day2-w28-temperature.test.ts
+++ b/tests/day2-w28-temperature.test.ts
@@ -1,0 +1,8 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse temperature coefficient rating specifications", () => {
+  expect(parseUnitToSiUnit("125C")).toEqual({ value: 125.0, unit: "C" })
+  expect(parseUnitToSiUnit("85C")).toEqual({ value: 85.0, unit: "C" })
+  expect(parseUnitToSiUnit("-40C")).toEqual({ value: -40.0, unit: "C" })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing Celsius temperature ratings.\n\n### Testing\n- Tested with bun test.