### PR TITLE
test(si-unit): add ferrite bead impedance at 100MHz parsing specs

### DIFF
--- a/tests/day3-w16-ferrite-bead.test.ts
+++ b/tests/day3-w16-ferrite-bead.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse ferrite bead impedance at 100MHz specifications", () => {
+  expect(parseUnitToSiUnit("600Ω @100MHz")).toEqual({
+    value: 600,
+    unit: "Ω",
+  })
+  expect(parseUnitToSiUnit("120R Ferrite")).toEqual({
+    value: 120,
+    unit: "Ω",
+  })
+  expect(parseUnitToSiUnit("1k Ohm Bead")).toEqual({
+    value: 1000,
+    unit: "Ω",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing ferrite bead impedance and frequency rated values.\n\n### Testing\n- Tested with bun test.