### PR TITLE
test(si-unit): add milliohm shunt resistance parsing specs

### DIFF
--- a/tests/day3-w04-milliohm.test.ts
+++ b/tests/day3-w04-milliohm.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse milliohm and low-value shunt resistance specifications", () => {
+  expect(parseUnitToSiUnit("5mΩ")).toEqual({
+    value: 0.005,
+    unit: "Ω",
+  })
+  expect(parseUnitToSiUnit("10mOhm")).toEqual({
+    value: 0.01,
+    unit: "Ω",
+  })
+  expect(parseUnitToSiUnit("0.05Ω")).toEqual({
+    value: 0.05,
+    unit: "Ω",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing mΩ, mOhm, and fractional Ohm shunt resistors.\n\n### Testing\n- Tested with bun test.