### PR TITLE
test(si-unit): add milli-henry power choke inductance parsing specs

### DIFF
--- a/tests/day3-w10-milli-henry-choke.test.ts
+++ b/tests/day3-w10-milli-henry-choke.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse high-current milli-henry power choke inductance specifications", () => {
+  expect(parseUnitToSiUnit("15mH")).toEqual({
+    value: 0.015,
+    unit: "H",
+  })
+  expect(parseUnitToSiUnit("47mH")).toEqual({
+    value: 0.047,
+    unit: "H",
+  })
+  expect(parseUnitToSiUnit("100mH Choke")).toEqual({
+    value: 0.1,
+    unit: "H",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing high-inductance mH choke and coil values.\n\n### Testing\n- Tested with bun test.