### PR TITLE
test(si-unit): add NTC/PTC thermistor resistance parsing specs

### DIFF
--- a/tests/day3-w12-thermistor.test.ts
+++ b/tests/day3-w12-thermistor.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse NTC and PTC thermistor temperature coefficient resistance specs", () => {
+  expect(parseUnitToSiUnit("10k NTC @25C")).toEqual({
+    value: 10000,
+    unit: "Ω",
+  })
+  expect(parseUnitToSiUnit("100k PTC")).toEqual({
+    value: 100000,
+    unit: "Ω",
+  })
+  expect(parseUnitToSiUnit("4.7k Thermistor")).toEqual({
+    value: 4700,
+    unit: "Ω",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing thermistor resistance values with temperature annotations.\n\n### Testing\n- Tested with bun test.