### PR TITLE
test(si-unit): add ceramic capacitor capacitance and voltage parsing specs

### DIFF
--- a/tests/day3-w18-ceramic-voltage.test.ts
+++ b/tests/day3-w18-ceramic-voltage.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse ceramic disk capacitor capacitance and voltage ratings", () => {
+  expect(parseUnitToSiUnit("100nF 50V")).toEqual({
+    value: 1e-7,
+    unit: "F",
+  })
+  expect(parseUnitToSiUnit("10uF 25V Ceramic")).toEqual({
+    value: 0.00001,
+    unit: "F",
+  })
+  expect(parseUnitToSiUnit("4.7uF 16V")).toEqual({
+    value: 0.0000047,
+    unit: "F",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing ceramic capacitor values with voltage suffix qualifiers.\n\n### Testing\n- Tested with bun test.