### PR TITLE
test(si-unit): add giga-ohm high-insulation resistance parsing specs

### DIFF
--- a/tests/day3-w06-giga-ohm.test.ts
+++ b/tests/day3-w06-giga-ohm.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse giga-ohm high-insulation resistance specifications", () => {
+  expect(parseUnitToSiUnit("1GΩ")).toEqual({
+    value: 1000000000,
+    unit: "Ω",
+  })
+  expect(parseUnitToSiUnit("10GOhm")).toEqual({
+    value: 10000000000,
+    unit: "Ω",
+  })
+  expect(parseUnitToSiUnit("2.2GΩ")).toEqual({
+    value: 2200000000,
+    unit: "Ω",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing GΩ and GOhm high-voltage isolation resistance values.\n\n### Testing\n- Tested with bun test.