### PR TITLE
test(si-unit): add piezo buzzer frequency and voltage parsing specs

### DIFF
--- a/tests/day3-w21-piezo-buzzer.test.ts
+++ b/tests/day3-w21-piezo-buzzer.test.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "bun:test"
+import { parseUnitToSiUnit } from "../lib/parse-unit-to-si-unit"
+
+test("si-unit - parse piezo buzzer resonant frequency specifications", () => {
+  expect(parseUnitToSiUnit("4kHz Buzzer")).toEqual({
+    value: 4000,
+    unit: "Hz",
+  })
+  expect(parseUnitToSiUnit("2.4kHz 12V")).toEqual({
+    value: 2400,
+    unit: "Hz",
+  })
+  expect(parseUnitToSiUnit("800Hz Audio")).toEqual({
+    value: 800,
+    unit: "Hz",
+  })
+})


### PR DESCRIPTION
### Summary
- Adds test coverage for  parsing acoustic buzzer resonant frequency specs.

### Testing
- Tested with bun test.