### PR TITLE
test(si-unit): add inductance tolerance percentage parsing specs

### DIFF
--- a/tests/day3-w07-inductance-tolerance.test.ts
+++ b/tests/day3-w07-inductance-tolerance.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse inductance tolerance specifications", () => {
+  expect(parseUnitToSiUnit("10uH ±10%")).toEqual({
+    value: 0.00001,
+    unit: "H",
+  })
+  expect(parseUnitToSiUnit("4.7uH +-5%")).toEqual({
+    value: 0.0000047,
+    unit: "H",
+  })
+  expect(parseUnitToSiUnit("100nH ±20%")).toEqual({
+    value: 1e-7,
+    unit: "H",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing inductance values containing ± tolerance postfixes.\n\n### Testing\n- Tested with bun test.