### PR TITLE
test(si-unit): add optocoupler isolation voltage rating parsing specs

### DIFF
--- a/tests/day3-w15-optocoupler.test.ts
+++ b/tests/day3-w15-optocoupler.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse optocoupler isolation voltage specifications", () => {
+  expect(parseUnitToSiUnit("5kVrms Optocoupler")).toEqual({
+    value: 5000,
+    unit: "V",
+  })
+  expect(parseUnitToSiUnit("3.75kV Isolation")).toEqual({
+    value: 3750,
+    unit: "V",
+  })
+  expect(parseUnitToSiUnit("2500V Opto")).toEqual({
+    value: 2500,
+    unit: "V",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing optocoupler and galvanic isolator voltage specifications.\n\n### Testing\n- Tested with bun test.