### PR TITLE
test(si-unit): add milli-henry and nano-henry inductance parsing specs

### DIFF
--- a/tests/day3-w03-milli-nano-henry.test.ts
+++ b/tests/day3-w03-milli-nano-henry.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse milli-henry and nano-henry inductance specifications", () => {
+  expect(parseUnitToSiUnit("3.3mH")).toEqual({
+    value: 0.0033,
+    unit: "H",
+  })
+  expect(parseUnitToSiUnit("15nH")).toEqual({
+    value: 1.5e-8,
+    unit: "H",
+  })
+  expect(parseUnitToSiUnit("100mH")).toEqual({
+    value: 0.1,
+    unit: "H",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing mH and nH inductor ratings.\n\n### Testing\n- Tested with bun test.