### PR TITLE
test(si-unit): add high-voltage kilovolt parsing specs

### DIFF
--- a/tests/day3-w02-kilovolt.test.ts
+++ b/tests/day3-w02-kilovolt.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse high-voltage kilovolt rating specifications", () => {
+  expect(parseUnitToSiUnit("1kV")).toEqual({
+    value: 1000,
+    unit: "V",
+  })
+  expect(parseUnitToSiUnit("2.5kV")).toEqual({
+    value: 2500,
+    unit: "V",
+  })
+  expect(parseUnitToSiUnit("6.3kV")).toEqual({
+    value: 6300,
+    unit: "V",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing 1kV, 2.5kV, and 6.3kV ratings.\n\n### Testing\n- Tested with bun test.