### PR TITLE
test(si-unit): add precision milli-ohm shunt resistor parsing specs

### DIFF
--- a/tests/day3-w17-milli-ohm-shunt.test.ts
+++ b/tests/day3-w17-milli-ohm-shunt.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse precision current sense shunt milli-ohm specifications", () => {
+  expect(parseUnitToSiUnit("5mΩ Shunt")).toEqual({
+    value: 0.005,
+    unit: "Ω",
+  })
+  expect(parseUnitToSiUnit("10mOhm 1W")).toEqual({
+    value: 0.01,
+    unit: "Ω",
+  })
+  expect(parseUnitToSiUnit("0.5mΩ Sense")).toEqual({
+    value: 0.0005,
+    unit: "Ω",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing low-resistance current sense shunt values in mΩ and mOhm.\n\n### Testing\n- Tested with bun test.