### PR TITLE
test(si-unit): add Schottky barrier diode voltage rating parsing specs

### DIFF
--- a/tests/day3-w14-schottky.test.ts
+++ b/tests/day3-w14-schottky.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse Schottky barrier diode voltage ratings", () => {
+  expect(parseUnitToSiUnit("40V 2A Schottky")).toEqual({
+    value: 40,
+    unit: "V",
+  })
+  expect(parseUnitToSiUnit("20V 0.5A")).toEqual({
+    value: 20,
+    unit: "V",
+  })
+  expect(parseUnitToSiUnit("100V 3A Diode")).toEqual({
+    value: 100,
+    unit: "V",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing Schottky barrier rectifier voltage specifications.\n\n### Testing\n- Tested with bun test.