### PR TITLE
test(si-unit): add TVS diode breakdown voltage parsing specs

### DIFF
--- a/tests/day3-w11-tvs-diode.test.ts
+++ b/tests/day3-w11-tvs-diode.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse TVS suppression diode voltage and wattage specifications", () => {
+  expect(parseUnitToSiUnit("3.3V TVS")).toEqual({
+    value: 3.3,
+    unit: "V",
+  })
+  expect(parseUnitToSiUnit("600W 15V")).toEqual({
+    value: 15,
+    unit: "V",
+  })
+  expect(parseUnitToSiUnit("5.0V ESD")).toEqual({
+    value: 5.0,
+    unit: "V",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing ESD and TVS clamp diode voltage ratings.\n\n### Testing\n- Tested with bun test.