### PR TITLE
test(si-unit): add micro and pico farad capacitance parsing specs

### DIFF
--- a/tests/day3-w01-micro-pico-farad.test.ts
+++ b/tests/day3-w01-micro-pico-farad.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse micro-farad and pico-farad capacitance variations", () => {
+  expect(parseUnitToSiUnit("0.01uF")).toEqual({
+    value: 1e-8,
+    unit: "F",
+  })
+  expect(parseUnitToSiUnit("1500pF")).toEqual({
+    value: 1.5e-9,
+    unit: "F",
+  })
+  expect(parseUnitToSiUnit("68uF")).toEqual({
+    value: 0.000068,
+    unit: "F",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing 0.01uF, 1500pF, and 68uF capacitor units.\n\n### Testing\n- Tested with bun test.