### PR TITLE
test(si-unit): add crystal frequency and load capacitance specs

### DIFF
--- a/tests/day3-w08-mhz-crystal.test.ts
+++ b/tests/day3-w08-mhz-crystal.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse crystal resonator frequency and load capacitance specifications", () => {
+  expect(parseUnitToSiUnit("16MHz")).toEqual({
+    value: 16000000,
+    unit: "Hz",
+  })
+  expect(parseUnitToSiUnit("32.768kHz")).toEqual({
+    value: 32768,
+    unit: "Hz",
+  })
+  expect(parseUnitToSiUnit("24MHz 18pF")).toEqual({
+    value: 24000000,
+    unit: "Hz",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing quartz crystal oscillator frequencies (MHz, kHz).\n\n### Testing\n- Tested with bun test.