### PR TITLE
test(si-unit): add Zener diode regulated breakdown voltage parsing specs

### DIFF
--- a/tests/day3-w19-zener-voltage.test.ts
+++ b/tests/day3-w19-zener-voltage.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse Zener diode regulated voltage specifications", () => {
+  expect(parseUnitToSiUnit("5.1V Zener")).toEqual({
+    value: 5.1,
+    unit: "V",
+  })
+  expect(parseUnitToSiUnit("3.3V 500mW")).toEqual({
+    value: 3.3,
+    unit: "V",
+  })
+  expect(parseUnitToSiUnit("12V 1W Zener")).toEqual({
+    value: 12,
+    unit: "V",
+  })
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for `parseUnitToSiUnit` parsing Zener diode voltage and power ratings.\n\n### Testing\n- Tested with bun test.