### PR TITLE
test(si-unit): add trimmer potentiometer resistance parsing specs

### DIFF
--- a/tests/day3-w09-trimmer-pot.test.ts
+++ b/tests/day3-w09-trimmer-pot.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse variable trimmer potentiometer resistance specifications", () => {
+  expect(parseUnitToSiUnit("10k Variable")).toEqual({
+    value: 10000,
+    unit: "Ω",
+  })
+  expect(parseUnitToSiUnit("50k Trimmer")).toEqual({
+    value: 50000,
+    unit: "Ω",
+  })
+  expect(parseUnitToSiUnit("100k Potentiometer")).toEqual({
+    value: 100000,
+    unit: "Ω",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing trimmer and potentiometer descriptor strings.\n\n### Testing\n- Tested with bun test.